### PR TITLE
fix: use selectedClusterName in ClusterTabs in order to avoid to lose it upon navigating on a different page

### DIFF
--- a/frontend/src/pages/Clusters/Details.js
+++ b/frontend/src/pages/Clusters/Details.js
@@ -33,6 +33,7 @@ export default function ClusterTabs() {
   const clusterPath = ['clusters', 'index', clusterName];
   const cluster = useState(clusterPath);
   const customActions = useState([...clusterPath, 'config', 'HeadNode', 'CustomActions']);
+  const selectedClusterName = useState(['app', 'clusters', 'selected']);
 
   let allScripts = [];
   const scriptName = (script) => {
@@ -65,7 +66,7 @@ export default function ClusterTabs() {
         {label: "Stack Events", id: "stack-events", content: <StackEvents />},
         {label: "Logs", id: "logs", content: <Logs />}
       ]}
-        onChange={({detail}) => {navigate(`/clusters/${params.clusterName}/${detail.activeTabId}`)}}
+        onChange={({detail}) => {navigate(`/clusters/${selectedClusterName}/${detail.activeTabId}`)}}
         activeTabId={params.tab || 'details'}
     />
       : <div style={{textAlign: "center", paddingTop: "40px"}}>


### PR DESCRIPTION
### Notes
In the Cluster List section, the selected cluster is lost when users navigate out of the page. When coming back, the cluster appears to be selected, but upon interaction with any other tab, the UI breaks as the selected cluster appears to be undefined.

The issue is rooted into the fact that on tab selection `params.clusterName` is used to populate the new navigation path. On the other hand, `selectedClusterName` from Redux store is used to determine if a specific cluster was selected before leaving the Cluster List page.

Using `selectedClusterName` in both places solved the issue.

### Open Points
* Keeping the cluster selected when leaving/re-entering the page is the expected behavior? We should double check which are Polaris best practices and/or have a look at the same pattern in one of the console services. If that is not the case, we should cleanup the state when leaving the page.

### Issue
* https://app.asana.com/0/1202530481823466/1202523788825824

### Testing
* Created 2 test clusters
* Selected `test-cluster-1`
* Moved to Custom Images page
* Navigated back to Cluster List page, `test-cluster-1` still selected
* When clicking on a different tab cluster is shown correctly, no UI issue displayed 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
