### PR TITLE
Memory Post-Install

### DIFF
--- a/frontend/src/pages/Configure/Components.js
+++ b/frontend/src/pages/Configure/Components.js
@@ -43,7 +43,8 @@ function strToOption(str){
 const multiRunner = 'https://raw.githubusercontent.com/aws-samples/pcluster-manager/main/resources/scripts/multi-runner.py'
 const knownExtensions = [{name: 'Cloud9', path: 'cloud9.sh', description: 'Cloud9 Install', args: [{name: 'Output File'}]},
   {name: 'Slurm Accounting', path: 'slurm-accounting.sh', description: 'Slurm Accounting', args: [{name: 'Secret ARN'}, {name: 'RDS Endpoint'}, {name: 'RDS Port', default: '3306'}]},
-  {name: 'Spack', path: "spack.sh", description: 'Install Spack package manager.', args:[{name: 'Spack Root'}]}]
+  {name: 'Spack', path: "spack.sh", description: 'Install Spack package manager.', args:[{name: 'Spack Root'}]},
+  {name: 'Memory', path: "mem.sh", description: 'Setup Memory Resource in Slurm.'}]
 
 // Selectors
 const selectVpc = state => getState(state, ['app', 'wizard', 'vpc']);

--- a/resources/scripts/mem.sh
+++ b/resources/scripts/mem.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Source:
+#   https://gist.github.com/bollig/56c277501505f5eaa5d185b86c2999b9
+# Usage:
+# ```
+#    sh mem.sh
+# ```
+# You'll need to include the following IAM permissions in your cluster's config:
+# ```
+# Iam:
+#   AdditionalIamPolicies:
+#       - Policy: arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
+# ```
+FILELIST=$(ls /opt/slurm/etc/pcluster/slurm_parallelcluster*_partition.conf)
+
+for PARTFILE in $FILELIST; do
+        echo "Writiting to /tmp/$(basename $PARTFILE)"
+        while IFS= read -r line; do
+            if [[ $line == NodeName* ]]; then
+                    # NodeName=spot-dy-c52xlarge-[1-16] CPUs=4 State=CLOUD Feature=dynamic,c5.2xlarge,sp-small
+                    instance_type=$(echo "$line" | awk '{print $4}' | cut -f 2 -d',' )
+
+                    memory=$(AWS_DEFAULT_REGION=$cfn_region aws ec2 describe-instance-types --instance-type $instance_type --query "InstanceTypes[*].MemoryInfo[]" --output text)
+                    RealMemory=$(python -c 'import sys; print(int(0.85 * int(sys.argv[1])))' $memory)
+                    (echo "$line" | grep -q "RealMemory" && echo "$line" | sed "s/RealMemory=\(.*\)$/RealMemory=${RealMemory}/" ) || echo "$line RealMemory=${RealMemory}" 
+            else
+                    echo "$line"
+            fi
+        done < $PARTFILE > /tmp/$(basename $PARTFILE)
+done
+
+# copy revised partition files to slurm conf
+cp /tmp/slurm_parallelcluster_*partition.conf /opt/slurm/etc/pcluster/.
+
+# restart slurm for changes to take effect
+systemctl restart slurmctld


### PR DESCRIPTION
All credit goes to @bollig

You'll also need the following IAM Policy in your cluster's config, this is for `ec2:DescribeInstanceTypes` to get the memory per-instance.

```yaml
Iam:
    AdditionalIamPolicies:
      - Policy: arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
```

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
