### PR TITLE
Make wizard compliant with limits for external storage attachments

### DIFF
--- a/frontend/src/__tests__/storagCreationValidation.test.tsx
+++ b/frontend/src/__tests__/storagCreationValidation.test.tsx
@@ -1,0 +1,87 @@
+import { canCreateStorage, canAttachExistingStorage } from "../old-pages/Configure/Storage";
+
+
+describe("Given a function to determine whether we can create a storage of a given type", () => {
+    describe("when the storage type is not available", () => {
+        it("should not allow the creation of a new storage", () => {
+            expect(canCreateStorage(null, [], {})).toBeFalsy();
+        });
+    });
+    describe("when the storage type does not support creation", () => {
+        it("should not allow the creation of a new storage", () => {
+            expect(canCreateStorage("FsxOntap", [], {})).toBeFalsy();
+        });
+    });
+    describe("when the attached storages are not available", () => {
+        it("should allow the creation of a new storage", () => {
+            expect(canCreateStorage("Efs", null, {})).toBeTruthy();
+        });
+    });
+    describe("when the ui storages details are not available", () => {
+        it("should allow the creation of a new storage", () => {
+            expect(canCreateStorage("Efs", [], null)).toBeTruthy();
+        });
+    });
+    describe("when we have exceeded the amount of storage of a given type we can create", () => {
+        it("should not allow the creation of a new storage", () => {
+            expect(
+                canCreateStorage(
+                    "FsxLustre",
+                    Array(20).fill({ "StorageType": "FsxLustre" }),
+                    [...Array(20).keys()].reduce((accumulator, number) => {
+                        accumulator[number] = { "useExisting": false };
+                        return accumulator
+                    }, {})
+                )
+            ).toBeFalsy();
+        });
+    });
+    describe("when we have not exceeded the amount of storage of a given type we can create", () => {
+        it("should allow the creation of a new storage", () => {
+            expect(canCreateStorage("FsxLustre", [{ "storageType": "FsxLustre" }], { 0: { "useExisting": true } })).toBeTruthy();
+        });
+    });
+});
+
+
+describe("Given a function to determine whether we can attach an existing storage of a given type", () => {
+    describe("when the storage type is not available", () => {
+        it("should not allow the attachment of an existing storage", () => {
+            expect(canAttachExistingStorage(null, [], {})).toBeFalsy();
+        });
+    });
+    describe("when the storage type is not available", () => {
+        it("should not allow the attachment of an existing storage", () => {
+		expect(canAttachExistingStorage(null, [], {})).toBeFalsy();
+        });
+    });
+    describe("when the attached storages are not available", () => {
+        it("should allow the attachment of an existing storage", () => {
+            expect(canAttachExistingStorage("Efs", null, {})).toBeTruthy();
+        });
+    });
+    describe("when the ui storages details are not available", () => {
+        it("should allow the attachment of an existing storage", () => {
+            expect(canAttachExistingStorage("Efs", [], null)).toBeTruthy();
+        });
+    });
+    describe("when we have exceeded the amount of existing storage of a given type we can attach", () => {
+        it("should not allow the attachment of an existing storage", () => {
+            expect(
+                canAttachExistingStorage(
+                    "FsxLustre",
+                    Array(20).fill({ "StorageType": "FsxLustre" }),
+                    [...Array(20).keys()].reduce((accumulator, number) => {
+                        accumulator[number] = { "useExisting": true };
+                        return accumulator
+                    }, {})
+                )
+            ).toBeFalsy();
+        });
+    });
+    describe("when we have not exceeded the amount of existing storage of a given type we can attach", () => {
+        it("should allow the attachment of an existing storage", () => {
+            expect(canAttachExistingStorage("FsxLustre", [{ "storageType": "FsxLustre" }], { 0: { "useExisting": true } })).toBeTruthy();
+        });
+    });
+});


### PR DESCRIPTION
### Notes
This patch makes the wizard compliant with the limits for external
storage attachments.

When creating a new storage, we check that we are not violating the
constraint of the maximum number of storage of that given type we can
attach. The toggle that allows to switch between creation and attachment
of an existing storage is disabled according to the constraints of the
maximum number of storage that can be created or of existing storage that
can be attached.

### Tests
- Unit tests.
- Manual tests:
  - Attached Efs storage (creation).
  - Attached 20 Efs storages (existing), verifying that the toggle is automatically set to "use existing" and disabled (greyed out).
  - When the 20th existing Efs storage is attached, the toggle of the Efs storage to create is also disabled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.