### PR TITLE
Add possibility to enable authentication in local development

### DIFF
--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -145,7 +145,7 @@ def authenticate(group):
         return auth_redirect()
     except jose.exceptions.JWSSignatureError:
         return logout()
-    if not disable_auth() and (group != "guest") and (group not in set(decoded.get(USER_ROLES_CLAIM, []))):
+    if (group != "guest") and (group not in set(decoded.get(USER_ROLES_CLAIM, []))):
         return auth_redirect()
 
 
@@ -571,9 +571,6 @@ def get_identity():
         decoded["attributes"] = {key: value for key, value in decoded_id.items()}
     except jwt.ExpiredSignatureError:
         return {"message": "Signature expired."}, 401
-
-    if disable_auth():
-        decoded["user_roles"] = ["user", "admin"]
 
     return decoded
 

--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -23,6 +23,8 @@ from flask import abort, redirect, request
 from flask_restful import Resource, reqparse
 from jose import jwt
 
+from api.utils import disable_auth
+
 USER_POOL_ID = os.getenv("USER_POOL_ID")
 AUTH_PATH = os.getenv("AUTH_PATH")
 API_BASE_URL = os.getenv("API_BASE_URL")
@@ -63,15 +65,6 @@ if not JWKS_URL:
 AUTH_URL_WITH_PARAMS = f"{AUTH_URL}?response_type=code&client_id={CLIENT_ID}" \
                        f"&scope={SCOPES_LIST}" \
                        f"&redirect_uri={REDIRECT_URL} "
-
-
-# Helpers
-def running_local():
-    return not os.getenv("AWS_LAMBDA_FUNCTION_NAME")
-
-
-def disable_auth():
-    return os.getenv("ENABLE_AUTH") == "false"
 
 
 def jwt_decode(token, audience=None, access_token=None):
@@ -140,7 +133,7 @@ def auth_redirect():
 
 
 def authenticate(group):
-    if running_local():
+    if disable_auth():
         return
 
     access_token = request.cookies.get("accessToken")
@@ -562,7 +555,7 @@ def _get_user_roles(decoded):
 
 
 def get_identity():
-    if running_local():
+    if disable_auth():
         return {"user_roles": ["user", "admin"], "username": "username", "attributes": {"email": "user@domain.com"}}
 
     access_token = request.cookies.get("accessToken")

--- a/api/tests/test_authenticate.py
+++ b/api/tests/test_authenticate.py
@@ -1,0 +1,13 @@
+import os
+from unittest import mock
+from api.PclusterApiHandler import authenticate
+
+
+@mock.patch.dict(os.environ,{"ENABLE_AUTH": "false"})
+def test_authenticate():
+    """
+    Given an authentication middleware
+      When authentication is disabled
+        Then it should do nothing
+    """
+    assert authenticate('any-group') is None

--- a/api/tests/test_get_identity.py
+++ b/api/tests/test_get_identity.py
@@ -1,0 +1,15 @@
+import os
+from unittest import mock
+from api.PclusterApiHandler import get_identity
+
+
+MOCK_IDENTITY_OBJECT = {"user_roles": ["user", "admin"], "username": "username", "attributes": {"email": "user@domain.com"}}
+
+@mock.patch.dict(os.environ,{"ENABLE_AUTH": "false"})
+def test_get_identity():
+    """
+    Given an handler for the /get-identity endpoint
+      When authentication is disabled
+        Then it should return a static identity object
+    """
+    assert get_identity() == MOCK_IDENTITY_OBJECT

--- a/api/utils.py
+++ b/api/utils.py
@@ -51,3 +51,9 @@ def to_iso_timestr(time_in: datetime.datetime) -> str:
     else:
         time_ = time_in.astimezone(datetime.timezone.utc)
     return to_utc_datetime(time_).isoformat(timespec="milliseconds")[:-6] + "Z"
+
+def running_local():
+    return os.getenv("ENV") == "dev"
+
+def disable_auth():
+    return os.getenv("ENABLE_AUTH") == "false"

--- a/api/utils.py
+++ b/api/utils.py
@@ -9,8 +9,11 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 import datetime
+import os
 
 import dateutil
