### PR TITLE
Change flask development port to fix ControlCenter issue

### DIFF
--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -32,7 +32,7 @@ function notify(text: any, type = 'info', duration = 5000, dismissButton = false
 
 function getHost() {
   if (process.env.NODE_ENV !== 'production')
-    return 'http://127.0.0.1:5000/';
+    return 'http://127.0.0.1:5001/';
   return '/';
 }
 

--- a/scripts/run_flask.sh
+++ b/scripts/run_flask.sh
@@ -1,1 +1,1 @@
-FLASK_APP=app:run flask run
+FLASK_RUN_PORT=5001 FLASK_APP=app:run flask run


### PR DESCRIPTION
## Description

Due to some CORS issues we found that Flask was listening on the same port used by Control Center on OSX ([thread here](https://developer.apple.com/forums/thread/682332)). The proposal is to switch to another port (5001) to fix this behavior.

## Changes

Flask port changed to 5001 for development.

## How Has This Been Tested?

Spawned both frontend and backend and verified proper communication between the two.

## References

[Apple forum thread](https://developer.apple.com/forums/thread/682332)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.