### PR TITLE
OIDC parametrization

### DIFF
--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -669,18 +669,24 @@ def login():
     )
 
     access_token = code_resp.json().get("access_token")
+    id_token = code_resp.json().get("id_token")
+    refresh_token = code_resp.json().get("refresh_token")
     if not access_token:
         return redirect(AUTH_URL, code=302)
 
     # give the jwt to the client for future requests
     resp = redirect("/index.html", code=302)
-    resp.set_cookie("accessToken", access_token)
+    resp.set_cookie("accessToken", access_token, httponly=True, secure=True, samesite="lax")
+    resp.set_cookie("idToken", id_token, httponly=True, secure=True, samesite="lax")
+    resp.set_cookie("refreshToken", refresh_token, httponly=True, secure=True, samesite="lax")
     return resp
 
 
 def logout():
     resp = redirect("/login", code=302)
     resp.set_cookie("accessToken", "", expires=0)
+    resp.set_cookie("idToken", "", expires=0)
+    resp.set_cookie("refreshToken", "", expires=0)
     return resp
 
 

--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -678,9 +678,9 @@ def login():
 
     # give the jwt to the client for future requests
     resp = redirect("/index.html", code=302)
-    resp.set_cookie("accessToken", access_token, httponly=True, secure=True, samesite="lax")
-    resp.set_cookie("idToken", id_token, httponly=True, secure=True, samesite="lax")
-    resp.set_cookie("refreshToken", refresh_token, httponly=True, secure=True, samesite="lax")
+    resp.set_cookie("accessToken", access_token, httponly=True, secure=True, samesite="Lax")
+    resp.set_cookie("idToken", id_token, httponly=True, secure=True, samesite="Lax")
+    resp.set_cookie("refreshToken", refresh_token, httponly=True, secure=True, samesite="Lax")
     return resp
 
 

--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -45,9 +45,8 @@ try:
 except Exception:
     pass
 
+
 # Helpers
-
-
 def running_local():
     return not os.getenv("AWS_LAMBDA_FUNCTION_NAME")
 
@@ -525,7 +524,8 @@ def get_instance_types():
         ec2 = boto3.client("ec2")
     filters = [
         {"Name": "current-generation", "Values": ["true"]},
-        {"Name": "instance-type", "Values": ["c5*", "c6*", "g4*", "g5*", "hpc*", "p3*", "p4*", "t2*", "t3*", "m6*", "r*"]},
+        {"Name": "instance-type",
+         "Values": ["c5*", "c6*", "g4*", "g5*", "hpc*", "p3*", "p4*", "t2*", "t3*", "m6*", "r*"]},
     ]
     instance_paginator = ec2.get_paginator("describe_instance_types")
     instances_paginator = instance_paginator.paginate(Filters=filters)

--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -499,7 +499,8 @@ def get_aws_config():
 
     fsx_volumes = []
     try:
-        fsx_volumes = list(filter(lambda vol: (vol["Lifecycle"] == "CREATED" or vol["Lifecycle"] == "AVAILABLE"), fsx.describe_volumes()["Volumes"]))
+        fsx_volumes = list(filter(lambda vol: (vol["Lifecycle"] == "CREATED" or vol["Lifecycle"] == "AVAILABLE"),
+                                  fsx.describe_volumes()["Volumes"]))
     except:
         pass
 
@@ -554,9 +555,7 @@ def get_instance_types():
 
 
 def _get_user_roles(decoded):
-    print(os.environ.get("USER_ROLES_CLAIM"))
     return decoded[USER_ROLES_CLAIM] if USER_ROLES_CLAIM in decoded else ["user"]
-
 
 
 def get_identity():

--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -575,9 +575,7 @@ def get_identity():
         decoded.pop(USER_ROLES_CLAIM)
 
         decoded_id = jwt_decode(id_token, audience=AUDIENCE, access_token=access_token)
-        username = decoded.get("username")
-        if username:
-            decoded["attributes"] = {key: value for key, value in decoded_id.items()}
+        decoded["attributes"] = {key: value for key, value in decoded_id.items()}
     except jwt.ExpiredSignatureError:
         return {"message": "Signature expired."}, 401
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,0 +1,26 @@
+import pytest
+from app import run
+
+
+@pytest.fixture()
+def app():
+    app = run()
+    app.config.update({
+        "TESTING": True,
+    })
+
+    # other setup can go here
+
+    yield app
+
+    # clean up / reset resources here
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture()
+def runner(app):
+    return app.test_cli_runner()

