### PR TITLE
Cluster Templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ infrastructure/cognitolambda/node_modules
 .DS_Store
 .hugo_build.lock
 public/*
+package.json
+package-lock.json

--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -204,6 +204,15 @@ def get_cluster_config_text(cluster_name, region=None):
 def get_cluster_config():
     return get_cluster_config_text(request.args.get("cluster_name"), request.args.get("region"))
 
+def get_cluster_template():
+    try:
+        template_path = request.args.get("template_path")
+        url = f"https://raw.githubusercontent.com/aws-samples/pcluster-manager/main/{template_path}"
+        with requests.get(url) as f:
+            template = f.content
+            return template
+    except Exception as e:
+        return {"message": str(e)}, 500
 
 def ssm_command(region, instance_id, user, run_command):
     # working_directory |= f"/home/{user}"

--- a/app.py
+++ b/app.py
@@ -27,6 +27,7 @@ from api.PclusterApiHandler import (
     ec2_action,
     get_aws_config,
     get_cluster_config,
+    get_cluster_template,
     get_custom_image_config,
     get_dcv_session,
     get_identity,
@@ -93,6 +94,11 @@ def run():
     @authenticated()
     def get_cluster_config_():
         return get_cluster_config()
+
+    @app.route("/manager/get_cluster_template")
+    @authenticated()
+    def get_cluster_template_():
+        return get_cluster_template()
 
     @app.route("/manager/get_custom_image_configuration")
     @authenticated()

--- a/frontend/src/model.js
+++ b/frontend/src/model.js
@@ -175,6 +175,20 @@ function GetConfiguration(clusterName, callback=null) {
   })
 }
 
+function GetClusterTemplate(clusterTemplatePath, callback=null) {
+  request('get', `manager/get_cluster_template?template_path=${clusterTemplatePath}`).then(response => {
+    console.log("Configuration Success", response)
+    if(response.status === 200) {
+      setState(['clusters', 'index', clusterTemplatePath, 'configuration'], response.data);
+      callback && callback(response.data)
+    }
+  }).catch(error => {
+    if(error.response)
+      notify(`Error (${clusterTemplatePath}): ${error.response.data.message}`, 'error');
+    console.log(error)
+  })
+}
+
 function UpdateComputeFleet(clusterName, fleetStatus) {
   request('patch', `api?path=/v3/clusters/${clusterName}/computefleet`,
     {"status": fleetStatus}
@@ -778,4 +792,4 @@ export {CreateCluster, UpdateCluster, ListClusters, DescribeCluster,
   GetCustomImageLogEvents, ListOfficialImages, LoadInitialState,
   Ec2Action,LoadAwsConfig, GetDcvSession, QueueStatus, CancelJob, SubmitJob,
   PriceEstimate, SlurmAccounting, JobInfo, ListUsers, SetUserRole, notify,
-  CreateUser, DeleteUser}
+  CreateUser, DeleteUser, GetClusterTemplate}

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -1,0 +1,23 @@
+HeadNode:
+  InstanceType: t2.micro
+  Ssh:
+    KeyName: keypair
+  Networking:
+    SubnetId: subnet-12345678
+  Iam:
+    AdditionalIamPolicies:
+      - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue0
+      ComputeResources:
+        - Name: queue0-t2-micro
+          MinCount: 0
+          MaxCount: 4
+          InstanceType: t2.micro
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+Image:
+  Os: alinux2

--- a/templates/weather.yaml
+++ b/templates/weather.yaml
@@ -1,0 +1,46 @@
+HeadNode:
+  InstanceType: c5a.2xlarge
+  Ssh:
+    KeyName: your-key
+  Networking:
+    SubnetId: subnet-1234567
+  LocalStorage:
+    RootVolume:
+      Size: 40
+  Iam:
+    AdditionalIamPolicies:
+      - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+      - Policy: arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
+  Dcv:
+    Enabled: true
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: compute
+      ComputeResources:
+        - Name: hpc6a
+          MinCount: 0
+          MaxCount: 64
+          InstanceType: hpc6a.48xlarge
+          Efa:
+            Enabled: true
+      Networking:
+        SubnetIds:
+          - subnet-1234567
+        PlacementGroup:
+          Enabled: true
+      Iam:
+        AdditionalIamPolicies:
+          - Policy: arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
+Region: us-east-2
+Image:
+  Os: alinux2
+SharedStorage:
+  - Name: FsxLustre0
+    StorageType: FsxLustre
+    MountDir: /shared
+    FsxLustreSettings:
+      StorageCapacity: 1200
+      DeploymentType: PERSISTENT_1
+      PerUnitStorageThroughput: 200
+      DataCompressionType: LZ4


### PR DESCRIPTION
## Description

* Pre-Defined Cluster templates for common applications
* All templates are hosted in `/templates` directory on Github

## Demo

https://user-images.githubusercontent.com/5545980/178086496-5946f18d-d99d-4f3f-96a9-263c76815dbc.mov

## Testing

Change the path of the Github URL in [api/PclusterApiHandler.py#210](https://github.com/aws-samples/pcluster-manager/pull/179/files#diff-5424a9a7f7cf5ddc8d3e420f077ac509a3b37f81c8cbf7c9bac5f8695fc9a8e2)

**from**
```bash
https://raw.githubusercontent.com/aws-samples/pcluster-manager/main/{template_path}
```

**to**
```bash
https://raw.githubusercontent.com/sean-smith/pcluster-manager/template/{template_path}
```

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
