### PR TITLE
`[Cluster/Scheduling]` Guard around SSM for enabling the scheduling tab.

### DIFF
--- a/frontend/src/pages/Clusters/Actions.js
+++ b/frontend/src/pages/Clusters/Actions.js
@@ -117,7 +117,7 @@ export default function Actions () {
           Filesystem
         </div>
       </Button>}
-      {headNode && headNode.publicIpAddress && headNode.publicIpAddress !== "" && 
+      {headNode && headNode.publicIpAddress && headNode.publicIpAddress !== "" && ssmEnabled &&
       <Button className="action" disabled={clusterStatus === 'DELETE_IN_PROGRESS'} onClick={() => {shellCluster(headNode.instanceId)}}>
         <div className="container">
           <FeaturedPlayListIcon />


### PR DESCRIPTION
*Issue #125, if available:*
Guard around enabling SSM for the scheduling tab.

![image](https://user-images.githubusercontent.com/6087509/164552199-70a26827-888b-4747-84ce-8f8566c60cb0.png)


*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