--- a/api/tests/test_pcluster_api_handler.py
+++ b/api/tests/test_pcluster_api_handler.py
@@ -11,7 +11,6 @@ def test_user_roles():
     _test_decoded_without_user_roles_claim(decoded={})
 
 
-
 def _test_decoded_with_user_roles_claim(decoded, user_roles):
     assert _get_user_roles(decoded) == user_roles
 

--- a/api/tests/test_pcluster_api_handler.py
+++ b/api/tests/test_pcluster_api_handler.py
@@ -1,4 +1,3 @@
-import pytest
 from unittest import mock
 from api.PclusterApiHandler import _get_user_roles
 
@@ -17,3 +16,19 @@ def _test_decoded_with_user_roles_claim(decoded, user_roles):
 
 def _test_decoded_without_user_roles_claim(decoded):
     assert _get_user_roles(decoded) == ["user"]
+
+
+@mock.patch("api.PclusterApiHandler.requests.post")
+def test_on_successful_login_auth_cookies_are_set(mock_post, client):
+    with client as flaskClient:
+        response_dict = {
+            "access_token": "testAccessToken",
+            "id_token": "testIdToken",
+            "refresh_token": "testRefreshToken"
+        }
+        mock_post.return_value.json.return_value = response_dict
+        resp = flaskClient.get("/login", query_string="code=testCode")
+        cookie_list = resp.headers.getlist('Set-Cookie')
+        assert "accessToken=testAccessToken; Secure; HttpOnly; Path=/; SameSite=Lax" in cookie_list
+        assert "idToken=testIdToken; Secure; HttpOnly; Path=/; SameSite=Lax" in cookie_list
+        assert "refreshToken=testRefreshToken; Secure; HttpOnly; Path=/; SameSite=Lax" in cookie_list

--- a/infrastructure/pcluster-manager-cognito.yaml
+++ b/infrastructure/pcluster-manager-cognito.yaml
@@ -259,6 +259,10 @@ Resources:
 
 Outputs:
 
+  AppClientId:
+    Description: The id of the Cognito app client
+    Value: !Ref CognitoAppClient
+
   UserPoolAuthPrefix:
     Description: The prefix of the domain of the authorization server.
     Value: !Ref UserPoolDomain

--- a/infrastructure/pcluster-manager.yaml
+++ b/infrastructure/pcluster-manager.yaml
@@ -137,6 +137,7 @@ Resources:
            - Api: !Ref ApiGateway
           AUTH_PATH: !GetAtt [ PclusterManagerCognito, Outputs.UserPoolAuthDomain ]
           SECRET_ID: !GetAtt [ PclusterManagerCognito, Outputs.UserPoolClientSecretName ]
+          AUDIENCE: !GetAtt [ PclusterManagerCognito, Outputs.AppClientId ]
           ENABLE_AUTH: !Ref EnableAuth
           ENABLE_MFA: !Ref EnableMFA
       FunctionName: !Sub

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .


### PR DESCRIPTION
**Description of changes:**

This PR aims to parametrize the values needed for OIDC auth. Decoupling it from Cognito.
The goal is to have everything working as before, but being able to support another Auth provider _in the future_ more easily.
The defaults are meant to make the code work as it was before this change.

This PR depends on https://github.com/aws-samples/pcluster-manager/pull/172 and should be merged after that. (Done, rebased after that)

We decided to add `openid` as default in the `scopes`, as that should be the bare minimum to make the system work, in fact, without that, we would not be able to get the `idToken`.
The data that were taken by Cognito CLI before are taken by the `idToken` at the moment. We are putting all the data in the `idToken` in the `attributes` section at the moment, a more fine choice can be made in the future.

Cookies are now secure/httpOnly/sameSite to adhere to best practices.

The `AUDIENCE` environment variable was added as it was mandatory to decode the `idToken`

The fixture was added following FLASK docs on https://flask.palletsprojects.com/en/2.1.x/testing/

**Testing**

Change was implemented testing locally. Then I deployed the new lambda and the new CF stacks manually to confirm everything was working also remotely.

After doing the changes requested by reviewers, I tested only remotely updating the Lambda.

Run `pytest` before submitting the PR to verify test were passing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
