### PR TITLE
Cost Explorer

### DIFF
--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -13,7 +13,6 @@ import json
 import os
 import re
 import time
-from types import TracebackType
 
 import boto3
 import botocore
@@ -43,11 +42,10 @@ AUTH_URL = os.getenv("AUTH_URL", f"{AUTH_PATH}/login")
 JWKS_URL = os.getenv("JWKS_URL")
 AUDIENCE = os.getenv("AUDIENCE")
 USER_ROLES_CLAIM = os.getenv("USER_ROLES_CLAIM", "cognito:groups")
-REDIRECT_URL = f"{SITE_URL}/login"
 PCLUSTER_COST_TAGS = ['parallelcluster:attributes', 
-        'parallelcluster:cluster-name', 'parallelcluster:compute-resource-name', 'parallelcluster:filesystem', 
-        'parallelcluster:networking', 'parallelcluster:node-type', 'parallelcluster:queue-name', 
-        'parallelcluster:resource', 'parallelcluster:version']
+    'parallelcluster:cluster-name', 'parallelcluster:compute-resource-name', 'parallelcluster:filesystem', 
+    'parallelcluster:networking', 'parallelcluster:node-type', 'parallelcluster:queue-name', 
+    'parallelcluster:resource', 'parallelcluster:version']
 
 try:
     if (not USER_POOL_ID or USER_POOL_ID == "") and SECRET_ID:
@@ -706,22 +704,22 @@ def activate_tags():
         cost_explorer = boto3.client('ce')
         newlist = [{'TagKey': tag, 'Status': 'Active'} for tag in PCLUSTER_COST_TAGS]
         cost_explorer.update_cost_allocation_tags_status(CostAllocationTagsStatus=newlist)
-        return "Activated Tags"
+        return {"message": "Activated Tags"}
     except Exception as e:
         return {"message": str(e)}, 500
-
+ 
 def get_graph_data():
     try:
         cluster_name = request.args.get("cluster_name")
