### PR TITLE
Add ONTAP/OpenZFS support

### DIFF
--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -485,6 +485,12 @@ def get_aws_config():
     except:
         pass
 
+    fsx_volumes = []
+    try:
+        fsx_volumes = list(filter(lambda vol: (vol["Lifecycle"] == "CREATED" or vol["Lifecycle"] == "AVAILABLE"), fsx.describe_volumes()["Volumes"]))
+    except:
+        pass
+
     efs_filesystems = []
     try:
         efs_filesystems = efs.describe_file_systems()["FileSystems"]
@@ -504,6 +510,7 @@ def get_aws_config():
         "subnets": subnets,
         "region": region,
         "fsx_filesystems": fsx_filesystems,
+        "fsx_volumes": fsx_volumes,
         "efs_filesystems": efs_filesystems,
         "efa_instance_types": efa_instance_types,
     }

--- a/frontend/src/model.js
+++ b/frontend/src/model.js
@@ -523,11 +523,16 @@ function LoadAwsConfig(region = null, callback) {
 }
 
 const extractFsxFilesystems = (filesystems) => {
-  const mappedFilesystems = filesystems.map(fs => ({
-    id: fs.FileSystemId,
-    name: nameFromFilesystem(fs),
-    type: fs.FileSystemType,
-  }));
+  const mappedFilesystems = filesystems
+    .map(fs => ({
+      id: fs.FileSystemId,
+      name: nameFromFilesystem(fs),
+      type: fs.FileSystemType,
+    }))
+    .map(fs => ({
+      ...fs,
+      displayName: `${fs.id} ${fs.name}`,
+    }));
 
   return {
     lustre: mappedFilesystems.filter(fs => fs.type === "LUSTRE"),
@@ -539,18 +544,24 @@ const extractFsxFilesystems = (filesystems) => {
 const nameFromFilesystem = (filesystem) => {
   const { Tags: tags } = filesystem;
   if(!tags) {
-    return null;
+    return "";
   }
   const nameTag = filesystem.Tags.find((tag) => tag.Key === "Name");
-  return nameTag ? nameTag.Value : null;
+  return nameTag ? nameTag.Value : "";
 }
 
 const extractFsxVolumes = (volumes) => {
-  const mappedVolumes = volumes.map(vol => ({
-    id: vol.VolumeId,
-    name: vol.Name,
-    type: vol.VolumeType,
-  }));
+  const mappedVolumes = volumes
+    .map(vol => ({
+      id: vol.VolumeId,
+      name: vol.Name,
+      type: vol.VolumeType,
+    }))
+    .map(vol => ({
+      ...vol,
+      displayName: `${vol.id} ${vol.name}`,
+    }));
+
   return {
     zfs: mappedVolumes.filter(vol => vol.type === "OPENZFS"),
     ontap: mappedVolumes.filter(vol => vol.type === "ONTAP"),

--- a/frontend/src/model.js
+++ b/frontend/src/model.js
@@ -503,9 +503,10 @@ function LoadAwsConfig(region = null, callback) {
   request('get', url).then(response => {
     if(response.status === 200) {
       console.log("aws", response.data);
-      const { fsx_filesystems, ...data} = response.data;
+      const { fsx_filesystems, fsx_volumes, ...data} = response.data;
       setState(['aws'], {
         fsxFilesystems: extractFsxFilesystems(fsx_filesystems),
+        fsxVolumes: extractFsxVolumes(fsx_volumes),
         ...data,
       });
       GetInstanceTypes(region);
@@ -542,6 +543,18 @@ const nameFromFilesystem = (filesystem) => {
   }
   const nameTag = filesystem.Tags.find((tag) => tag.Key === "Name");
   return nameTag ? nameTag.Value : null;
+}
+
+const extractFsxVolumes = (volumes) => {
+  const mappedVolumes = volumes.map(vol => ({
+    id: vol.VolumeId,
+    name: vol.Name,
+    type: vol.VolumeType,
+  }));
+  return {
+    zfs: mappedVolumes.filter(vol => vol.type === "OPENZFS"),
+    ontap: mappedVolumes.filter(vol => vol.type === "ONTAP"),
+  };
 }
 
 function GetVersion() {

--- a/frontend/src/pages/Configure/Storage.js
+++ b/frontend/src/pages/Configure/Storage.js
@@ -449,6 +449,11 @@ function EbsSettings({index}) {
   )
 }
 
+/*
+ * Used to configure the Storage part of the Cluster wizard:
+ *  - controls whether a storage type can be created or just linked
+ *  - specify if a storage type can be mounted as a file system or just one of its volumes
+ */
 const STORAGE_TYPE_PROPS = {
   "FsxLustre": {
     canCreate: true,

--- a/frontend/src/pages/Configure/Storage.js
+++ b/frontend/src/pages/Configure/Storage.js
@@ -460,18 +460,9 @@ function StorageInstance({index}) {
   const existingId = useState(existingPath) || "";
   const storages = useState(storagePath);
 
-  const fsxFilesystems = useState(['aws', 'fsx_filesystems']) || [];
+  const fsxFilesystems = useState(['aws', 'fsxFilesystems']);
   const efsFilesystems = useState(['aws', 'efs_filesystems']) || [];
   const editing = useState(['app', 'wizard', 'editing']);
-
-  const fsxName = (fsx) => {
-    var tags = fsx.Tags;
-    if(!tags) {
-      return null;
-    }
-    tags = fsx.Tags.filter((t) => {return t.Key === "Name"})
-    return (tags.length > 0) ? tags[0].Value : null
-  }
 
   const removeStorage = (type) => {
     if(index === 0 && storages.length === 1)
@@ -542,11 +533,12 @@ function StorageInstance({index}) {
                         value={existingId}
                         onChange={(({detail}) => {setState(existingPath, detail.value)})} />
                     </div>,
-                  "FsxLustre": <FormField label="FSx Filesystem">
+                  "FsxLustre": <FormField label="FSx Lustre Filesystem">
                     <Select
                       placeholder="Please Select"
                       selectedOption={existingId && idToOption(existingId)} label="FSx Filesystem" onChange={({detail}) => {setState(existingPath, detail.selectedOption.value)}}
-                      options={fsxFilesystems.map((x, i) => {return {value: x.FileSystemId, label: (x.FileSystemId + (fsxName(x) ? ` (${fsxName(x)})` : ""))}})}
+                      options={fsxFilesystems.lustre.map((fs) => {return {value: fs.id, label: fs.name}})}
+                    />
                     />
                   </FormField>,
                   "Efs": <FormField label="EFS Filesystem">

--- a/frontend/src/pages/Configure/Storage.js
+++ b/frontend/src/pages/Configure/Storage.js
@@ -567,21 +567,21 @@ function StorageInstance({index}) {
                     <Select
                       placeholder="Please Select"
                       selectedOption={existingId && idToOption(existingId)} label="FSx Filesystem" onChange={({detail}) => {setState(existingPath, detail.selectedOption.value)}}
-                      options={fsxFilesystems.lustre.map((fs) => {return {value: fs.id, label: fs.name}})}
+                      options={fsxFilesystems.lustre.map((fs) => ({value: fs.id, label: fs.displayName}))}
                     />
                   </FormField>,
                   "FsxOpenZfs": <FormField label="Existing FSx OpenZFS volume">
                     <Select
                       placeholder="Please Select"
                       selectedOption={existingId && idToOption(existingId)} label="FSx OpenZFS volume" onChange={({detail}) => {setState(existingPath, detail.selectedOption.value)}}
-                      options={fsxVolumes.zfs.map((fs) => {return {value: fs.id, label: fs.name}})}
+                      options={fsxVolumes.zfs.map((vol) => ({value: vol.id, label: vol.displayName}))}
                     />
                   </FormField>,
                   "FsxOntap": <FormField label="Existing FSx NetApp ONTAP volume">
                     <Select
                       placeholder="Please Select"
                       selectedOption={existingId && idToOption(existingId)} label="FSx ONTAP volume" onChange={({detail}) => {setState(existingPath, detail.selectedOption.value)}}
-                      options={fsxVolumes.ontap.map((fs) => {return {value: fs.id, label: fs.name}})}
+                      options={fsxVolumes.ontap.map((vol) => ({value: vol.id, label: vol.displayName}))}
                     />
                   </FormField>,
                   "Efs": <FormField label="EFS Filesystem">


### PR DESCRIPTION
## Notes
This PR adds support for [FSx ONTAP](https://aws.amazon.com/fsx/netapp-ontap/) and [FSx OpenZFS](https://aws.amazon.com/fsx/openzfs/).

### Changelist
- existing filesystem are filtered to apply only Lustre FS to the corresponding storage type, fixing a bug where Windows File Server FS were selectable
- return FSx volumes from the API
- add support for ONTAP/OpenZFS depending on the ParallelCluster version (3.2.0 and above)
- fixed a bug with EBS: linking an existing EBS volume wasn't working with the wizard

## Testing
- created a new cluster with OpenZFS/ONTAP volumes attached
- verified that the new ZFS/ONTAP filesystem do not appear under the Lustre section
- verified that the Lustre storage is still working
- linked an existing EBS volume and verified that the wizard is working

https://user-images.githubusercontent.com/3091286/177185857-bffb1f5f-7f6f-45d9-81e9-7940e88134fb.mov

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
