### PR TITLE
Adr adoption

### DIFF
--- a/.log4brains.yml
+++ b/.log4brains.yml
@@ -1,0 +1,5 @@
+project:
+  name: ParallelCluster Manager (PCM)
+  tz: Europe/Rome
+  adrFolder: ./decisions
+  packages: []

--- a/decisions/20220708-use-log4brains-to-manage-the-adrs.md
+++ b/decisions/20220708-use-log4brains-to-manage-the-adrs.md
@@ -1,0 +1,22 @@
+# Use Log4brains to manage the ADRs
+
+- Status: accepted
+- Date: 2022-07-07
+- Tags: dev-tools, doc
+
+## Context and Problem Statement
+
+We want to record architectural decisions made in this project.
+Which tool(s) should we use to manage these records?
+
+## Considered Options
+
+- [Log4brains](https://github.com/thomvaill/log4brains): architecture knowledge base (command-line + static site generator)
+- [ADR Tools](https://github.com/npryce/adr-tools): command-line to create ADRs
+- [ADR Tools Python](https://bitbucket.org/tinkerer_/adr-tools-python/src/master/): command-line to create ADRs
+- [adr-viewer](https://github.com/mrwilson/adr-viewer): static site generator
+- [adr-log](https://adr.github.io/adr-log/): command-line to create a TOC of ADRs
+
+## Decision Outcome
+
+Chosen option: "Log4brains", because it includes the features of all the other tools, and even more.

--- a/decisions/20220708-use-michael-nygard-format-for-adr.md
+++ b/decisions/20220708-use-michael-nygard-format-for-adr.md
@@ -1,0 +1,19 @@
+# Use Michael Nygard format for ADR
+
+- Status: accepted
+- Deciders: [list everyone involved in the decision] <!-- optional -->
+- Date: [YYYY-MM-DD when the decision was last updated] <!-- optional. To customize the ordering without relying on last edit dates -->
+- Tags: adr, general
+
+## Context
+Adopting a format for ADR which is too verbose might prevent people from writing them, as they might consider the activity too time consuming.
+
+## Decision
+We decided to adopt the format proposed by Michael Nygard, as it is brief enough to be written rapidly and conveys enough information for making the adoption of ADR valuable.
+
+## Consequences
+- People might be more keen to write ADRs as the format is simpler
+- We might risk to loose the driver for some decisions and the options evaluated
+
+## Links <!-- optional -->
+- [ADR template by Michael Nygard in Markdown](https://github.com/joelparkerhenderson/architecture-decision-record/blob/main/templates/decision-record-template-by-michael-nygard/index.md)

--- a/decisions/20220708-use-michael-nygard-format-for-adr.md
+++ b/decisions/20220708-use-michael-nygard-format-for-adr.md
@@ -1,9 +1,7 @@
 # Use Michael Nygard format for ADR
 
 - Status: accepted
-- Deciders: [list everyone involved in the decision] <!-- optional -->
-- Date: [YYYY-MM-DD when the decision was last updated] <!-- optional. To customize the ordering without relying on last edit dates -->
-- Tags: adr, general
+- Tags: dev-tools, doc
 
 ## Context
 Adopting a format for ADR which is too verbose might prevent people from writing them, as they might consider the activity too time consuming.

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -1,0 +1,29 @@
+# Architecture Decision Records
+
+## Development
+
+If not already done, install Log4brains:
+
+```bash
+npm install -g log4brains
+```
+
+To preview the knowledge base locally, run:
+
+```bash
+log4brains preview
+```
+
+In preview mode, the Hot Reload feature is enabled: any change you make to a markdown file is applied live in the UI.
+
+To create a new ADR interactively, run:
+
+```bash
+log4brains adr new
+```
+
+## More information
+
+- [Log4brains documentation](https://github.com/thomvaill/log4brains/tree/master#readme)
+- [What is an ADR and why should you use them](https://github.com/thomvaill/log4brains/tree/master#-what-is-an-adr-and-why-should-you-use-them)
+- [ADR GitHub organization](https://adr.github.io/)

--- a/decisions/index.md
+++ b/decisions/index.md
@@ -1,0 +1,36 @@
+<!-- This file is the homepage of your Log4brains knowledge base. You are free to edit it as you want -->
+
+# Architecture knowledge base
+
+Welcome 👋 to the architecture knowledge base of ParallelCluster Manager (PCM).
+You will find here all the Architecture Decision Records (ADR) of the project.
+
+## Definition and purpose
+
+> An Architectural Decision (AD) is a software design choice that addresses a functional or non-functional requirement that is architecturally significant.
+> An Architectural Decision Record (ADR) captures a single AD, such as often done when writing personal notes or meeting minutes; the collection of ADRs created and maintained in a project constitutes its decision log.
+
+An ADR is immutable: only its status can change (i.e., become deprecated or superseded). That way, you can become familiar with the whole project history just by reading its decision log in chronological order.
+Moreover, maintaining this documentation aims at:
+
+- 🚀 Improving and speeding up the onboarding of a new team member
+- 🔭 Avoiding blind acceptance/reversal of a past decision (cf [Michael Nygard's famous article on ADRs](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions.html))
+- 🤝 Formalizing the decision process of the team
+
+## Usage
+
+This website is automatically updated after a change on the `master` branch of the project's Git repository.
+In fact, the developers manage this documentation directly with markdown files located next to their code, so it is more convenient for them to keep it up-to-date.
+You can browse the ADRs by using the left menu or the search bar.
+
+The typical workflow of an ADR is the following:
+
+![ADR workflow](/l4b-static/adr-workflow.png)
+
+The decision process is entirely collaborative and backed by pull requests.
+
+## More information
+
+- [Log4brains documentation](https://github.com/thomvaill/log4brains/tree/master#readme)
+- [What is an ADR and why should you use them](https://github.com/thomvaill/log4brains/tree/master#-what-is-an-adr-and-why-should-you-use-them)
+- [ADR GitHub organization](https://adr.github.io/)

--- a/decisions/template.md
+++ b/decisions/template.md
@@ -1,0 +1,19 @@
+# [short title of solved problem and solution]
+
+- Status: [draft | proposed | rejected | accepted | deprecated | … | superseded by [xxx](yyyymmdd-xxx.md)] <!-- optional -->
+- Deciders: [list everyone involved in the decision] <!-- optional -->
+- Date: [YYYY-MM-DD when the decision was last updated] <!-- optional. To customize the ordering without relying on last edit dates -->
+- Tags: [space and/or comma separated list of tags] <!-- optional -->
+
+## Context
+What is the issue that we're seeing that is motivating this decision or change?
+
+## Decision
+What is the change that we're proposing and/or doing?
+
+## Consequences
+What becomes easier or more difficult to do because of this change?
+
+## Links <!-- optional -->
+- [Link type](link to adr) <!-- example: Refined by [xxx](yyyymmdd-xxx.md) -->
+- … <!-- numbers of links can vary -->


### PR DESCRIPTION
## Description of changes

This PR aims at introducing [ADRs](https://adr.github.io/) within the project. The goal is to document any architectural or meaningful decision we might make during the development, so that we can keep track of our decisions and the drivers that generated them.
In order to do that we decided to adopt [Log4brains](https://github.com/thomvaill/log4brains/tree/master#readme) as a tool for managing and writing our ADRs.

Please note that in order to use the tool for creating ADR you will need to install it globally, by doing:

```bash
npm install -g log4brains
```

Refer to the [Getting Started](https://github.com/thomvaill/log4brains/tree/master#-getting-started) section of the official Log4Brains repository for further information.

## Testing
- Launched the preview with the `log4brains preview` command and saw the current ADR.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.