### PR TITLE
feat: make user roles claim in the jwt configurable, using 'cognito:groups' as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,15 @@ npm run dev
 
 Then navigate to [http://localhost:3000](http://localhost:3000)
 
+## Testing
+
+Launch tests of the API backend by running:
+
+```bash
+pytest
+```
+For detailed information on how to invoke `pytest`, see this [resource](https://docs.pytest.org/en/7.1.x/how-to/usage.html). 
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -33,7 +33,7 @@ CLIENT_SECRET = os.getenv("CLIENT_SECRET")
 SECRET_ID = os.getenv("SECRET_ID")
 ENABLE_MFA = os.getenv("ENABLE_MFA")
 SITE_URL = os.getenv("SITE_URL", API_BASE_URL)
-USER_ROLES_CLAIM = os.getenv("USER_ROLES_CLAIM")
+USER_ROLES_CLAIM = os.getenv("USER_ROLES_CLAIM", "cognito:groups")
 
 try:
     if (not USER_POOL_ID or USER_POOL_ID == "") and SECRET_ID:

--- a/api/tests/test_pcluster_api_handler.py
+++ b/api/tests/test_pcluster_api_handler.py
@@ -1,0 +1,20 @@
+import pytest
+from unittest import mock
+from api.PclusterApiHandler import _get_user_roles
+
+
+@mock.patch("api.PclusterApiHandler.USER_ROLES_CLAIM", "user_roles")
+def test_user_roles():
+    user_roles = ["user", "admin"]
+
+    _test_decoded_with_user_roles_claim(decoded={"user_roles": user_roles}, user_roles=user_roles)
+    _test_decoded_without_user_roles_claim(decoded={})
+
+
+
+def _test_decoded_with_user_roles_claim(decoded, user_roles):
+    assert _get_user_roles(decoded) == user_roles
+
+
+def _test_decoded_without_user_roles_claim(decoded):
+    assert _get_user_roles(decoded) == ["user"]

--- a/frontend/src/auth/constants.ts
+++ b/frontend/src/auth/constants.ts
@@ -1,0 +1,1 @@
+export const USER_ROLES_CLAIM = "user_roles"

--- a/frontend/src/components/SideBar.js
+++ b/frontend/src/components/SideBar.js
@@ -11,6 +11,7 @@
 import * as React from 'react';
 import { Link, useLocation } from "react-router-dom"
 import { setState, useState, isAdmin} from '../store'
+import { USER_ROLES_CLAIM } from '../auth/constants';
 
 // UI Elements
 import Divider from '@mui/material/Divider';
@@ -25,7 +26,7 @@ import GroupIcon from '@mui/icons-material/Group';
 
 export function SideBarIcons(props) {
   let identity = useState(['identity']);
-  let groups = useState(['identity', 'cognito:groups']) || [];
+  let groups = useState(['identity', USER_ROLES_CLAIM]) || [];
   const drawerOpen = useState(['app', 'sidebar', 'drawerOpen']);
 
   const isGuest = () => {
@@ -73,7 +74,7 @@ export function SideBarIcons(props) {
 
 export default function SideBar(props) {
   let identity = useState(['identity']);
-  let groups = useState(['identity', 'cognito:groups']);
+  let groups = useState(['identity', USER_ROLES_CLAIM]);
   const drawerOpen = useState(['app', 'sidebar', 'drawerOpen']);
 
   const isGuest = () => {

--- a/frontend/src/components/SideBar.js
+++ b/frontend/src/components/SideBar.js
@@ -10,8 +10,7 @@
 // limitations under the License.
 import * as React from 'react';
 import { Link, useLocation } from "react-router-dom"
-import { setState, useState, isAdmin} from '../store'
-import { USER_ROLES_CLAIM } from '../auth/constants';
+import { setState, useState, isGuest, isUser, isAdmin } from '../store'
 
 // UI Elements
 import Divider from '@mui/material/Divider';
@@ -25,18 +24,8 @@ import HomeIcon from '@mui/icons-material/Home';
 import GroupIcon from '@mui/icons-material/Group';
 
 export function SideBarIcons(props) {
-  let identity = useState(['identity']);
-  let groups = useState(['identity', USER_ROLES_CLAIM]) || [];
   const drawerOpen = useState(['app', 'sidebar', 'drawerOpen']);
-
-  const isGuest = () => {
-    return identity && (!groups || ((!groups.includes("admin")) && (!groups.includes("user"))));
-  }
-
-  const isUser = () => {
-    return groups && ((groups.includes("admin")) || (groups.includes("user")));
-  }
-
+  
   const location = useLocation();
   let defaultPage = isGuest() ? "home" : "clusters";
   let section = location && location.pathname && location.pathname.substring(1);
@@ -73,18 +62,7 @@ export function SideBarIcons(props) {
 }
 
 export default function SideBar(props) {
-  let identity = useState(['identity']);
-  let groups = useState(['identity', USER_ROLES_CLAIM]);
   const drawerOpen = useState(['app', 'sidebar', 'drawerOpen']);
-
-  const isGuest = () => {
-    return identity && (!groups || ((!groups.includes("admin")) && (!groups.includes("user"))));
-  }
-
-  const isUser = () => {
-    return groups && ((groups.includes("admin")) || (groups.includes("user")));
-  }
-
   useNotifier();
 
   const location = useLocation();

--- a/frontend/src/model.js
+++ b/frontend/src/model.js
@@ -12,6 +12,7 @@ import axios from 'axios'
 import { store, setState, getState, clearState, updateState, clearAllState } from './store'
 import { enqueueSnackbar as enqueueSnackbarAction } from './redux/snackbar_actions';
 import { closeSnackbar as closeSnackbarAction } from './redux/snackbar_actions';
+import { USER_ROLES_CLAIM } from './auth/constants';
 
 // UI Elements
 import Button from '@mui/material/Button';
@@ -768,7 +769,7 @@ function LoadInitialState() {
   clearAllState();
   GetVersion();
   GetIdentity((identity) => {
-    let groups = identity['cognito:groups'];
+    let groups = identity[USER_ROLES_CLAIM];
     if(groups && (groups.includes("admin") || groups.includes("user")))
     {
       ListUsers();

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -30,10 +30,18 @@ import CssBaseline from '@mui/material/CssBaseline';
 // Components
 import Loading from '../components/Loading'
 
+import { USER_ROLES_CLAIM } from './auth/constants';
+
+
 export default function App() {
   const identity = useState(['identity']);
+<<<<<<< HEAD:frontend/src/pages/index.tsx
   const groups = useState(['identity', 'cognito:groups']);
   
+=======
+  const groups = useState(['identity', USER_ROLES_CLAIM]);
+
+>>>>>>> feat(frontend): remove 'cognito:groups' occurrences in favor of USER_ROLES_CLAIM constant:frontend/src/App.js
   const isGuest = () => {
     return identity && (!groups || ((!groups.includes("admin")) && (!groups.includes("user"))));
   }

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -30,22 +30,12 @@ import CssBaseline from '@mui/material/CssBaseline';
 // Components
 import Loading from '../components/Loading'
 
-import { USER_ROLES_CLAIM } from './auth/constants';
+import { isGuest } from '../store';
 
 
 export default function App() {
   const identity = useState(['identity']);
-<<<<<<< HEAD:frontend/src/pages/index.tsx
-  const groups = useState(['identity', 'cognito:groups']);
-  
-=======
-  const groups = useState(['identity', USER_ROLES_CLAIM]);
 
->>>>>>> feat(frontend): remove 'cognito:groups' occurrences in favor of USER_ROLES_CLAIM constant:frontend/src/App.js
-  const isGuest = () => {
-    return identity && (!groups || ((!groups.includes("admin")) && (!groups.includes("user"))));
-  }
-  
   React.useEffect(() => {
     LoadInitialState();
   }, [])

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -12,6 +12,7 @@ import { createStore, combineReducers } from '@reduxjs/toolkit'
 import { useSelector } from 'react-redux'
 import notifications from './redux/snackbar_reducer'
 import { getIn, swapIn } from './util'
+import { USER_ROLES_CLAIM } from './auth/constants'
 
 // These are identity reducers that allow the names to be at the top level for combining
 function clusters(state = {}, action){ return state }
@@ -143,12 +144,12 @@ function useState(path) {
 }
 
 function isAdmin() {
-  let groups = getState(['identity', 'cognito:groups']) || [];
+  let groups = getState(['identity', USER_ROLES_CLAIM]) || [];
   return groups && groups.includes("admin");
 }
 
 function isUser() {
-  let groups = getState(['identity', 'cognito:groups']) || [];
+  let groups = getState(['identity', USER_ROLES_CLAIM]) || [];
   return groups && ((groups.includes("admin")) || (groups.includes("user")));
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ boto3
 requests
 python-jose
 pyyaml
+pytest


### PR DESCRIPTION
### Notes
#### Context
In the context of implementing a configurable generic OIDC provider in current codebase, we want to get rid of the hardcoded dependencies of `cognito:groups` and introduce a configurable parameter for the name of the user groups claim in the JWT.

#### Solution
This PR aims to be a starting point in the direction of having a configurable OIDC provider in the ParallelCluster Manager. 

On the backend side, a new environment variable `USER_GROUPS_CLAIM` was introduced, with `cognito:groups` as default. On the frontend, the occurrences of `cognito:groups` were removed in favor of a generic `user_groups`, which is set in the `get_identity` function in the backend.

### Out of Scope
* Make the parameter effectively configurable through CloudFormation template. The overall UX setup will be handled in a dedicated story.

### Testing
* Tested frontend locally
* Tested backend deploying lambda through `update.sh` script:

```
{"attributes":{"email":"tsscarla@amazon.com","phone_number":"+10000000000","sub":"6343e9cb-32a3-42aa-92ae-400a1f5181f1"},"auth_time":1657208843,"client_id":"115p8h8vnrhp9sfrcieggbqdcq","event_id":"bee73da5-dfb4-4c31-baa6-1423829414eb","exp":1657295243,"iat":1657208843,"iss":"https://cognito-idp.eu-west-1.amazonaws.com/eu-west-1_nJFByWJpL","jti":"5e3925f6-bc4a-479e-9359-0df170e00ca2","origin_jti":"3db9f5a0-3b4a-4970-b128-019fd0bf18f7","scope":"openid email","sub":"6343e9cb-32a3-42aa-92ae-400a1f5181f1","token_use":"access","user_roles":["user","admin"],"username":"6343e9cb-32a3-42aa-92ae-400a1f5181f1","version":2}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
