### PR TITLE
Realign PC API template reflecting aws-parallelcluster changes

### DIFF
--- a/infrastructure/parallelcluster-api.yaml
+++ b/infrastructure/parallelcluster-api.yaml
@@ -612,6 +612,7 @@ Resources:
                   - s3.data-source.lustre.fsx.amazonaws.com
           - Action:
               - lambda:CreateFunction
+              - lambda:TagResource
               - lambda:DeleteFunction
               - lambda:GetFunctionConfiguration
               - lambda:GetFunction
@@ -619,6 +620,8 @@ Resources:
               - lambda:AddPermission
               - lambda:RemovePermission
               - lambda:UpdateFunctionConfiguration
+              - lambda:ListTags
+              - lambda:UntagResource
             Resource:
               - !Sub arn:${AWS::Partition}:lambda:${Region}:${AWS::AccountId}:function:parallelcluster-*
               - !Sub arn:${AWS::Partition}:lambda:${Region}:${AWS::AccountId}:function:pcluster-*
@@ -735,6 +738,7 @@ Resources:
             Effect: Allow
             Action:
               - lambda:CreateFunction
+              - lambda:TagResource
               - lambda:GetFunction
               - lambda:AddPermission
             Resource:
@@ -960,6 +964,17 @@ Resources:
       ManagedPolicyArns:
         - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
         - !Sub arn:${AWS::Partition}:iam::aws:policy/EC2InstanceProfileForImageBuilderECRContainerBuilds
+      Policies:
+        - PolicyName: ImageBuilderCustomPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: ecs:RegisterContainerInstance
+                Resource: !Sub arn:${AWS::Partition}:ecs:*:${AWS::AccountId}:cluster/*
+              - Effect: Allow
+                Action: ecs:DiscoverPollEndpoint
+                Resource: "*"
       AssumeRolePolicyDocument:
         Statement:
           - Action:
@@ -1259,7 +1274,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - imagebuilder:ListImagePipelineImages
-                Resource: !Ref EcrImagePipeline
+                Resource: !Sub
+                  - arn:${AWS::Partition}:imagebuilder:${Region}:${AWS::AccountId}:image-pipeline/ecrimagepipeline-*${StackIdSuffix}*
+                  - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
               - Effect: Allow
                 Action:
                   - imagebuilder:DeleteImage


### PR DESCRIPTION
### Notes

This patch realigns the PC API template, reflecting the changes in:

https://github.com/aws/aws-parallelcluster/blob/develop/api/infrastructure/parallelcluster-api.yaml

among those, the missing policies that were added in:

https://github.com/aws/aws-parallelcluster/pull/4194

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.