### PR TITLE
`[Clusters]` Add additional logic to reload cluster once it reaches c…

### DIFF
--- a/frontend/src/model.js
+++ b/frontend/src/model.js
@@ -144,11 +144,12 @@ function DeleteCluster(clusterName, callback=null) {
   })
 }
 
-function ListClusters() {
+function ListClusters(callback) {
   var url = 'api?path=/v3/clusters';
   request('get', url).then(response => {
     //console.log("List Success", response)
     if(response.status === 200) {
+      callback && callback(response.data.clusters);
       setState(['clusters', 'list'], response.data.clusters);
     }
   }).catch(error => {

--- a/frontend/src/pages/Clusters/Clusters.js
+++ b/frontend/src/pages/Clusters/Clusters.js
@@ -12,8 +12,9 @@ import { useNavigate, useParams } from "react-router-dom"
 
 import { ListClusters } from '../../model'
 
-import { useState, isAdmin } from '../../store'
+import { useState, getState, setState, isAdmin } from '../../store'
 import { selectCluster } from './util'
+import { findFirst } from '../../util'
 
 // UI Elements
 import {
@@ -36,6 +37,27 @@ import Actions from './Actions';
 import Details from "./Details";
 import { wizardShow } from '../Configure/Configure';
 
+function updateClusterList() {
+  const selectedClusterName = getState(['app', 'clusters', 'selected']);
+  const oldStatus = getState(['app', 'clusters', 'selectedStatus']);
+
+  ListClusters((clusterList) => {
+    if(selectedClusterName)
+    {
+      const selectedCluster = findFirst(clusterList, c => c.clusterName === selectedClusterName);
+      if(selectedCluster)
+      {
+        if(oldStatus !== selectedCluster.clusterStatus)
+          setState(['app', 'clusters', 'selectedStatus'], selectedCluster.clusterStatus);
+
+        if(oldStatus === 'CREATE_IN_PROGRESS' && selectedCluster.clusterStatus === 'CREATE_COMPLETE')
+          selectCluster(selectedClusterName);
+      }
+    }
+
+  })
+}
+
 function ClusterList() {
   let clusters = useState(['clusters', 'list']);
   const selectedClusterName = useState(['app', 'clusters', 'selected']);
@@ -43,7 +65,7 @@ function ClusterList() {
   let params = useParams();
 
   React.useEffect(() => {
-    const timerId = (setInterval(ListClusters, 5000));
+    const timerId = (setInterval(updateClusterList, 5000));
     return () => { clearInterval(timerId); }
   }, [])
 

--- a/frontend/src/pages/Clusters/StackEvents.js
+++ b/frontend/src/pages/Clusters/StackEvents.js
@@ -20,7 +20,6 @@ import { findFirst } from '../../util'
 // UI Elements
 import {
   Button,
-  Container,
   CollectionPreferences,
   Header,
   Pagination,
@@ -97,7 +96,6 @@ export default function ClusterStackEvents() {
     const cluster = getState(clusterPath);
     const headNode = getState([...clusterPath, 'headNode']);
     GetClusterStackEvents(clusterName);
-    console.log("describing: ", clusterName);
     DescribeCluster(clusterName);
 
     let timerId = (setInterval(() => {

--- a/frontend/src/pages/Clusters/util.js
+++ b/frontend/src/pages/Clusters/util.js
@@ -21,7 +21,7 @@ export function selectCluster(clusterName, navigate)
   GetConfiguration(name, (configuration) => {
     setState(['clusters', 'index', name, 'configYaml'], configuration);
     setState(config_path, jsyaml.load(configuration))});
-  DescribeCluster(name, () => {navigate('/clusters')});
+  DescribeCluster(name, () => {navigate && navigate('/clusters')});
   if(oldClusterName !== clusterName)
     setState(['app', 'clusters', 'selected'], name);
 }


### PR DESCRIPTION
…omplete status

*Issue #91 and #103, if available:*

*Description of changes:*
Refresh cluster information when the cluster transitions from `CREATE_IN_PROGRESS` to `CREATE_COMPLETE` so that we are able to properly show button actions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
