### PR TITLE
Support for environments without a default Vpc

### DIFF
--- a/infrastructure/pcluster-manager-cognito.yaml
+++ b/infrastructure/pcluster-manager-cognito.yaml
@@ -187,8 +187,11 @@ Resources:
       EnabledMfas: !If [MFA, [SMS_MFA], !Ref AWS::NoValue]
       MfaConfiguration: !If [MFA, 'ON', 'OFF']
       SmsConfiguration:
-        ExternalId: !Sub ${AWS::StackName}-external
-        SnsCallerArn: !GetAtt SNSRole.Arn
+        Fn::If:
+          - MFA
+          - ExternalId: !Sub ${AWS::StackName}-external
+            SnsCallerArn: !GetAtt SNSRole.Arn
+          - !Ref AWS::NoValue
       Schema: !If
         - MFA
         - [{Name: email, AttributeDataType: String, Mutable: false, Required: true}, {Name: phone_number, AttributeDataType: String, Mutable: false, Required: true}]

--- a/infrastructure/pcluster-manager.yaml
+++ b/infrastructure/pcluster-manager.yaml
@@ -24,7 +24,19 @@ Parameters:
     Description: Version of AWS ParallelCluster to deploy
     Type: String
     Default: 3.1.2
+  ImageBuilderVpcId:
+    Description: Optional. Provide a specific vpc id to use for building the container images. Use this if you don't have a default vpc available.
+    Type: String
+  ImageBuilderSubnetId:
+    Description: Optional. Provide a specific subnet id to use for building the container images. Use this if you don't have a default vpc available.
+    Type: String
 
+Conditions:
+  NonDefaultVpc:
+    Fn::And:
+      - !Not [!Equals [!Ref ImageBuilderVpcId, ""]]
+      - !Not [!Equals [!Ref ImageBuilderSubnetId, ""]]
+    
 Mappings:
   PclusterManager:
     Constants:
@@ -56,6 +68,8 @@ Resources:
         CreateApiUserRole: False
         EnableIamAdminAccess: True
         PublicEcrImageUri: !Sub public.ecr.aws/parallelcluster/pcluster-api:${Version}
+        ImageBuilderVpcId: !Ref ImageBuilderVpcId
+        ImageBuilderSubnetId: !Ref ImageBuilderSubnetId
       TemplateURL: !Sub https://${AWS::Region}-aws-parallelcluster.s3.${AWS::Region}.amazonaws.com/parallelcluster/${Version}/api/parallelcluster-api.yaml
       TimeoutInMinutes: 30
 
@@ -160,6 +174,13 @@ Resources:
       Roles:
         - !Ref ImageBuilderInstanceRole
 
+  InfrastructureConfigurationSecurityGroup:
+    Condition: NonDefaultVpc
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref ImageBuilderVpcId
+      GroupDescription: Parallel cluster image builder security group
+
   InfrastructureConfiguration:
     Type: AWS::ImageBuilder::InfrastructureConfiguration
     Properties:
@@ -169,6 +190,16 @@ Resources:
       InstanceProfileName: !Ref ImageBuilderInstanceProfile
       TerminateInstanceOnFailure: true
       SnsTopicArn: !Ref EcrImageBuilderSNSTopic
+      SubnetId: 
+        Fn::If:
+          - NonDefaultVpc
+          - !Ref ImageBuilderSubnetId
+          - !Ref AWS::NoValue
+      SecurityGroupIds:
+        Fn::If:
+          - NonDefaultVpc
+          - [!Ref InfrastructureConfigurationSecurityGroup]
+          - !Ref AWS::NoValue
 
   EcrImageRecipe:
     Type: AWS::ImageBuilder::ContainerRecipe


### PR DESCRIPTION
Allows passing a VPC and subnet ID to be used for the image build infrastructure to allow for launching in an environment where no default VPC exists.

Of note, the subnet passed in as a parameter should have internet access (i.e private subnet with NAT gateway routes, or a public subnet). When a public subnet is used, it must have MapPublicIpOnLaunch enabled as image builder won't automatically map a public IP address and the image build will timeout.

**In addition** - this also resolved an issue when deploying in accounts where SNS is still in sandbox. If MFA is false, SmsConfiguration can be ignored to prevent stack creation failure due to Cognito not being able to validate SMS ability of SNS.

Tests
Manually launched parallel cluster (via parallel cluster manager) stacks using a stack referencing stack set templates with these updates which exist in my personal AWS account S3 bucket.