### PR TITLE
Fix for memory.sh script

### DIFF
--- a/frontend/src/pages/Configure/Components.js
+++ b/frontend/src/pages/Configure/Components.js
@@ -44,7 +44,7 @@ const multiRunner = 'https://raw.githubusercontent.com/aws-samples/pcluster-mana
 const knownExtensions = [{name: 'Cloud9', path: 'cloud9.sh', description: 'Cloud9 Install', args: [{name: 'Output File'}]},
   {name: 'Slurm Accounting', path: 'slurm-accounting.sh', description: 'Slurm Accounting', args: [{name: 'Secret ARN'}, {name: 'RDS Endpoint'}, {name: 'RDS Port', default: '3306'}]},
   {name: 'Spack', path: "spack.sh", description: 'Install Spack package manager.', args:[{name: 'Spack Root'}]},
-  {name: 'Memory', path: "mem.sh", description: 'Setup Memory Resource in Slurm.'}]
+  {name: 'Memory', path: "mem.sh", description: 'Setup Memory Resource in Slurm.', args:[]}]
 
 // Selectors
 const selectVpc = state => getState(state, ['app', 'wizard', 'vpc']);

--- a/resources/scripts/mem.sh
+++ b/resources/scripts/mem.sh
@@ -11,6 +11,9 @@
 #   AdditionalIamPolicies:
 #       - Policy: arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
 # ```
+
+source /opt/parallelcluster/cfnconfig
+
 FILELIST=$(ls /opt/slurm/etc/pcluster/slurm_parallelcluster*_partition.conf)
 
 for PARTFILE in $FILELIST; do


### PR DESCRIPTION
* I've added `source /opt/parallelcluster/cfnconfig` which is redundant but allows people to use the script independent of the multi-runner script.
* The empty args needs to be tested.

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
