### PR TITLE
Support FSx for OpenZFS and NetApp ONTAP in the cluster details' storage section

### DIFF
--- a/frontend/src/pages/Clusters/Filesystems.js
+++ b/frontend/src/pages/Clusters/Filesystems.js
@@ -27,22 +27,27 @@ import {
 import EmptyState from '../../components/EmptyState';
 
 function StorageId({storage}){
-  const settingsKey = `${storage.StorageType}Settings`
-  const fs_id = getIn(storage, [settingsKey, 'FileSystemId'])
+  const settingsKey = `${storage.StorageType}Settings`;
+  const canMountFileSystem = ['Efs', 'FsxLustre'].includes(storage.StorageType);
+  const idKey = canMountFileSystem ? 'FileSystemId' : 'VolumeId';
+  const detailsFragment = canMountFileSystem ? '#file-system-details' : '#volume-details';
+  const id = getIn(storage, [settingsKey, idKey]);
   const defaultRegion = useState(['aws', 'region']);
   const region = useState(['app', 'selectedRegion']) || defaultRegion;
+  const versionMinor = useState(['app', 'version', 'minor']);
+  const fsxStorageTypes = (versionMinor && versionMinor >= 2) ? ['FsxLustre', 'FsxOntap', 'FsxOpenZfs'] : ['FsxLustre'];
 
   return <>
-    {fs_id && storage.StorageType === 'FsxLustre' && <Link external externalIconAriaLabel="Opens a new tab"
-      href={`${consoleDomain(region)}/fsx/home?region=${region}#file-system-details/${fs_id}`}
-    >{fs_id}</Link>}
-    {fs_id && storage.StorageType === 'Ebs' && <Link external externalIconAriaLabel="Opens a new tab"
-      href={`${consoleDomain(region)}/efs/home?region=${region}#/file-systems/${fs_id}`}
-    >{fs_id}</Link>}
-    {fs_id && storage.StorageType === 'Efs' && <Link external externalIconAriaLabel="Opens a new tab"
-      href={`${consoleDomain(region)}/ec2/v2/home?region=${region}#VolumeDetails:volumeId=${fs_id}`}
-    >{fs_id}</Link>}
-    {!fs_id && "internal"}
+    {id && fsxStorageTypes.includes(storage.StorageType) && <Link external externalIconAriaLabel="Opens a new tab"
+      href={`${consoleDomain(region)}/fsx/home?region=${region}${detailsFragment}/${id}`}
+    >{id}</Link>}
+    {id && storage.StorageType === 'Efs' && <Link external externalIconAriaLabel="Opens a new tab"
+      href={`${consoleDomain(region)}/efs/home?region=${region}#/file-systems/${id}`}
+    >{id}</Link>}
+    {id && storage.StorageType === 'Ebs' && <Link external externalIconAriaLabel="Opens a new tab"
+      href={`${consoleDomain(region)}/ec2/v2/home?region=${region}#VolumeDetails:volumeId=${id}`}
+    >{id}</Link>}
+    {!id && "internal"}
   </>
 
 }


### PR DESCRIPTION
### Notes
If we are using a ParallelCluster version with a minor equal or greater than 2,
like 3.2.0b, support showing a link to FSx for OpenZFS and NetApp ONTAP file systems
in the cluster details' storage section.

In the case of ONTAP and OpenZFS we cannot mount an entire file system, so the id
links to the volume details, not to the file system details page. This is similar to
what happens with Ebs, while Efs and FSx for Lustre can mount the entire file system.

### Tests
Tested with a cluster with ONTAP and OpenZFS shared storage, created with the following configuration:

``` yaml
HeadNode:
  InstanceType: t2.micro
  Ssh:
    KeyName: ermann-dcv-dub
  Networking:
    SubnetId: <subnet id>
  LocalStorage:
    RootVolume:
      VolumeType: gp3
Scheduling:
  Scheduler: slurm
  SlurmQueues:
    - Name: queue0
      ComputeResources:
        - Name: queue0-t2-micro
          MinCount: 0
          MaxCount: 4
          InstanceType: t2.micro
      Networking:
        SubnetIds:
          - <subnet id>
      ComputeSettings:
        LocalStorage:
          RootVolume:
            VolumeType: gp3
Region: eu-west-1
Image:
  Os: alinux2
SharedStorage:
  - Name: testOntap
    StorageType: FsxOntap
    MountDir: <mount point 1>
    FsxOntapSettings:
      VolumeId: <volume id 1>
  - Name: testOpenZfz
    StorageType: FsxOpenZfs
    MountDir: <mount point 2>
    FsxOpenZfsSettings:
      VolumeId: <volume id 2>
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