+from flask import Flask, Response, request, send_from_directory
+import requests
 
 
 def to_utc_datetime(time_in, default_timezone=datetime.timezone.utc) -> datetime.datetime:
@@ -57,3 +60,32 @@ def running_local():
 
 def disable_auth():
     return os.getenv("ENABLE_AUTH") == "false"
+
+def proxy_to(to_url):
+  """
+  Proxies Flask requests to the provided to_url
+  """
+  resp = requests.request(
+        method=request.method,
+        url=to_url,
+        headers={key: value for (key, value) in request.headers if key != 'Host'},
+        data=request.get_data(),
+        cookies=request.cookies,
+        allow_redirects=False)
+  excluded_headers = ['content-encoding', 'content-length', 'transfer-encoding', 'connection']
+  headers = [(name, value) for (name, value) in resp.raw.headers.items()
+              if name.lower() not in excluded_headers]
+  response = Response(resp.content, resp.status_code, headers)
+  return response
+
+def build_flask_app(name):
+  if running_local():
+    return Flask(name)
+
+  return Flask(name, static_url_path="", static_folder="frontend/public")
+
+def serve_frontend(app, path):
+  if running_local():
+    return proxy_to("http://localhost:3000/" + path)
+
+  return send_from_directory(app.static_folder, "index.html")

--- a/app.py
+++ b/app.py
@@ -62,7 +62,7 @@ class PClusterJSONEncoder(JSONEncoder):
 
 
 def run():
-    app = Flask(__name__, static_url_path="", static_folder="frontend/public")
+    app = utils.build_flask_app(__name__)
     app.json_encoder = PClusterJSONEncoder
     app.url_map.converters["regex"] = RegexConverter
     CORS(app)  # comment this on deployment
@@ -80,9 +80,10 @@ def run():
         )
 
     @app.route("/", defaults={"path": ""})
+    @app.route('/<path:path>')
     @authenticated()
     def serve(path):
-        return send_from_directory(app.static_folder, "index.html")
+        return utils.serve_frontend(app, path)
 
     @app.route("/manager/ec2_action", methods=["POST"])
     @authenticated()
@@ -180,21 +181,6 @@ def run():
     @app.route("/logout")
     def logout_():
         return logout()
-
-    @app.route(
-        '/<regex("(home|clusters|users|configure|custom-images|official-images).*"):base>', defaults={"base": ""}
-    )
-    @authenticated()
-    def catch_all(base):
-        return send_from_directory(app.static_folder, "index.html")
-
-    @app.route(
-        '/<regex("(home|clusters|users|configure|custom-images|official-images).*"):base>/<path:u_path>',
-        defaults={"base": "", "u_path": ""},
-    )
-    @authenticated()
-    def catch_all2(base, u_path):
-        return send_from_directory(app.static_folder, "index.html")
 
     api.add_resource(PclusterApiHandler, "/api")
     return app

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -32,7 +32,7 @@ function notify(text: any, type = 'info', duration = 5000, dismissButton = false
 
 function getHost() {
   if (process.env.NODE_ENV !== 'production')
-    return 'http://127.0.0.1:5001/';
+    return 'http://localhost:5001/';
   return '/';
 }
 


### PR DESCRIPTION
## Description

This PR adds the possibility to enable authentication in local development, with the following limitations:

- you'd need to add `http://localhost:5001` to the allowed redirect_uri in your Cognito settings
- you'd need the `ENV`, `SECRET_ID`, `SITE_URL` and `AUDIENCE` environment variables set
- you'd need to browse PCM at `http://localhost:5001` instead of `http://localhost:3000`
- HMR is currently broken when working on `http://localhost:5001`, but you can still fallback to your regular workflow by connecting to `http://localhost:3000` setting the `ENABLE_AUTH` environment variable to `false`

## Changes

- Use `disable_auth` to detect whether to allow authentication or not, regardless of environment
- When `ENV` is set to `dev`, the frontend is served via proxy from NextJs at `http://localhost:3000`

## How Has This Been Tested?

- Tested cluster creation with real authentication on `http://localhost:5001`
- Tested cluster creation with authentication disabled on `http://localhost:3000`
- Pytest

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.