-        Start = request.args.get("Start")
-        End = request.args.get("End")
-        if cluster_name is None or Start is None or End is None:
+        start = request.args.get("start")
+        end = request.args.get("end")
+        if cluster_name is None or start is None or end is None:
             return {"message": "cluster_name , start date, or end date are not specified"}, 400
         cost_explorer = boto3.client('ce')
         data = cost_explorer.get_cost_and_usage(
             TimePeriod={
-                'Start': Start,
-                'End': End
+                'Start': start,
+                'End': end
             },
             Filter={
                 'Tags': {

--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -42,6 +42,16 @@ AUTH_URL = os.getenv("AUTH_URL", f"{AUTH_PATH}/login")
 JWKS_URL = os.getenv("JWKS_URL")
 AUDIENCE = os.getenv("AUDIENCE")
 USER_ROLES_CLAIM = os.getenv("USER_ROLES_CLAIM", "cognito:groups")
+REDIRECT_URL = f"{SITE_URL}/login"
+PCluster_tags = ['parallelcluster:attributes', 
+        'parallelcluster:cluster-name', 'parallelcluster:compute-resource-name', 'parallelcluster:filesystem', 
+        'parallelcluster:networking', 'parallelcluster:node-type', 'parallelcluster:queue-name', 
+        'parallelcluster:resource', 'parallelcluster:version']
+cost_explorer = boto3.client('ce',)
+
+
+
+
 
 try:
     if (not USER_POOL_ID or USER_POOL_ID == "") and SECRET_ID:
@@ -688,14 +698,9 @@ def _get_params(_request):
     return params
 
 # Check if parallelcluster tags are active
-def check_tags(self, inactive_tags):
+def check_tags():
     try:
-        cost_explorer = boto3.client('ce',)
-        tags = ['parallelcluster:attributes', 
-        'parallelcluster:cluster-name', 'parallelcluster:compute-resource-name', 'parallelcluster:filesystem', 
-        'parallelcluster:networking', 'parallelcluster:node-type', 'parallelcluster:queue-name', 
-        'parallelcluster:resource', 'parallelcluster:version']
-        inactive_tags = cost_explorer.list_cost_allocation_tags(Status='Inactive',TagKeys=tags)
+        inactive_tags = cost_explorer.list_cost_allocation_tags(Status='Inactive',TagKeys=PCluster_tags)
         if len(inactive_tags['CostAllocationtTags']) > 0:
             return True
         else:
@@ -704,44 +709,10 @@ def check_tags(self, inactive_tags):
         return {"message": str(e)}, 500
 
 # Activate parallelcluster tags in cost explorer
-def activate_tags(self, cost_explorer):
+def activate_tags():
     try:
-        updated_tags = cost_explorer.update_cost_allocation_tags_status(
-            CostAllocationTagsStatus=[
-                {
-                    'TagKey': 'parallelcluster:attributes',
-                    'Status': 'Active'
-                },
-                {
-                    'TagKey': 'parallelcluster:cluster-name',
-                    'Status': 'Active'
-                },
-                {
-                    'TagKey': 'parallelcluster:compute-resource-name',
-                    'Status': 'Active'
-                },
-                {
-                    'TagKey': 'parallelcluster:filesystem',
-                    'Status': 'Active'
-                },
-                {
-                    'TagKey': 'parallelcluster:node-type',
-                    'Status': 'Active'
-                },
-                {
-                    'TagKey': 'parallelcluster:queue-name',
-                    'Status': 'Active'
-                },
-                {
-                    'TagKey': 'parallelcluster:resource',
-                    'Status': 'Active'
-                },
-                {
-                    'TagKey': 'parallelcluster:version',
-                    'Status': 'Active'
-                }
-            ]
-        )
+        for tag in PCluster_tags:
+            updated_tags = cost_explorer.CostAllocationTagStatus.append({'Tagkey': tag, 'Value': 'Active'})
     except Exception as e:
         return {"message": str(e)}, 500
     

--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -687,9 +687,64 @@ def _get_params(_request):
     params.pop("path")
     return params
 
+# Check if parallelcluster tags are active
+def check_tags(self, inactive_tags):
+    try:
+        cost_explorer = boto3.client('ce',)
+        tags = ['parallelcluster:attributes', 
+        'parallelcluster:cluster-name', 'parallelcluster:compute-resource-name', 'parallelcluster:filesystem', 
+        'parallelcluster:networking', 'parallelcluster:node-type', 'parallelcluster:queue-name', 
+        'parallelcluster:resource', 'parallelcluster:version']
+        inactive_tags = cost_explorer.list_cost_allocation_tags(Status='Inactive',TagKeys=tags)
+        if len(inactive_tags['CostAllocationtTags']) > 0:
+            return True
+        else:
+            return False
+    except Exception as e:
+        return {"message": str(e)}, 500
 
-# Proxy
-
+# Activate parallelcluster tags in cost explorer
+def activate_tags(self, cost_explorer):
+    try:
+        updated_tags = cost_explorer.update_cost_allocation_tags_status(
+            CostAllocationTagsStatus=[
+                {
+                    'TagKey': 'parallelcluster:attributes',
+                    'Status': 'Active'
+                },
+                {
+                    'TagKey': 'parallelcluster:cluster-name',
+                    'Status': 'Active'
+                },
+                {
+                    'TagKey': 'parallelcluster:compute-resource-name',
+                    'Status': 'Active'
+                },
+                {
+                    'TagKey': 'parallelcluster:filesystem',
+                    'Status': 'Active'
+                },
+                {
+                    'TagKey': 'parallelcluster:node-type',
+                    'Status': 'Active'
+                },
+                {
+                    'TagKey': 'parallelcluster:queue-name',
+                    'Status': 'Active'
+                },
+                {
+                    'TagKey': 'parallelcluster:resource',
+                    'Status': 'Active'
+                },
+                {
+                    'TagKey': 'parallelcluster:version',
+                    'Status': 'Active'
+                }
+            ]
+        )
+    except Exception as e:
+        return {"message": str(e)}, 500
+    
 
 class PclusterApiHandler(Resource):
     method_decorators = [authenticated("user")]

--- a/app.py
+++ b/app.py
@@ -142,6 +142,19 @@ def run():
     @authenticated("admin")
     def set_user_role_():
         return set_user_role()
+    
+    # Andy
+    @app.route("/manager/check_tag_status", methods=["GET"])
+    @authenticated()
+    def check_tags():
+        return check_tags()
+
+    @app.route("/manager/activate_tags")
+    @authenticated()
+    def activate_tags():
+        return activate_tags()
+
+    # End
 
     @app.route("/manager/queue_status")
     @authenticated()

--- a/app.py
+++ b/app.py
@@ -19,9 +19,11 @@ from werkzeug.routing import BaseConverter
 import api.utils as utils
 from api.PclusterApiHandler import (
     PclusterApiHandler,
+    activate_tags,
     authenticate,
     authenticated,
     cancel_job,
+    check_tags,
     create_user,
     delete_user,
     ec2_action,
@@ -30,6 +32,7 @@ from api.PclusterApiHandler import (
     get_cluster_config,
     get_custom_image_config,
     get_dcv_session,
+    get_graph_data,
     get_identity,
     get_version,
     get_instance_types,
@@ -143,15 +146,20 @@ def run():
     def set_user_role_():
         return set_user_role()
     
-    @app.route("/manager/check_tag_status", methods=["GET"])
+    @app.route("/manager/check_tag_status")
     @authenticated()
-    def check_tags():
+    def check_tags_():
         return check_tags()
 
     @app.route("/manager/activate_tags")
     @authenticated()
-    def activate_tags():
+    def activate_tags_():
         return activate_tags()
+
+    @app.route("/manager/graph_data")
+    @authenticated()
+    def get_graph_data_():
+        return get_graph_data()
 
     @app.route("/manager/queue_status")
     @authenticated()

--- a/app.py
+++ b/app.py
@@ -143,7 +143,6 @@ def run():
     def set_user_role_():
         return set_user_role()
     
-    # Andy
     @app.route("/manager/check_tag_status", methods=["GET"])
     @authenticated()
     def check_tags():
@@ -153,8 +152,6 @@ def run():
     @authenticated()
     def activate_tags():
         return activate_tags()
-
-    # End
 
     @app.route("/manager/queue_status")
     @authenticated()

--- a/app.py
+++ b/app.py
@@ -29,6 +29,7 @@ from api.PclusterApiHandler import (
     ec2_action,
     get_app_config,
     get_aws_config,
+    get_budget_data,
     get_cluster_config,
     get_custom_image_config,
     get_dcv_session,
@@ -160,6 +161,12 @@ def run():
     @authenticated()
     def get_graph_data_():
         return get_graph_data()
+
+    @app.route("/manager/get_budget_data")
+    @authenticated()
+    def get_budget_data_():
+        return get_budget_data()
+
 
     @app.route("/manager/queue_status")
     @authenticated()

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -361,5 +361,102 @@
       "header": "Required memory",
       "description": "Real memory required per node, in MB. A memory size specification of zero is treated as a special case and grants the job access to all of the memory on each node. [optional]"
     }
+  },
+  "CostTab": {
+    "dateRangePicker": {
+      "placeholder": "Filter by a date range",
+      "dateRangePickerSetting":  {
+        "todayAriaLabel": "Today",
+        "nextMonthAriaLabel": "Next month",  
+        "previousMonthAriaLabel": "Previous month",
+        "customRelativeRangeDurationLabel": "Duration",
+        "customRelativeRangeDurationPlaceholder": "Enter duration",
+        "customRelativeRangeOptionLabel": "Custom range",
+        "customRelativeRangeOptionDescription": "Set a custom range of days in the past. Use Days as Unit of Time.",
+        "customRelativeRangeUnitLabel": "Unit of time",
+        "dateTimeConstraintText": "Select any Range of days. Use 24 hour format.",
+        "relativeModeTitle": "Relative range",
+        "absoluteModeTitle": "Absolute range",
+        "relativeRangeSelectionHeading": "Choose a range",
+        "startDateLabel": "Start date",
+        "endDateLabel": "End date",
+        "startTimeLabel": "Start time",
+        "endTimeLabel": "End time",
+        "clearButtonLabel": "Clear and dismiss",
+        "cancelButtonLabel": "Cancel",
+        "applyButtonLabel": "Apply"
+      }
+    },
+    "ProgressBar": {
+      "additionalInfo": "Create a Budget with an identical name as your respective cluster for accurate information", 
+      "description": "Progress",
+      "label": "Cost Usage of Budget"
+    },
+    "HelpToolTip": {
+      "Text": "If you haven't created a budget, create a custom cost budget on ",
+      "Title": "AWS Budgets"
+    },
+    "CostExplorerButton": {
+      "Text": "View Data in Cost Explorer"
+    },
+    "Header": {
+      "Title": "Cluster Costs"
+    },
+    "TagsButton": {
+      "Text": "Activate Tags"
+    },
+    "CostTable": {
+      "Name": "All Instance Types",
+      "description": {
+        "Sentence": "Total Cost for all instance types from",
+        "To": "to",
+        "TotalCostFor": "Total Cost for",
+        "Transition": "instances from"
+      }
+    },
+    "NoInstanceType": {
+      "Text": "*The NoInstanceType category includes miscellaneous costs such as EBS, read more about",
+      "Title": "EBS Pricing"
+    },
+    "Table": {
+      "NoResources":"Loading resources",
+      "LoadingText": {
+        "NoResources": "No Resources",
+        "NoResourcesToDisplay": "No Resources To Display.",
+        "CreateResources": "Create Resources"
+      }
+    },
+    "BarChart": {
+      "values": {
+        "ariaLabel": "Stacked bar chart",
+        "errorText": "Error loading data.",
+        "loadingText": "Loading chart",
+        "recoveryText": "Retry",
+        "xScaleType": "categorical",
+        "xTitle":"Date",
+        "yTitle":"Cost(s) $"
+      },
+      "empty": {
+        "NoData": "No data available",
+        "ThereIsNoData": "There is no data available"
+      },
+      "noMatch":{
+        "NoMatchingData": "No matching data",
+        "ThereIsNoMatchingData": "There is no matching data to display",
+        "ClearFilter": "Clear filter"
+      }
+    },
+    "BarChartSetting": {
+      "filterLabel": "Filter displayed data",
+      "filterPlaceholder": "Filter data",
+      "filterSelectedAriaLabel": "selected",
+      "legendAriaLabel": "Legend",
+      "chartAriaRoleDescription": "line chart"
+    },
+    "BarChartColumns": {
+      "InstanceType": "Instance Type",
+      "TotalCost": "Total Cost",
+      "Summary": "Summary"
+    }
   }
 }

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -605,7 +605,56 @@ function GetVersion() {
   })
 }
 
-function Ec2Action(instanceIds: any, action: any, callback?: Callback) {
+function GetTagStatus(callback: any): void {
+  var url = `manager/check_tag_status`
+  request('get', url).then((response: any) => {
+    if(response.status === 200) {
+      console.log("Checking Tag Status...");
+      console.log(response.data)
+      callback && callback(response.data)
+    }
+  }).catch((error: any) => {
+    if(error.response)
+    {
+      console.log(error.response)
+    }
+    console.log(error)
+  })
+}
+
+function ActivateTags(callback: any): void {
+  var url = `manager/activate_tags`
+  request('get', url).then((response: any) => {
+    if(response.status === 200) {
+      console.log("Activating Tags....");
+      console.log(response.data)
+      callback && callback(response.data)
+    }
+  }).catch((error: any) => {
+    if(error.response) {
+      console.log(error.response)
+    }
+    console.log(error)
+  })
+}
+
+function GetGraphData(callback: any, cluster_name: string, Start: string, End: string): void {
+  var url = `manager/graph_data?cluster_name=${cluster_name}&Start=${Start}&End=${End}`
+  request('get', url).then((response: any) => {
+    if(response.status === 200) {
+      console.log("Getting Usage data from Cost Explorer API....");
+      console.log(response.data)
+      callback && callback(response.data)
+    }
+  }).catch((error: any) => {
+    if(error.response) {
+      console.log(error.response)
+    }
+    console.log(error)
+  })
+}
+
+function Ec2Action(instanceIds: any, action: any, callback: any) {
   let url = `manager/ec2_action?instance_ids=${instanceIds.join(',')}&action=${action}`
 
   request('post', url).then((response: any) => {
@@ -823,4 +872,4 @@ export {CreateCluster, UpdateCluster, ListClusters, DescribeCluster,
   GetCustomImageLogEvents, ListOfficialImages, LoadInitialState,
   Ec2Action,LoadAwsConfig, GetDcvSession, QueueStatus, CancelJob, SubmitJob,
   PriceEstimate, SlurmAccounting, JobInfo, ListUsers, SetUserRole, notify,
-  CreateUser, DeleteUser}
+  CreateUser, DeleteUser, GetTagStatus, ActivateTags, GetGraphData}

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -638,8 +638,8 @@ function ActivateTags(callback: any): void {
   })
 }
 
-function GetGraphData(callback: any, cluster_name: string, Start: string, End: string): void {
-  var url = `manager/graph_data?cluster_name=${cluster_name}&Start=${Start}&End=${End}`
+function GetGraphData(callback: any, cluster_name: string, start: string, end: string): void {
+  var url = `manager/graph_data?cluster_name=${cluster_name}&start=${start}&end=${end}`
   request('get', url).then((response: any) => {
     if(response.status === 200) {
       console.log("Getting Usage data from Cost Explorer API....");
@@ -654,8 +654,8 @@ function GetGraphData(callback: any, cluster_name: string, Start: string, End: s
   })
 }
 
-function GetBudget(callback: any, cluster_name: string, AccountId: string): void {
-  var url = `manager/get_budget_data?cluster_name=${cluster_name}&AccountId=${AccountId}`
+function GetBudget(callback: any, cluster_name: string, accountId: string): void {
+  var url = `manager/get_budget_data?cluster_name=${cluster_name}&accountId=${accountId}`
   request('get', url).then((response: any) => {
     if(response.status === 200) {
       console.log("Getting Budget Data from Budgets API....");

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -654,6 +654,22 @@ function GetGraphData(callback: any, cluster_name: string, Start: string, End: s
   })
 }
 
+function GetBudget(callback: any, cluster_name: string, AccountId: string): void {
+  var url = `manager/get_budget_data?cluster_name=${cluster_name}&AccountId=${AccountId}`
+  request('get', url).then((response: any) => {
+    if(response.status === 200) {
+      console.log("Getting Budget Data from Budgets API....");
+      console.log(response.data)
+      callback && callback(response.data)
+    }
+  }).catch((error: any) => {
+    if(error.response) {
+      console.log(error.response)
+    }
+    console.log(error)
+  })
+} 
+
 function Ec2Action(instanceIds: any, action: any, callback: any) {
   let url = `manager/ec2_action?instance_ids=${instanceIds.join(',')}&action=${action}`
 
@@ -872,4 +888,4 @@ export {CreateCluster, UpdateCluster, ListClusters, DescribeCluster,
   GetCustomImageLogEvents, ListOfficialImages, LoadInitialState,
   Ec2Action,LoadAwsConfig, GetDcvSession, QueueStatus, CancelJob, SubmitJob,
   PriceEstimate, SlurmAccounting, JobInfo, ListUsers, SetUserRole, notify,
-  CreateUser, DeleteUser, GetTagStatus, ActivateTags, GetGraphData}
+  CreateUser, DeleteUser, GetTagStatus, ActivateTags, GetGraphData, GetBudget}

--- a/frontend/src/old-pages/Clusters/Cost.tsx
+++ b/frontend/src/old-pages/Clusters/Cost.tsx
@@ -1,0 +1,293 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+import React from 'react';
+import { useState, consoleDomain, setState, clearState } from '../../store'
+// import { getIn } from '../../util'
+// import { useCollection } from '@awsui/collection-hooks';
+
+
+// UI Elements
+import {
+  Button,
+  Box,
+  BarChart,
+  DateRangePicker,
+  Container,
+  Header,
+  SpaceBetween,
+} from "@awsui/components-react";
+
+// Components
+import HelpTooltip from '../../components/HelpTooltip'
+import { ActivateTags, GetTagStatus, GetGraphData } from '../../model';
+import { Star } from '@mui/icons-material';
+import { totalmem } from 'os';
+
+export default function Cost() {
+  const cluster_name = useState(['app', 'clusters', 'selected']);
+  const tag_active = useState(['app', 'tags', 'active']);
+  const y_domain = useState(['app', 'cost', cluster_name, 'max']);
+  const [dateValue, setDateValue] = React.useState(undefined);
+  const dates = useState(['app', 'cost', cluster_name, 'dates']) || [];
+  const stack_info = useState(['app', 'cost', cluster_name, 'stack_info']) || [];
+
+  // Check tag status
+  const check_tags = () => {
+    const status_update = (value: {TagStatus?: boolean} ) => {
+      setState(['app', 'tags', 'active'], value['TagStatus']);
+    }
+    GetTagStatus(status_update)
+  }
+
+  // Activate all the tags
+  const activate_tags = () => {
+    const status_update = () => {
+      setState(['app', 'tags', 'active'], true);
+    }
+    ActivateTags(status_update)
+  }
+
+  // Pull cost and usage from CE API
+  const get_graph_data = (Start: string, End: string) => {
+    const query_costs = (data: any) => {
+      const usage_data = data['ResultsByTime'];
+      const dates: Date[] = [];
+      const instance_types = new Set();
+      const stack_info: any[] = [];
+      let day_info: any[] = [];
+      let total = 0;
+      let max = 0;
+  
+      // Find XDomain
+      const x_domain = usage_data?.map((obj: any) => {
+          dates.push(new Date(obj.TimePeriod.Start));
+      })
+    
+      // Find All Instance Types
+      const data_instance_types = usage_data?.map((obj: any) => {
+        let data_by_instance_type = obj.Groups;
+        const days = data_by_instance_type?.map((obj2: any) => {
+            instance_types.add(obj2.Keys[0]);
+        })
+      })
+  
+      // Create a data set for each instance type
+      instance_types.forEach((type) => {
+          const costs = usage_data?.map((obj: any) => {
+              let data_by_instance_type = obj.Groups;
+              const day_data = data_by_instance_type?.map((obj2: any) => {
+                if (obj2.Keys[0] == type) {
+                    total = Number(obj2.Metrics.NetUnblendedCost.Amount) + total
+                    day_info.push({
+                      x: new Date(obj.TimePeriod.Start),
+                      y: Number(parseFloat(obj2.Metrics.NetUnblendedCost.Amount).toFixed(2)),
+                    },)
+                }
+              })
+              if (total > max) {
+                max = total
+              }
+              total = 0
+          })
+          stack_info.push({
+            title: type,
+            type: 'bar',
+            data: day_info,
+          })
+          day_info = []
+    }) 
+    setState(['app', 'cost', cluster_name, 'stack_info'], stack_info);
+    setState(['app', 'cost', cluster_name, 'dates'], dates);
+    setState(['app', 'cost', cluster_name, 'max'], max);
+    }
+    GetGraphData(query_costs, cluster_name, Start, End)
+  }
+
+  const fetchGraphData = (val: any) => {
+    let start_value = ""
+    let end_value = ""
+    if (!val) {
+      let current_date = new Date();
+      let start = new Date(current_date.setDate(current_date.getDate()-7));
+      let start_string = new Date(start).toISOString().split('T');
+      let end_string = new Date().toISOString().split('T');
+      start_value = String(start_string[0]);
+      end_value = String(end_string[0]);
+    } 
+    else {
+      if (val.type === 'relative') {
+        if (val.unit === 'day') {
+          let current_date = new Date()
+          let start = new Date(current_date.setDate(current_date.getDate()-val.amount));
+          let start_string = new Date(start).toISOString().split('T');
+          let end_string = new Date().toISOString().split('T');
+          start_value = String(start_string[0]);
+          end_value = String(end_string[0]);
+        }
+      } 
+      else {
+        const start = new Date(val.startDate).toISOString().split('T');
+        const end = new Date(val.endDate).toISOString().split('T');
+        start_value = String(start[0]);
+        end_value = String(end[0])
+      }
+    }
+    get_graph_data(String(start_value), String(end_value));
+  }
+
+  // These will be called once on loading of page
+  React.useEffect(() => {
+      check_tags()
+      const Default = {
+          key: 'previous-7-days',
+          type: 'relative',
+          unit: 'day',
+          amount: 7,
+        };
+      fetchGraphData(Default);
+      setDateValue(Default);
+  },[])
+
+  return (
+    <Container
+      header={
+        <Header
+          variant="h2"
+          actions={
+            <SpaceBetween
+              direction="horizontal"
+              size="xs"
+            >
+              <DateRangePicker
+              onChange={({ detail }) => {fetchGraphData(detail.value); setDateValue(detail.value); }}
+                value={dateValue}
+                relativeOptions={[
+                  {
+                    key: "previous-30-days",
+                    amount: 30,
+                    unit: "day",
+                    type: "relative"
+                  },
+                  {
+                    key: "previous-14-days",
+                    amount: 14,
+                    unit: "day",
+                    type: "relative"
+                  },
+                  {
+                    key: "previous-7-days",
+                    amount: 7,
+                    unit: "day",
+                    type: "relative"
+                  },
+                  {
+                    key: "previous-1-day",
+                    amount: 1,
+                    unit: "day",
+                    type: "relative"
+                  }
+                ]}
+                i18nStrings={{
+                  todayAriaLabel: "Today",
+                  nextMonthAriaLabel: "Next month",
+                  previousMonthAriaLabel: "Previous month",
+                  customRelativeRangeDurationLabel: "Duration",
+                  customRelativeRangeDurationPlaceholder:
+                    "Enter duration",
+                  customRelativeRangeOptionLabel: "Custom range",
+                  customRelativeRangeOptionDescription:
+                    "Set a custom range of days in the past. Use Days as Unit of Time.",
+                  customRelativeRangeUnitLabel: "Unit of time",
+                  formatRelativeRange: e => {
+                    const t =
+                      1 === e.amount ? e.unit : `${e.unit}s`;
+                    return `Last ${e.amount} ${t}`;
+                  },
+                  formatUnit: (e, t) => (1 === t ? e : `${e}s`),
+                  dateTimeConstraintText:
+                    "Select any Range of days. Use 24 hour format.",
+                  relativeModeTitle: "Relative range",
+                  absoluteModeTitle: "Absolute range",
+                  relativeRangeSelectionHeading: "Choose a range",
+                  startDateLabel: "Start date",
+                  endDateLabel: "End date",
+                  startTimeLabel: "Start time",
+                  endTimeLabel: "End time",
+                  clearButtonLabel: "Clear and dismiss",
+                  cancelButtonLabel: "Cancel",
+                  applyButtonLabel: "Apply"
+                }}
+                placeholder="Filter by a date range" />
+        <Button disabled={tag_active} onClick={activate_tags} variant="primary">Activate Tags</Button> 
+        <HelpTooltip> 
+        The NoInstanceType category includes miscellaneous costs such as EBS, read more about <a href="https://aws.amazon.com/ebs/pricing/" target="-blank"> EBS Pricing</a>.
+        </HelpTooltip>
+            </SpaceBetween>
+          }
+        >
+          Cluster Costs
+        </Header>
+      }
+    >
+         <BarChart
+        series={stack_info}
+        xDomain={dates}
+        // Set Max Dynamically
+        yDomain={[0,(y_domain * 2)]}
+        i18nStrings={{
+          filterLabel: "Filter displayed data",
+          filterPlaceholder: "Filter data",
+          filterSelectedAriaLabel: "selected",
+          legendAriaLabel: "Legend",
+          chartAriaRoleDescription: "line chart",
+          xTickFormatter: e =>
+            e
+              .toLocaleDateString("en-US", {
+                month: "short",
+                day: "numeric",
+                // hour: "numeric",
+                // minute: "numeric",
+                // hour12: !1
+              })
+              .split(",")
+              .join("\n")
+        }}
+        ariaLabel="Stacked bar chart"
+        errorText="Error loading data."
+        height={300}
+        hideFilter
+        loadingText="Loading chart"
+        recoveryText="Retry"
+        stackedBars
+        xScaleType="categorical"
+        xTitle="Date"
+        yTitle="Cost(s) $"
+        empty={
+          <Box textAlign="center" color="inherit">
+            <b>No data available</b>
+            <Box variant="p" color="inherit">
+              There is no data available
+            </Box>
+          </Box>
+        }
+        noMatch={
+          <Box textAlign="center" color="inherit">
+            <b>No matching data</b>
+            <Box variant="p" color="inherit">
+              There is no matching data to display
+            </Box>
+            <Button>Clear filter</Button>
+          </Box>
+        }
+      ></BarChart>
+    </Container>
+  );
+}

--- a/frontend/src/old-pages/Clusters/Cost.tsx
+++ b/frontend/src/old-pages/Clusters/Cost.tsx
@@ -32,46 +32,68 @@ export default function Cost() {
   const [dateValue, setDateValue] = React.useState(undefined);
   const defaultRegion = useState(['aws', 'region']) || 'us-east-1';
   const region = useState(['app', 'selectedRegion']) || defaultRegion;
-  const cluster_name = useState(['app', 'clusters', 'selected']);
-  const tag_active = useState(['app', 'tags', 'active']);
-  const y_axis = useState(['app', 'cost', cluster_name, 'max']);
-  const x_axis = useState(['app', 'cost', cluster_name, 'dates']) || [];
-  const graph_data = useState(['app', 'cost', cluster_name, 'graph_data']) || [];
-  const start_url = useState(['app', 'cost', cluster_name, 'Start']) || [];
-  const end_url = useState(['app', 'cost', cluster_name, 'End']) || [];
-  const budget_used = useState(['app', 'cost', cluster_name, 'budget']) || [];
-  const table_data = useState(['app', 'cost', cluster_name, 'table_data']) || [];
-  const url_data = useState(['app', 'cost', cluster_name, 'object']) || [];
-  const account_id =  useState(['app', 'account']) || [];
+  const clusterName = useState(['app', 'clusters', 'selected']);
+  const tagActive = useState(['app', 'tags', 'active']);
+  const yAxis = useState(['app', 'cost', clusterName, 'max']);
+  const xAxis = useState(['app', 'cost', clusterName, 'dates']) || [];
+  const graphData = useState(['app', 'cost', clusterName, 'graphData']) || [];
+  const startUrl = useState(['app', 'cost', clusterName, 'Start']) || [];
+  const endUrl = useState(['app', 'cost', clusterName, 'End']) || [];
+  const budgetUsed = useState(['app', 'cost', clusterName, 'budget']) || [];
+  const tableData = useState(['app', 'cost', clusterName, 'tableData']) || [];
+  const urlData = useState(['app', 'cost', clusterName, 'object']) || [];
+  const accountId =  useState(['app', 'account']) || [];
+  const Options = [
+    {
+      key: "previous-30-days",
+      amount: 30,
+      unit: "day",
+      type: "relative",
+    },
+    {
+      key: "previous-14-days",
+      amount: 14,
+      unit: "day",
+      type: "relative",
+    },
+    {
+      key: "previous-7-days",
+      amount: 7,
+      unit: "day",
+      type: "relative",
+    },
+    {
+      key: "previous-1-day",
+      amount: 1,
+      unit: "day",
+      type: "relative",
+    }
+  ]
 
-  // Check tag status
-  const check_tags = () => {
-    const status_update = (value: {TagStatus?: boolean} ) => {
+  const checkTags = () => {   // Check tag status
+    const statusUpdate = (value: {TagStatus?: boolean}) => {
       setState(['app', 'tags', 'active'], value['TagStatus']);
     }
-    GetTagStatus(status_update)
+    GetTagStatus(statusUpdate)
   }
 
-  // Activate all the tags
-  const activate_tags = () => {
-    const status_update = () => {
+  const activateTags = () => {   // Activate all the tags
+    const statusUpdate = () => {
       setState(['app', 'tags', 'active'], true);
     }
-    ActivateTags(status_update)
+    ActivateTags(statusUpdate)
   }
 
-  // Get Budget Limit(Monthly)
-  const get_budget = () => {
-    const budget_data = (value: any) => {
+  const getBudget = () => {   // Get percentage of budget used
+    const budgetData = (value: any) => {
       let budget = value['Budget']
-      let percent_used =  (budget.CalculatedSpend.ActualSpend.Amount / budget.BudgetLimit.Amount) * 100;
-      setState(['app','cost', cluster_name, 'budget'], percent_used);
+      let percentUsed =  (budget.CalculatedSpend.ActualSpend.Amount / budget.BudgetLimit.Amount) * 100;
+      setState(['app','cost', clusterName, 'budget'], percentUsed);
     }
-    GetBudget(budget_data, cluster_name, account_id)
+    GetBudget(budgetData, clusterName, accountId)
   }
 
-  // Create URL for Cost Explorer Link
-  const create_url = () => {
+  const createUrl = () => {   // Create URL for Cost Explorer Link
     let data = [
       {
         "dimension": "TagKeyValue",
@@ -81,7 +103,7 @@ export default function Cost() {
           {
             "dimension": "parallelcluster:cluster-name",
             "values": [
-              cluster_name,
+              clusterName,
             ],
             "include": true,
             "children": null
@@ -89,134 +111,123 @@ export default function Cost() {
         ]
       }
     ]
-    setState(['app', 'cost', cluster_name, 'object'], data)
+    setState(['app', 'cost', clusterName, 'object'], data)
   }
 
-  // Pull cost and usage from CE API
-  const get_graph_data = (Start: string, End: string) => {
-    const query_costs = (data: any) => {
-      const usage_data = data['ResultsByTime'];
-      const dates: Date[] = [];
-      const instance_types = new Set();
-      const day_costs: any[] = [];
-      let table_cost_data = [];
-      let day_info: any[] = [];
+  const getGraphData = (Start: string, End: string) => { // Pull cost and usage from CE API
+    const queryCosts = (data: any) => {
+      const usageData = data['ResultsByTime'];
+      let instanceTypes = new Set();
+      let dayCosts: any[] = [];
+      let dates: Date[] = [];
+      let tableCostData = [];
+      let dayInfo: any[] = [];
       let total = 0;
       let max = 0;
-      let instance_cost = 0;
-      let total_range_cost = 0;
+      let instanceCost = 0;
+      let totalRangeCost = 0;
   
-      // Find XDomain
-      const x_domain = usage_data?.map((obj: any) => {
-          dates.push(new Date(obj.TimePeriod.End));
+      usageData?.forEach((day: any) => { // Find XDomain
+        dates.push(new Date(day.TimePeriod.End));
       })
 
-      // Find All Instance Types
-      const data_instance_types = usage_data?.map((obj: any) => {
-        let data_by_instance_type = obj.Groups;
-        const days = data_by_instance_type?.map((obj2: any) => {
-            instance_types.add(obj2.Keys[0]);
+      usageData?.forEach((date: any) => { // Find all instance types
+        let dataByInstanceType = date.Groups;
+        dataByInstanceType?.forEach((type: any) => {
+          instanceTypes.add(type.Keys[0]);
         })
       })
-  
-      // Create a data set for each instance type
-      instance_types.forEach((type) => {
-          const costs = usage_data?.map((obj: any) => {
-              let data_by_instance_type = obj.Groups;
-              const day_data = data_by_instance_type?.map((obj2: any) => {
-                if (obj2.Keys[0] == type) {
-                    instance_cost = Number(obj2.Metrics.NetUnblendedCost.Amount) + instance_cost
-                    total = Number(obj2.Metrics.NetUnblendedCost.Amount) + total
-                    total_range_cost = Number(obj2.Metrics.NetUnblendedCost.Amount) + total_range_cost;
-                    day_info.push({
-                      x: new Date(obj.TimePeriod.End),
-                      y: Number(parseFloat(obj2.Metrics.NetUnblendedCost.Amount).toFixed(2)),
+      
+      instanceTypes.forEach((type) => { // Create a data set for each instance type
+          const costs = usageData?.map((date: any) => {
+              let dataByInstanceType = date.Groups;
+              const day_data = dataByInstanceType?.map((instanceType: any) => {
+                if (instanceType.Keys[0] == type) {
+                    instanceCost = Number(instanceType.Metrics.NetUnblendedCost.Amount) + instanceCost
+                    total = Number(instanceType.Metrics.NetUnblendedCost.Amount) + total
+                    totalRangeCost = Number(instanceType.Metrics.NetUnblendedCost.Amount) + totalRangeCost;
+                    dayInfo.push({
+                      x: new Date(date.TimePeriod.End),
+                      y: Number(parseFloat(instanceType.Metrics.NetUnblendedCost.Amount).toFixed(2)),
                     },)
                 }
               })
-              // Find highest Cost data in range of days
-              if (total > max) {
-                max = total
-              }
+              max = Math.max(max, total) // Find highest Cost data in range of days
               total = 0
           })
-          // Cost Data for each day
-          if (type == 'NoInstanceType') {
+          if (type == 'NoInstanceType') { // Cost Data for each day
             type = 'NoInstanceType*'
           }
-          day_costs.push({
+          dayCosts.push({
             title: type,
             type: 'bar',
-            data: day_info,
+            data: dayInfo,
           })
-          day_info = []
-          // Cost Data for each instance type
-          if (table_cost_data.length != instance_types.size) {
-            table_cost_data.push({
+          dayInfo = []
+          if (tableCostData.length != instanceTypes.size) { // Cost Data for each instance type
+            tableCostData.push({
               name: type,
-              alt: '$' + instance_cost.toFixed(2),
+              alt: '$' + instanceCost.toFixed(2),
               description: `Total Cost for  ${type} instances from ${Start} to ${End}`,
               type: "1A",
               size: "xxLarge"
             })
           }
-          instance_cost = 0
+          instanceCost = 0
     }) 
-    // Total Cost data for range of days
-    table_cost_data.push({
+    tableCostData.push({ // Total Cost data for range of days
       name: <b> All Instance Types </b>,
-      alt: <b> ${total_range_cost.toFixed(2)} </b>,
+      alt: <b> ${totalRangeCost.toFixed(2)} </b>,
       description: <b> Total Cost for all instance types from {Start} to {End} </b>,
       type: "1A",
       size: "xxLarge"
     })
-    setState(['app', 'cost', cluster_name, 'graph_data'], day_costs);
-    setState(['app', 'cost', cluster_name, 'dates'], dates);
-    setState(['app', 'cost', cluster_name, 'max'], max);
-    setState(['app', 'cost', cluster_name, 'table_data'], table_cost_data);
-    get_budget()
-    table_cost_data = [];
+    setState(['app', 'cost', clusterName, 'graphData'], dayCosts);
+    setState(['app', 'cost', clusterName, 'dates'], dates);
+    setState(['app', 'cost', clusterName, 'max'], max);
+    setState(['app', 'cost', clusterName, 'tableData'], tableCostData);
+    getBudget()
+    tableCostData = [];
     }
-    GetGraphData(query_costs, cluster_name, Start, End)
+    GetGraphData(queryCosts, clusterName, Start, End)
   }
 
   const fetchGraphData = (val: any) => {
-    let start_value = ""
-    let end_value = ""
+    let startValue = ""
+    let endValue = ""
     if (!val) {
-      let current_date = new Date();
-      let start = new Date(current_date.setDate(current_date.getDate()-7));
-      let start_string = new Date(start).toISOString().split('T');
-      let end_string = new Date().toISOString().split('T');
-      start_value = String(start_string[0]);
-      end_value = String(end_string[0]);
+      let currentDate = new Date();
+      let start = new Date(currentDate.setDate(currentDate.getDate()-7));
+      let startString = new Date(start).toISOString().split('T');
+      let endString = new Date().toISOString().split('T');
+      startValue = String(startString[0]);
+      endValue = String(endString[0]);
     } 
     else {
       if (val.type === 'relative') {
         if (val.unit === 'day') {
-          let current_date = new Date()
-          let start = new Date(current_date.setDate(current_date.getDate()-val.amount));
-          let start_string = new Date(start).toISOString().split('T');
-          let end_string = new Date().toISOString().split('T');
-          start_value = String(start_string[0]);
-          end_value = String(end_string[0]);
+          let currentDate = new Date()
+          let start = new Date(currentDate.setDate(currentDate.getDate()-val.amount));
+          let startString = new Date(start).toISOString().split('T');
+          let endString = new Date().toISOString().split('T');
+          startValue = String(startString[0]);
+          endValue = String(endString[0]);
         }
       } 
       else {
         const start = new Date(val.startDate).toISOString().split('T');
         const end = new Date(val.endDate).toISOString().split('T');
-        start_value = String(start[0]);
-        end_value = String(end[0])
+        startValue = String(start[0]);
+        endValue = String(end[0])
       }
     }
-    setState(['app', 'cost', cluster_name, 'End'],String(end_value));
-    setState(['app', 'cost', cluster_name, 'Start'], String(start_value));
-    get_graph_data(String(start_value), String(end_value));
+    setState(['app', 'cost', clusterName, 'End'],String(endValue));
+    setState(['app', 'cost', clusterName, 'Start'], String(startValue));
+    getGraphData(String(startValue), String(endValue));
   }
 
-  // These will be called once on loading of page
-  React.useEffect(() => {
-      check_tags()
+  React.useEffect(() => { // These will be called once on loading of page
+      checkTags()
       const Default = {
           key: 'previous-7-days',
           type: 'relative',
@@ -225,123 +236,109 @@ export default function Cost() {
         };
       fetchGraphData(Default);
       setDateValue(Default);
-      create_url();
+      createUrl();
   },[])
 
   return (
     <Container
-      header={
-        <Header
-          variant="h2"
-          actions={
-            <SpaceBetween
-              direction="horizontal"
-              size="l"
+    header={
+      <Header
+        variant="h2"
+        actions={
+          <SpaceBetween direction="horizontal" size="l">
+            <Button disabled={tagActive} onClick={activateTags} variant="primary">
+              Activate Tags
+            </Button>
+            <DateRangePicker
+              onChange={({ detail }) => {
+                fetchGraphData(detail.value);
+                setDateValue(detail.value);
+              }}
+              value={dateValue}
+              relativeOptions={Options}
+              i18nStrings={{
+                todayAriaLabel: "Today",
+                nextMonthAriaLabel: "Next month",
+                previousMonthAriaLabel: "Previous month",
+                customRelativeRangeDurationLabel: "Duration",
+                customRelativeRangeDurationPlaceholder: "Enter duration",
+                customRelativeRangeOptionLabel: "Custom range",
+                customRelativeRangeOptionDescription:
+                  "Set a custom range of days in the past. Use Days as Unit of Time.",
+                customRelativeRangeUnitLabel: "Unit of time",
+                formatRelativeRange: (e) => {
+                  const t = 1 === e.amount ? e.unit : `${e.unit}s`;
+                  return `Last ${e.amount} ${t}`;
+                },
+                formatUnit: (e, t) => (1 === t ? e : `${e}s`),
+                dateTimeConstraintText:
+                  "Select any Range of days. Use 24 hour format.",
+                relativeModeTitle: "Relative range",
+                absoluteModeTitle: "Absolute range",
+                relativeRangeSelectionHeading: "Choose a range",
+                startDateLabel: "Start date",
+                endDateLabel: "End date",
+                startTimeLabel: "Start time",
+                endTimeLabel: "End time",
+                clearButtonLabel: "Clear and dismiss",
+                cancelButtonLabel: "Cancel",
+                applyButtonLabel: "Apply",
+              }}
+              placeholder="Filter by a date range"
+            />
+            <ProgressBar
+              value={budgetUsed}
+              additionalInfo="Create a Budget with an identical name as your respective cluster for accurate information"
+              description="Progress"
+              label="Cost Usage of Budget"
+            />
+            <HelpTooltip>
+              If you haven't created a budget, create a custom cost budget on{" "}
+              <a
+                href="https://us-east-1.console.aws.amazon.com/billing/home?#/budgets/overview"
+                target="_blank"
+              >
+                {" "}
+                AWS Budgets
+              </a>
+              .
+            </HelpTooltip>
+            <Button
+              href={`https://${region}.console.aws.amazon.com/cost-management/home?region=${region}"#/custom?groupBy=InstanceType&hasBlended=false&hasAmortized=false&excludeDiscounts=true&excludeTaggedResources=false&excludeCategorizedResources=false&excludeForecast=false&timeRangeOption=Custom&granularity=Daily&reportName=&reportType=CostUsage&isTemplate=true&filter=${JSON.stringify(
+                urlData
+              )}&chartStyle=Stack&forecastTimeRangeOption=None&usageAs=usageQuantity&startDate=${startUrl}&endDate=${endUrl}`}
+              target="-blank"
+              iconAlign="right"
+              iconName="external"
             >
-              <Button disabled={tag_active} onClick={activate_tags} variant="primary">Activate Tags</Button>
-              <DateRangePicker
-              onChange={({ detail }) => {fetchGraphData(detail.value); setDateValue(detail.value);}}
-                value={dateValue}
-                relativeOptions={[
-                  {
-                    key: "previous-30-days",
-                    amount: 30,
-                    unit: "day",
-                    type: "relative"
-                  },
-                  {
-                    key: "previous-14-days",
-                    amount: 14,
-                    unit: "day",
-                    type: "relative"
-                  },
-                  {
-                    key: "previous-7-days",
-                    amount: 7,
-                    unit: "day",
-                    type: "relative"
-                  },
-                  {
-                    key: "previous-1-day",
-                    amount: 1,
-                    unit: "day",
-                    type: "relative"
-                  }
-                ]}
-                i18nStrings={{
-                  todayAriaLabel: "Today",
-                  nextMonthAriaLabel: "Next month",
-                  previousMonthAriaLabel: "Previous month",
-                  customRelativeRangeDurationLabel: "Duration",
-                  customRelativeRangeDurationPlaceholder:
-                    "Enter duration",
-                  customRelativeRangeOptionLabel: "Custom range",
-                  customRelativeRangeOptionDescription:
-                    "Set a custom range of days in the past. Use Days as Unit of Time.",
-                  customRelativeRangeUnitLabel: "Unit of time",
-                  formatRelativeRange: e => {
-                    const t =
-                      1 === e.amount ? e.unit : `${e.unit}s`;
-                    return `Last ${e.amount} ${t}`;
-                  },
-                  formatUnit: (e, t) => (1 === t ? e : `${e}s`),
-                  dateTimeConstraintText:
-                    "Select any Range of days. Use 24 hour format.",
-                  relativeModeTitle: "Relative range",
-                  absoluteModeTitle: "Absolute range",
-                  relativeRangeSelectionHeading: "Choose a range",
-                  startDateLabel: "Start date",
-                  endDateLabel: "End date",
-                  startTimeLabel: "Start time",
-                  endTimeLabel: "End time",
-                  clearButtonLabel: "Clear and dismiss",
-                  cancelButtonLabel: "Cancel",
-                  applyButtonLabel: "Apply"
-                }}
-                placeholder="Filter by a date range" />
-        <ProgressBar
-      value={budget_used}
-      additionalInfo="Create a Budget with an identical name as your respective cluster for accurate information"
-      description="Progress"
-      label="Cost Usage of Budget"
-    />
-        <HelpTooltip> 
-            If you haven't created a budget, create a custom cost budget on <a href="https://us-east-1.console.aws.amazon.com/billing/home?#/budgets/overview" target="_blank"> AWS Budgets</a>.
-        </HelpTooltip>
-        <Button
-          href={`https://${region}.console.aws.amazon.com/cost-management/home?region=${region}"#/custom?groupBy=InstanceType&hasBlended=false&hasAmortized=false&excludeDiscounts=true&excludeTaggedResources=false&excludeCategorizedResources=false&excludeForecast=false&timeRangeOption=Custom&granularity=Daily&reportName=&reportType=CostUsage&isTemplate=true&filter=${JSON.stringify(url_data)}&chartStyle=Stack&forecastTimeRangeOption=None&usageAs=usageQuantity&startDate=${start_url}&endDate=${end_url}`}
-          target='-blank'
-          iconAlign="right"
-          iconName="external"
-        >
-          View Data in Cost Explorer
-        </Button> 
-            </SpaceBetween>
-          }
-        >
+              View Data in Cost Explorer
+            </Button>
+          </SpaceBetween>
+        }
+      >
         Cluster Costs
-        </Header>
-      }
-    >
-      <SpaceBetween size="xxl">
-         <BarChart
-        series={graph_data}
-        xDomain={x_axis}
-        yDomain={[0,(y_axis * 1.9)]}
+      </Header>
+    }
+  >
+    <SpaceBetween size="xxl">
+      <BarChart
+        series={graphData}
+        xDomain={xAxis}
+        yDomain={[0, yAxis * 1.9]}
         i18nStrings={{
           filterLabel: "Filter displayed data",
           filterPlaceholder: "Filter data",
           filterSelectedAriaLabel: "selected",
           legendAriaLabel: "Legend",
           chartAriaRoleDescription: "line chart",
-          xTickFormatter: e =>
+          xTickFormatter: (e) =>
             e
               .toLocaleDateString("en-US", {
                 month: "short",
                 day: "numeric",
               })
               .split(",")
-              .join("\n")
+              .join("\n"),
         }}
         ariaLabel="Stacked bar chart"
         errorText="Error loading data."
@@ -372,46 +369,50 @@ export default function Cost() {
         }
       ></BarChart>
       <Table
-      columnDefinitions={[
-      {
-        id: "variable",
-        header: "Instance Type",
-        cell: item => item.name || "-",
-        sortingField: "name"
-      },
-      {
-        id: "alt",
-        header: "Total Cost",
-        cell: item => item.alt || "-",
-        sortingField: "alt"
-      },
-      {
-        id: "description",
-        header: "Summary",
-        cell: item => item.description || "-"
-      }
-      ]}
-      items={table_data}
-      loadingText="Loading resources"
-      sortingDisabled
-      empty={
-        <Box textAlign="center" color="inherit">
-          <b>No resources</b>
-          <Box
-            padding={{ bottom: "s" }}
-            variant="p"
-            color="inherit"
-          >
-            No resources to display.
+        columnDefinitions={[
+          {
+            id: "variable",
+            header: "Instance Type",
+            cell: (item) => item.name || "-",
+            sortingField: "name",
+          },
+          {
+            id: "alt",
+            header: "Total Cost",
+            cell: (item) => item.alt || "-",
+            sortingField: "alt",
+          },
+          {
+            id: "description",
+            header: "Summary",
+            cell: (item) => item.description || "-",
+          },
+        ]}
+        items={tableData}
+        loadingText="Loading resources"
+        sortingDisabled
+        empty={
+          <Box textAlign="center" color="inherit">
+            <b>No resources</b>
+            <Box padding={{ bottom: "s" }} variant="p" color="inherit">
+              No resources to display.
+            </Box>
+            <Button>Create resource</Button>
           </Box>
-          <Button>Create resource</Button>
-        </Box>
-      }
-      header={<Header> Cluster Costs </Header>}
-    />
-    <div> *The <b>NoInstanceType</b> category includes miscellaneous costs such as EBS, read more about <a href="https://aws.amazon.com/ebs/pricing/" target="-blank"> EBS Pricing</a>.</div>
-
+        }
+        header={<Header> Cluster Costs </Header>}
+      />
+      <div>
+        {" "}
+        *The <b>NoInstanceType</b> category includes miscellaneous costs such as
+        EBS, read more about{" "}
+        <a href="https://aws.amazon.com/ebs/pricing/" target="-blank">
+          {" "}
+          EBS Pricing
+        </a>
+        .
+      </div>
     </SpaceBetween>
-    </Container>
+  </Container>
   );
 }

--- a/frontend/src/old-pages/Clusters/Cost.tsx
+++ b/frontend/src/old-pages/Clusters/Cost.tsx
@@ -29,7 +29,8 @@ import HelpTooltip from '../../components/HelpTooltip'
 import { ActivateTags, GetTagStatus, GetGraphData, GetBudget } from '../../model';
 
 export default function Cost() {
-  const [dateValue, setDateValue] = React.useState(null);
+
+  const [dateValue, setDateValue] = React.useState(undefined);
   const defaultRegion = useState(['aws', 'region']) || 'us-east-1';
   const region = useState(['app', 'selectedRegion']) || defaultRegion;
   const clusterName = useState(['app', 'clusters', 'selected']);
@@ -162,7 +163,7 @@ export default function Cost() {
       let max = 0;
       let instanceCost = 0;
       let totalRangeCost = 0;
-  
+
       usageData?.forEach((day: any) => { // Find XDomain
         dates.push(new Date(day.TimePeriod.End));
       })
@@ -226,7 +227,7 @@ export default function Cost() {
     tableCostData = [];
     }
     GetGraphData(queryCosts, clusterName, Start, End)
-    }
+  }
 
   const fetchGraphData = (val: any) => {
     let startValue = ""
@@ -294,6 +295,7 @@ export default function Cost() {
           amount: 7,
         };
       fetchGraphData(Default);
+      /* @ts-expect-error TS(2345) FIXME: Argument of type 'Value | null' is not assignable ... Remove this comment to see the full error message */
       setDateValue(Default);
   },[])
 
@@ -308,10 +310,9 @@ export default function Cost() {
               Activate Tags
             </Button>
             <DateRangePicker
-              onChange={({ detail }) => {
-                fetchGraphData(detail.value);
-                setDateValue(detail.value);
-              }}
+              /* @ts-expect-error TS(2345) FIXME: Argument of type 'Value | null' is not assignable ... Remove this comment to see the full error message */
+              onChange={({ detail }) => { fetchGraphData(detail.value); setDateValue(detail.value); } }
+              /* @ts-expect-error TS(2345) FIXME: Argument of type 'Value | null' is not assignable ... Remove this comment to see the full error message */
               value={dateValue}
               relativeOptions={[
                 {
@@ -341,7 +342,8 @@ export default function Cost() {
               ]}
               i18nStrings={dateRangePickerSettings}
               placeholder="Filter by a date range"
-            />
+              isValidRange={function (value: any): any { return; } }
+              />
             <ProgressBar
               value={budgetUsed}
               additionalInfo="Create a Budget with an identical name as your respective cluster for accurate information"

--- a/frontend/src/old-pages/Clusters/Cost.tsx
+++ b/frontend/src/old-pages/Clusters/Cost.tsx
@@ -27,9 +27,10 @@ import {
 // Components
 import HelpTooltip from '../../components/HelpTooltip'
 import { ActivateTags, GetTagStatus, GetGraphData, GetBudget } from '../../model';
+import { useTranslation } from 'react-i18next';
 
 export default function Cost() {
-
+  const { t } = useTranslation();
   const [dateValue, setDateValue] = React.useState(undefined);
   const defaultRegion = useState(['aws', 'region']) || 'us-east-1';
   const region = useState(['app', 'selectedRegion']) || defaultRegion;
@@ -41,64 +42,39 @@ export default function Cost() {
   const budgetUsed = useState(['app', 'cost', clusterName, 'budget']) || [];
   const tableData = useState(['app', 'cost', clusterName, 'tableData']) || [];
   const accountId =  useState(['app', 'account']) || [];
-  const Options = [
-    {
-      key: "previous-30-days",
-      amount: 30,
-      unit: "day",
-      type: "relative",
-    },
-    {
-      key: "previous-14-days",
-      amount: 14,
-      unit: "day",
-      type: "relative",
-    },
-    {
-      key: "previous-7-days",
-      amount: 7,
-      unit: "day",
-      type: "relative",
-    },
-    {
-      key: "previous-1-day",
-      amount: 1,
-      unit: "day",
-      type: "relative",
-    },
-  ]
   const dateRangePickerSettings = {
-    todayAriaLabel: "Today",
-    nextMonthAriaLabel: "Next month",
-    previousMonthAriaLabel: "Previous month",
-    customRelativeRangeDurationLabel: "Duration",
-    customRelativeRangeDurationPlaceholder: "Enter duration",
-    customRelativeRangeOptionLabel: "Custom range",
-    customRelativeRangeOptionDescription: "Set a custom range of days in the past. Use Days as Unit of Time.",
-    customRelativeRangeUnitLabel: "Unit of time",
-    formatRelativeRange: (e:any) => {
-      const t = 1 === e.amount ? e.unit : `${e.unit}s`;
-      return `Last ${e.amount} ${t}`;
+    todayAriaLabel: t("CostTab.dateRangePicker.dateRangePickerSetting.todayAriaLabel"),
+    nextMonthAriaLabel: t("CostTab.dateRangePicker.dateRangePickerSetting.nextMonthAriaLabel"),
+    previousMonthAriaLabel: t("CostTab.dateRangePicker.dateRangePickerSetting.previousMonthAriaLabel"),
+    customRelativeRangeDurationLabel: t("CostTab.dateRangePicker.dateRangePickerSetting.customRelativeRangeDurationLabel"),
+    customRelativeRangeDurationPlaceholder: t("CostTab.dateRangePicker.dateRangePickerSetting.customRelativeRangeDurationPlaceholder"),
+    customRelativeRangeOptionLabel: t("CostTab.dateRangePicker.dateRangePickerSetting.customRelativeRangeOptionLabel"),
+    customRelativeRangeOptionDescription: t("CostTab.dateRangePicker.dateRangePickerSetting.customRelativeRangeOptionDescription"),
+    customRelativeRangeUnitLabel: t("CostTab.dateRangePicker.dateRangePickerSetting.customRelativeRangeUnitLabel"),
+    formatRelativeRange: (e: { amount: number; unit: any; }) => {
+      const t =
+        1 === e.amount ? e.unit : `${e.unit}s`;
+      return  `Last ${e.amount} ${t}`;
     },
-    formatUnit: (e:any, t:any) => (1 === t ? e : `${e}s`),
-    dateTimeConstraintText: "Select any Range of days. Use 24 hour format.",
-    relativeModeTitle: "Relative range",
-    absoluteModeTitle: "Absolute range",
-    relativeRangeSelectionHeading: "Choose a range",
-    startDateLabel: "Start date",
-    endDateLabel: "End date",
-    startTimeLabel: "Start time",
-    endTimeLabel: "End time",
-    clearButtonLabel: "Clear and dismiss",
-    cancelButtonLabel: "Cancel",
-    applyButtonLabel: "Apply",
+    formatUnit: (e: any, t: number) => (1 === t ? e : `${e}s`),
+    dateTimeConstraintText: t("CostTab.dateRangePicker.dateRangePickerSetting.dateTimeConstraintText"),
+    relativeModeTitle: t("CostTab.dateRangePicker.dateRangePickerSetting.relativeModeTitle"),
+    absoluteModeTitle: t("CostTab.dateRangePicker.dateRangePickerSetting.absoluteModeTitle"),
+    relativeRangeSelectionHeading: t("CostTab.dateRangePicker.dateRangePickerSetting.relativeRangeSelectionHeading"),
+    startDateLabel: t("CostTab.dateRangePicker.dateRangePickerSetting.startDateLabel"),
+    endDateLabel: t("CostTab.dateRangePicker.dateRangePickerSetting.endDateLabel"),
+    startTimeLabel: t("CostTab.dateRangePicker.dateRangePickerSetting.startTimeLabel"),
+    endTimeLabel: t("CostTab.dateRangePicker.dateRangePickerSetting.endTimeLabel"),
+    clearButtonLabel: t("CostTab.dateRangePicker.dateRangePickerSetting.clearButtonLabel"),
+    cancelButtonLabel: t("CostTab.dateRangePicker.dateRangePickerSetting.cancelButtonLabel"),
+    applyButtonLabel: t("CostTab.dateRangePicker.dateRangePickerSetting.applyButtonLabel"),
   }
   const barChartSettings = {
-    filterLabel: "Filter displayed data",
-    filterPlaceholder: "Filter data",
-    filterSelectedAriaLabel: "selected",
-    legendAriaLabel: "Legend",
-    chartAriaRoleDescription: "line chart",
+    filterLabel: t("CostTab.BarChartSetting.filterLabel"),
+    filterPlaceholder: t("CostTab.BarChartSetting.filterPlaceHolder"),
+    filterSelectedAriaLabel: t("CostTab.BarChartSetting.filterSelectedAriaLabel"),
+    legendAriaLabel: t("CostTab.BarChartSetting.legendAriaLabel"),
+    chartAriaRoleDescription: t("CostTab.BarChartSetting.chartAriaRoleDescription"),
     xTickFormatter: (e: any) =>
       e
         .toLocaleDateString("en-US", {
@@ -111,19 +87,19 @@ export default function Cost() {
   const barChartColumns = [
     {
       id: "variable",
-      header: "Instance Type",
+      header: t("CostTab.BarChartColumns.InstanceType"),
       cell: (item: any) => item.name || "-",
       sortingField: "name",
     },
     {
       id: "alt",
-      header: "Total Cost",
+      header: t("CostTab.BarChartColumns.TotalCost"),
       cell: (item: any) => item.alt || "-",
       sortingField: "alt",
     },
     {
       id: "description",
-      header: "Summary",
+      header: t("CostTab.BarChartColumns.Summary"),
       cell: (item: any) => item.description || "-",
     },
   ]
@@ -205,7 +181,7 @@ export default function Cost() {
             tableCostData.push({
               name: type,
               alt: '$' + instanceCost.toFixed(2),
-              description: `Total Cost for  ${type} instances from ${Start} to ${End}`,
+              description: <div> {t("CostTab.CostTable.description.TotalCostFor")} {type} {t("CostTab.CostTable.description.Transition")} {Start} {t("CostTab.CostTable.description.To")} {End}</div>,
               type: "1A",
               size: "xxLarge"
             })
@@ -213,9 +189,9 @@ export default function Cost() {
           instanceCost = 0
     }) 
     tableCostData.push({ // Total Cost data for range of days
-      name: <b> All Instance Types </b>,
+      name: <b> {t("CostTab.CostTable.Name")} </b>,
       alt: <b> ${totalRangeCost.toFixed(2)} </b>,
-      description: <b> Total Cost for all instance types from {Start} to {End} </b>,
+      description: <b> {t("CostTab.CostTable.description.Sentence")} {Start} {t("CostTab.CostTable.description.To")} {End} </b>,
       type: "1A",
       size: "xxLarge"
     })
@@ -289,7 +265,7 @@ export default function Cost() {
   React.useEffect(() => { // These will be called once on loading of page
       checkTags()
       const Default = {
-          key: 'previous-7-days',
+          key: "previous-7-days",
           type: 'relative',
           unit: 'day',
           amount: 7,
@@ -307,7 +283,7 @@ export default function Cost() {
         actions={
           <SpaceBetween direction="horizontal" size="l">
             <Button disabled={tagActive} onClick={activateTags} variant="primary">
-              Activate Tags
+            {t("CostTab.TagsButton.Text")}
             </Button>
             <DateRangePicker
               /* @ts-expect-error TS(2345) FIXME: Argument of type 'Value | null' is not assignable ... Remove this comment to see the full error message */
@@ -341,22 +317,22 @@ export default function Cost() {
                 }
               ]}
               i18nStrings={dateRangePickerSettings}
-              placeholder="Filter by a date range"
+              placeholder={t("CostTab.dateRangePicker.placeholder")}
               isValidRange={function (value: any): any { return; } }
               />
             <ProgressBar
               value={budgetUsed}
-              additionalInfo="Create a Budget with an identical name as your respective cluster for accurate information"
-              description="Progress"
-              label="Cost Usage of Budget"
+              additionalInfo={t("CostTab.ProgressBar.additionalInfo")}
+              description={t("CostTab.ProgressBar.description")}
+              label={t("CostTab.ProgressBar.label")}
             />
             <HelpTooltip>
-              If you haven't created a budget, create a custom cost budget on{" "}
+              {t("CostTab.HelpToolTip.Text")}{" "}
               <a
                 href="https://us-east-1.console.aws.amazon.com/billing/home?#/budgets/overview"
                 target="_blank"
               >
-                AWS Budgets
+              {t("CostTab.HelpToolTip.Title")}
               </a>
               .
             </HelpTooltip>
@@ -366,12 +342,12 @@ export default function Cost() {
               iconAlign="right"
               iconName="external"
             >
-              View Data in Cost Explorer
+              {t("CostTab.CostExplorerButton.Text")}
             </Button>
           </SpaceBetween>
         }
       >
-        Cluster Costs
+        {t("CostTab.Header.Title")}
       </Header>
     }
   >
@@ -381,57 +357,56 @@ export default function Cost() {
         xDomain={xAxis}
         yDomain={[0, yAxis * 1.9]}
         i18nStrings={barChartSettings}
-        ariaLabel="Stacked bar chart"
-        errorText="Error loading data."
+        ariaLabel={t("CostTab.BarChart.values.arialLabel")}
+        errorText={t("CostTab.BarChart.values.errorText")}
         height={300}
         hideFilter
-        loadingText="Loading chart"
-        recoveryText="Retry"
+        loadingText={t("CostTab.BarChart.values.loadingText")}
+        recoveryText={t("CostTab.BarChart.values.recoveryText")}
         stackedBars
-        xScaleType="categorical"
-        xTitle="Date"
-        yTitle="Cost(s) $"
+        xScaleType={t("CostTab.BarChart.values.xScaleType")}
+        xTitle={t("CostTab.BarChart.values.xTitle")}
+        yTitle={t("CostTab.BarChart.values.yTitle")}
         empty={
           <Box textAlign="center" color="inherit">
-            <b>No data available</b>
+            <b>{t("CostTab.BarChart.empty.NoData")}</b>
             <Box variant="p" color="inherit">
-              There is no data available
+            {t("CostTab.BarChart.noMatch.ThereIsNoData")}
             </Box>
           </Box>
         }
         noMatch={
           <Box textAlign="center" color="inherit">
-            <b>No matching data</b>
+            <b>{t("CostTab.BarChart.noMatch.NoMatchingData")}</b>
             <Box variant="p" color="inherit">
-              There is no matching data to display
+            {t("CostTab.BarChart.noMatch.ThereIsNoMatchingData")}
             </Box>
-            <Button>Clear filter</Button>
+            <Button>{t("CostTab.BarChart.noMatch.ClearFilter")}</Button>
           </Box>
         }
       ></BarChart>
       <Table
         columnDefinitions={barChartColumns}
         items={tableData}
-        loadingText="Loading resources"
+        loadingText={t("CostTab.Table.NoResources")}
         sortingDisabled
         empty={
           <Box textAlign="center" color="inherit">
-            <b>No resources</b>
+            <b>{t("CostTab.Table.LoadingText.NoResources")}</b>
             <Box padding={{ bottom: "s" }} variant="p" color="inherit">
-              No resources to display.
+            {t("CostTab.Table.LoadingText.NoResourcesToDisplay")}
             </Box>
-            <Button>Create resource</Button>
+            <Button>{t("CostTab.Table.LoadingText.CreateResources")}</Button>
           </Box>
         }
-        header={<Header> Cluster Costs </Header>}
+        header={<Header> {t("CostTab.Header.Title")} </Header>}
       />
       <div>
         {" "}
-        *The <b>NoInstanceType</b> category includes miscellaneous costs such as
-        EBS, read more about{" "}
+        {t("CostTab.NoInstanceType.Text")}
         <a href="https://aws.amazon.com/ebs/pricing/" target="-blank">
           {" "}
-          EBS Pricing
+          {t("CostTab.NoInstanceType.Title")}
         </a>
         .
       </div>

--- a/frontend/src/old-pages/Clusters/Details.tsx
+++ b/frontend/src/old-pages/Clusters/Details.tsx
@@ -26,6 +26,7 @@ import Scheduling from './Scheduling'
 import Properties from './Properties'
 import Logs from './Logs'
 import Loading from '../../components/Loading'
+import Cost from './Cost'
 
 export default function ClusterTabs() {
 
@@ -61,6 +62,7 @@ export default function ClusterTabs() {
         {label: "Details", id: "details", content: <Properties />},
         {label: "Instances", id: "instances", content: <Instances />},
         {label: "Storage", id: "storage", content: <Filesystems />},
+        {label: "Cost", id: "cost", content: <Cost />},
         {label: "Job Scheduling", id: "scheduling", content: <Scheduling />},
         ...(accountingEnabled ? [{label: "Accounting", id: "accounting", content: <Accounting />}] : []),
         {label: "Stack Events", id: "stack-events", content: <StackEvents />},


### PR DESCRIPTION
## Description

This adds a tab called "Cost" which summarizes Cluster cost by pulling in data from cost-explorer and graphing it by instance type. Also, this includes a button to activate cost allocation tags, which is a necessary pre-requisite for cost explorer.

## Changes

- Included new Cost.tsx file
- Added route `/manager/graph_data?cluster_name=Cluster&Start=Start&End=End/`
- Added route `/manager/activate_tags/`
- Added route `/manager/check_tag_status/`

## How Has This Been Tested?

- Tested locally using created clusters


https://user-images.githubusercontent.com/68314782/180088672-fad78396-854a-425f-92c8-7c8152289d64.mov


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
