### PR TITLE
Add schedulable memory parameter in the queue section of the Wizard

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -5,11 +5,61 @@
     }
   },
   "wizard": {
-     "headNode": {
-       "memoryBasedSchedulingEnabled": {
-         "label": "Slurm Memory Based Scheduling Enabled",
-         "help": "If enabled, users may use <i>--mem</i> to specify the amount of memory per node required by a job. For more information, see the <0>Slurm documentation for ConstrainRAMSpace</0>"
-       }
+    "headNode": {
+      "memoryBasedSchedulingEnabled": {
+        "label": "Slurm Memory Based Scheduling Enabled",
+        "help": "If enabled, users may use <i>--mem</i> to specify the amount of memory per node required by a job. For more information, see the <0>Slurm documentation for ConstrainRAMSpace</0>"
+     }
+   },
+    "queues": {
+      "schedulableMemory": {
+        "name": "Schedulable Memory (MiB)",
+        "description": "Amount of memory in MiB to be made available to jobs on the compute nodes of the compute resource",
+        "placeholder": "Leave empty for default",
+        "help": "The default value is 95 % of the memory advertised by EC2."
+      }
+   },
+    "multiuser": {
+      "domainName": {
+        "name": "Domain Name*",
+        "description": "The Active Directory (AD) domain that you use for identity information.",
+        "help": "This property corresponds to the sssd-ldap parameter that's called ldap_search_base."
+      },
+      "domainAddress": {
+        "name": "Domain Address*",
+        "description": "The URI or URIs that point to the AD domain controller that's used as the LDAP server.",
+        "help": "The URI corresponds to the sssd-ldap parameter that's called ldap_uri. The value can be a comma separated string of URIs. To use LDAP, you must add ldap:// to the beginning of the each URI."
+      },
+      "passwordSecretArn" : {
+        "name": "Password Secret ARN*",
+        "description": "The URI or URIs that point to the AD domain controller that's used as the LDAP server.",
+        "help": "The URI corresponds to the sssd-ldap parameter that's called ldap_uri. The value can be a comma separated string of URIs. To use LDAP, you must add ldap:// to the beginning of the each URI."
+      },
+      "domainReadOnlyUser": {
+        "name": "Domain Read Only User*",
+        "description": "The identity that's used to query the AD domain for identity information when authenticating cluster user logins.",
+        "help": "It corresponds to sssd-ldap parameter that's called ldap_default_bind_dn. Use your AD identity information for this value."
+      },
+     "caCertificate": {
+       "name": "CA Certificate",
+       "description": "The absolute path to a certificates bundle containing the certificates for every certification authority in the certification chain that issued a certificate for the domain controllers.",
+       "help": "It corresponds to the sssd-ldap parameter that's called ldap_tls_cacert."
+     },
+      "requireCertificate": {
+        "name": "Require Certificate",
+        "description": "Specifies what checks to perform on server certificates in a TLS session.",
+        "help": "It corresponds to sssd-ldap parameter that's called ldap_tls_reqcert."
+      },
+      "LDAPAccessFilter": {
+        "name": "LDAP Access Filter",
+        "description": "Specifies a filter to limit LDAP queries to a subset of the directory that's being queried.",
+        "help": "This property corresponds to the sssd-ldap parameter that's called ldap_access_filter. You can use it to limit queries to an AD that supports a large number of users."
+      },
+      "generateSSHKeys": {
+        "name": "Generate SSH Keys",
+        "description": "Defines whether AWS ParallelCluster generates SSH key pairs for cluster users after they log in to the head node for the first time.",
+        "help": "The key pair is saved to the user home directory at /home/username/.ssh/. Users can use the SSH key pair for subsequent logins to the cluster head node and compute nodes. With AWS ParallelCluster, logins to cluster compute nodes are disabled by design. If a user hasn't logged into the head node, SSH keys aren't generated and the user won't be able to log in to compute nodes."
+      }
     }
   },
   "JobSubmitDialog": {

--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -35,6 +35,7 @@ import {
 
 // Components
 import HelpTooltip from '../../components/HelpTooltip'
+import {NonCancelableEventHandler} from "@awsui/components-react/internal/events";
 
 // Helper Functions
 function strToOption(str: any){
@@ -646,8 +647,7 @@ type HelpTextInputProps = {
   help: string,
   placeholder: string,
   type?: InputProps.Type,
-  setterFunction?: (path: string[], value: string) => void
-  validationFunction?: () => boolean,
+  onChange: NonCancelableEventHandler<InputProps.ChangeDetail>
 };
 
 function HelpTextInput({
@@ -659,8 +659,7 @@ function HelpTextInput({
   help,
   placeholder,
   type = "text",
-  setterFunction = setState,
-  validationFunction = () => true,
+  onChange
 }: HelpTextInputProps)
 {
   let value = useState([...path, configKey]);
@@ -676,7 +675,7 @@ function HelpTextInput({
             placeholder={placeholder}
             value={value}
             type={type}
-            onChange={({detail}) => {setterFunction([...path, configKey], detail.value); validationFunction();}} />
+            onChange={onChange} />
       </div>
       <HelpTooltip>{help}</HelpTooltip>
     </div>

--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -30,6 +30,7 @@ import {
   Toggle,
   TokenGroup,
   Select,
+  InputProps,
 } from "@awsui/components-react";
 
 // Components
@@ -636,4 +637,50 @@ function IamPoliciesEditor({
   );
 }
 
-export { SubnetSelect, SecurityGroups, InstanceSelect, LabeledIcon, ActionsEditor, CustomAMISettings, RootVolume, IamPoliciesEditor }
+type HelpTextInputProps = {
+  name: string,
+  path: string[],
+  errorsPath: string[],
+  configKey: string,
+  description: string,
+  help: string,
+  placeholder: string,
+  type?: InputProps.Type,
+  setterFunction?: (path: string[], value: string) => void
+  validationFunction?: () => boolean,
+};
+
+function HelpTextInput({
+  name,
+  path,
+  errorsPath,
+  configKey,
+  description,
+  help,
+  placeholder,
+  type = "text",
+  setterFunction = setState,
+  validationFunction = () => true,
+}: HelpTextInputProps)
+{
+  let value = useState([...path, configKey]);
+  let error = useState([...errorsPath, configKey]);
+
+  return <FormField
+      label={name}
+      errorText={error}
+      description={description}>
+    <div style={{display: "flex", flexDirection: "row", alignItems: "center", justifyContent: "space-between"}}>
+      <div style={{flexGrow: 1}}>
+        <Input
+            placeholder={placeholder}
+            value={value}
+            type={type}
+            onChange={({detail}) => {setterFunction([...path, configKey], detail.value); validationFunction();}} />
+      </div>
+      <HelpTooltip>{help}</HelpTooltip>
+    </div>
+  </FormField>
+}
+
+export { SubnetSelect, SecurityGroups, InstanceSelect, LabeledIcon, ActionsEditor, CustomAMISettings, RootVolume, IamPoliciesEditor, HelpTextInput }

--- a/frontend/src/old-pages/Configure/MultiUser.tsx
+++ b/frontend/src/old-pages/Configure/MultiUser.tsx
@@ -31,6 +31,7 @@ import { setState, useState, getState, clearState } from '../../store'
 // Components
 import HelpTooltip from '../../components/HelpTooltip'
 import {HelpTextInput} from './Components'
+import {useTranslation} from "react-i18next";
 
 // Constants
 const errorsPath = ['app', 'wizard', 'errors', 'multiUser'];
@@ -137,6 +138,7 @@ function AdditionalSssdOptions() {
 }
 
 function MultiUser() {
+  const { t } = useTranslation();
   return <Container header={<Header variant="h2">Multi User Properties</Header>}>
     <SpaceBetween direction="vertical" size="xs">
       <span>
@@ -146,25 +148,25 @@ function MultiUser() {
           externalIconAriaLabel="Opens in a new tab"
           href={"https://docs.aws.amazon.com/parallelcluster/latest/ug/tutorials_05_multi-user-ad.html"}>this tutorial</Link>.
       </span>
-        <HelpTextInput name={'Domain Name*'} path={dsPath} errorsPath={errorsPath} configKey={'DomainName'} description={'The Active Directory (AD) domain that you use for identity information.'}
-          placeholder={'dc=corp,dc=pcluster,dc=com'} help={'This property corresponds to the sssd-ldap parameter that\'s called ldap_search_base.'} validationFunction={multiUserValidate}/>
-        <HelpTextInput name={'Domain Address*'} path={dsPath} errorsPath={errorsPath} configKey={'DomainAddr'} description={'The URI or URIs that point to the AD domain controller that\'s used as the LDAP server.'}
-          placeholder={'ldaps://corp.pcluster.com'} help={'The URI corresponds to the sssd-ldap parameter that\'s called ldap_uri. The value can be a comma separated string of URIs. To use LDAP, you must add ldap:// to the beginning of the each URI.'} validationFunction={multiUserValidate}/>
-        <HelpTextInput name={'Password Secret ARN*'} path={dsPath} errorsPath={errorsPath} configKey={'PasswordSecretArn'} description={'The URI or URIs that point to the AD domain controller that\'s used as the LDAP server.'}
-          placeholder={'arn:aws:secretsmanager:region:000000000000:secret:secret_name'} help={'The URI corresponds to the sssd-ldap parameter that\'s called ldap_uri. The value can be a comma separated string of URIs. To use LDAP, you must add ldap:// to the beginning of the each URI.'} validationFunction={multiUserValidate} />
-        <HelpTextInput name={'Domain Read Only User*'} path={dsPath} errorsPath={errorsPath} configKey={'DomainReadOnlyUser'} description={'The identity that\'s used to query the AD domain for identity information when authenticating cluster user logins.'}
-          placeholder={'cn=ReadOnlyUser,ou=Users,ou=CORP,dc=corp,dc=pcluster,dc=com'} help={'It corresponds to sssd-ldap parameter that\'s called ldap_default_bind_dn. Use your AD identity information for this value.'} validationFunction={multiUserValidate} />
+      <HelpTextInput name={t("wizard.multiuser.domainName.name")} path={dsPath} errorsPath={errorsPath} configKey={'DomainName'} description={t("wizard.multiuser.domainName.description")}
+                     placeholder={'dc=corp,dc=pcluster,dc=com'} help={t("wizard.multiuser.domainName.help")} validationFunction={multiUserValidate}/>
+      <HelpTextInput name={t("wizard.multiuser.domainAddress.name")} path={dsPath} errorsPath={errorsPath} configKey={'DomainAddr'} description={t("wizard.multiuser.domainAddress.description")}
+                     placeholder={'ldaps://corp.pcluster.com'} help={t("wizard.multiuser.domainAddress.help")} validationFunction={multiUserValidate}/>
+      <HelpTextInput name={t("wizard.multiuser.passwordSecretArn.name")} path={dsPath} errorsPath={errorsPath} configKey={'PasswordSecretArn'} description={t("wizard.multiuser.passwordSecretArn.description")}
+                     placeholder={'arn:aws:secretsmanager:region:000000000000:secret:secret_name'} help={t("wizard.multiuser.passwordSecretArn.help")} validationFunction={multiUserValidate} />
+      <HelpTextInput name={t("wizard.multiuser.domainReadOnlyUser.name")} path={dsPath} errorsPath={errorsPath} configKey={'DomainReadOnlyUser'} description={t("wizard.multiuser.domainReadOnlyUser.description")}
+                     placeholder={'cn=ReadOnlyUser,ou=Users,ou=CORP,dc=corp,dc=pcluster,dc=com'} help={t("wizard.multiuser.domainReadOnlyUser.help")} validationFunction={multiUserValidate} />
       <ExpandableSection header="Advanced options">
         <SpaceBetween direction="vertical" size="xs">
-            <HelpTextInput name={'CA Certificate'} path={dsPath} errorsPath={errorsPath} configKey={'LdapTlsCaCert'} description={'The absolute path to a certificates bundle containing the certificates for every certification authority in the certification chain that issued a certificate for the domain controllers.'}
-              placeholder={'/path/to/certificate.pem'} help={'It corresponds to the sssd-ldap parameter that\'s called ldap_tls_cacert.'} validationFunction={multiUserValidate} />
-            <HelpTextInput name={'Require Certificate'} path={dsPath} errorsPath={errorsPath} configKey={'LdapTlsReqCert'} description={'Specifies what checks to perform on server certificates in a TLS session.'}
-              placeholder={'hard'} help={'It corresponds to sssd-ldap parameter that\'s called ldap_tls_reqcert.'} />
-            <HelpTextInput name={'LDAP Access Filter'} path={dsPath} errorsPath={errorsPath} configKey={'LdapAccessFilter'} description={'Specifies a filter to limit LDAP queries to a subset of the directory that\'s being queried.'}
-              placeholder={'memberOf=cn=TeamOne,ou=Users,ou=CORP,dc=corp,dc=pcluster,dc=com'} help={'This property corresponds to the sssd-ldap parameter that\'s called ldap_access_filter. You can use it to limit queries to an AD that supports a large number of users.'} validationFunction={multiUserValidate} />
-            <HelpToggle name={'Generate SSH Keys'} path={dsPath} errorsPath={errorsPath} configKey={'GenerateSshKeysForUsers'} description={'Defines whether AWS ParallelCluster generates SSH key pairs for cluster users after they log in to the head node for the first time.'}
-              help={' The key pair is saved to the user home directory at /home/username/.ssh/. Users can use the SSH key pair for subsequent logins to the cluster head node and compute nodes. With AWS ParallelCluster, logins to cluster compute nodes are disabled by design. If a user hasn\'t logged into the head node, SSH keys aren\'t generated and the user won\'t be able to log in to compute nodes.'}
-              defaultValue={true} validationFunction={multiUserValidate}/>
+          <HelpTextInput name={t("wizard.multiuser.caCertificate.name")} path={dsPath} errorsPath={errorsPath} configKey={'LdapTlsCaCert'} description={t("wizard.multiuser.caCertificate.description")}
+                         placeholder={'/path/to/certificate.pem'} help={t("wizard.multiuser.caCertificate.help")} validationFunction={multiUserValidate} />
+          <HelpTextInput name={t("wizard.multiuser.requireCertificate.name")} path={dsPath} errorsPath={errorsPath} configKey={'LdapTlsReqCert'} description={t("wizard.multiuser.requireCertificate.description")}
+                         placeholder={'hard'} help={t("wizard.multiuser.requireCertificate.help")} />
+          <HelpTextInput name={t("wizard.multiuser.LDAPAccessFilter.name")} path={dsPath} errorsPath={errorsPath} configKey={'LdapAccessFilter'} description={t("wizard.multiuser.LDAPAccessFilter.description")}
+                         placeholder={'memberOf=cn=TeamOne,ou=Users,ou=CORP,dc=corp,dc=pcluster,dc=com'} help={t("wizard.multiuser.LDAPAccessFilter.help")} validationFunction={multiUserValidate} />
+          <HelpToggle name={t("wizard.multiuser.generateSSHKeys.name")} path={dsPath} errorsPath={errorsPath} configKey={'GenerateSshKeysForUsers'} description={t("wizard.multiuser.generateSSHKeys.description")}
+                      help={t("wizard.multiuser.generateSSHKeys.help")}
+                      defaultValue={true} validationFunction={multiUserValidate}/>
           <AdditionalSssdOptions />
         </SpaceBetween>
       </ExpandableSection>

--- a/frontend/src/old-pages/Configure/MultiUser.tsx
+++ b/frontend/src/old-pages/Configure/MultiUser.tsx
@@ -30,13 +30,14 @@ import { setState, useState, getState, clearState } from '../../store'
 
 // Components
 import HelpTooltip from '../../components/HelpTooltip'
+import {HelpTextInput} from './Components'
 
 // Constants
 const errorsPath = ['app', 'wizard', 'errors', 'multiUser'];
+const dsPath = ['app', 'wizard', 'config', 'DirectoryService'];
 
 function multiUserValidate() {
   let valid = true
-  let dsPath = ['app', 'wizard', 'config', 'DirectoryService'];
 
   const checkRequired = (key: any) => {
     const value = getState([...dsPath, key]);
@@ -58,34 +59,6 @@ function multiUserValidate() {
   return valid;
 }
 
-function HelpTextInput({
-  name,
-  configKey,
-  description,
-  help,
-  placeholder
-}: any)
-{
-  //let editing = useState(['app', 'wizard', 'editing']);
-  let dsPath = ['app', 'wizard', 'config', 'DirectoryService'];
-  let value = useState([...dsPath, configKey]);
-  let error = useState([...errorsPath, configKey]);
-
-  return <FormField
-    label={name}
-    errorText={error}
-    description={description}>
-    <div style={{display: "flex", flexDirection: "row", alignItems: "center", justifyContent: "space-between"}}>
-      <div style={{flexGrow: 1}}>
-        <Input
-          placeholder={placeholder}
-          value={value}
-          onChange={({detail}) => {setState([...dsPath, configKey], detail.value); multiUserValidate();}} />
-      </div>
-      <HelpTooltip>{help}</HelpTooltip>
-    </div>
-  </FormField>
-}
 
 function HelpToggle({
   name,
@@ -96,8 +69,6 @@ function HelpToggle({
   defaultValue
 }: any)
 {
-  //let editing = useState(['app', 'wizard', 'editing']);
-  let dsPath = ['app', 'wizard', 'config', 'DirectoryService'];
   let value = useState([...dsPath, configKey]);
   let error = useState([...errorsPath, configKey]);
 
@@ -117,7 +88,6 @@ function HelpToggle({
 }
 
 function AdditionalSssdOptions() {
-  let dsPath = ['app', 'wizard', 'config', 'DirectoryService'];
   let additionalSssdConfigsErrors = useState([...errorsPath, 'additionalSssdConfigs']);
   let additionalSssdConfigs = useState([...dsPath, 'AdditionalSssdConfigs']) || {};
 
@@ -176,25 +146,25 @@ function MultiUser() {
           externalIconAriaLabel="Opens in a new tab"
           href={"https://docs.aws.amazon.com/parallelcluster/latest/ug/tutorials_05_multi-user-ad.html"}>this tutorial</Link>.
       </span>
-        <HelpTextInput name={'Domain Name*'} configKey={'DomainName'} description={'The Active Directory (AD) domain that you use for identity information.'}
-          placeholder={'dc=corp,dc=pcluster,dc=com'} help={'This property corresponds to the sssd-ldap parameter that\'s called ldap_search_base.'} />
-        <HelpTextInput name={'Domain Address*'} configKey={'DomainAddr'} description={'The URI or URIs that point to the AD domain controller that\'s used as the LDAP server.'}
-          placeholder={'ldaps://corp.pcluster.com'} help={'The URI corresponds to the sssd-ldap parameter that\'s called ldap_uri. The value can be a comma separated string of URIs. To use LDAP, you must add ldap:// to the beginning of the each URI.'} />
-        <HelpTextInput name={'Password Secret ARN*'} configKey={'PasswordSecretArn'} description={'The URI or URIs that point to the AD domain controller that\'s used as the LDAP server.'}
-          placeholder={'arn:aws:secretsmanager:region:000000000000:secret:secret_name'} help={'The URI corresponds to the sssd-ldap parameter that\'s called ldap_uri. The value can be a comma separated string of URIs. To use LDAP, you must add ldap:// to the beginning of the each URI.'} />
-        <HelpTextInput name={'Domain Read Only User*'} configKey={'DomainReadOnlyUser'} description={'The identity that\'s used to query the AD domain for identity information when authenticating cluster user logins.'}
-          placeholder={'cn=ReadOnlyUser,ou=Users,ou=CORP,dc=corp,dc=pcluster,dc=com'} help={'It corresponds to sssd-ldap parameter that\'s called ldap_default_bind_dn. Use your AD identity information for this value.'} />
+        <HelpTextInput name={'Domain Name*'} path={dsPath} errorsPath={errorsPath} configKey={'DomainName'} description={'The Active Directory (AD) domain that you use for identity information.'}
+          placeholder={'dc=corp,dc=pcluster,dc=com'} help={'This property corresponds to the sssd-ldap parameter that\'s called ldap_search_base.'} validationFunction={multiUserValidate}/>
+        <HelpTextInput name={'Domain Address*'} path={dsPath} errorsPath={errorsPath} configKey={'DomainAddr'} description={'The URI or URIs that point to the AD domain controller that\'s used as the LDAP server.'}
+          placeholder={'ldaps://corp.pcluster.com'} help={'The URI corresponds to the sssd-ldap parameter that\'s called ldap_uri. The value can be a comma separated string of URIs. To use LDAP, you must add ldap:// to the beginning of the each URI.'} validationFunction={multiUserValidate}/>
+        <HelpTextInput name={'Password Secret ARN*'} path={dsPath} errorsPath={errorsPath} configKey={'PasswordSecretArn'} description={'The URI or URIs that point to the AD domain controller that\'s used as the LDAP server.'}
+          placeholder={'arn:aws:secretsmanager:region:000000000000:secret:secret_name'} help={'The URI corresponds to the sssd-ldap parameter that\'s called ldap_uri. The value can be a comma separated string of URIs. To use LDAP, you must add ldap:// to the beginning of the each URI.'} validationFunction={multiUserValidate} />
+        <HelpTextInput name={'Domain Read Only User*'} path={dsPath} errorsPath={errorsPath} configKey={'DomainReadOnlyUser'} description={'The identity that\'s used to query the AD domain for identity information when authenticating cluster user logins.'}
+          placeholder={'cn=ReadOnlyUser,ou=Users,ou=CORP,dc=corp,dc=pcluster,dc=com'} help={'It corresponds to sssd-ldap parameter that\'s called ldap_default_bind_dn. Use your AD identity information for this value.'} validationFunction={multiUserValidate} />
       <ExpandableSection header="Advanced options">
         <SpaceBetween direction="vertical" size="xs">
-            <HelpTextInput name={'CA Certificate'} configKey={'LdapTlsCaCert'} description={'The absolute path to a certificates bundle containing the certificates for every certification authority in the certification chain that issued a certificate for the domain controllers.'}
-              placeholder={'/path/to/certificate.pem'} help={'It corresponds to the sssd-ldap parameter that\'s called ldap_tls_cacert.'} />
-            <HelpTextInput name={'Require Certificate'} configKey={'LdapTlsReqCert'} description={'Specifies what checks to perform on server certificates in a TLS session.'}
+            <HelpTextInput name={'CA Certificate'} path={dsPath} errorsPath={errorsPath} configKey={'LdapTlsCaCert'} description={'The absolute path to a certificates bundle containing the certificates for every certification authority in the certification chain that issued a certificate for the domain controllers.'}
+              placeholder={'/path/to/certificate.pem'} help={'It corresponds to the sssd-ldap parameter that\'s called ldap_tls_cacert.'} validationFunction={multiUserValidate} />
+            <HelpTextInput name={'Require Certificate'} path={dsPath} errorsPath={errorsPath} configKey={'LdapTlsReqCert'} description={'Specifies what checks to perform on server certificates in a TLS session.'}
               placeholder={'hard'} help={'It corresponds to sssd-ldap parameter that\'s called ldap_tls_reqcert.'} />
-            <HelpTextInput name={'LDAP Access Filter'} configKey={'LdapAccessFilter'} description={'Specifies a filter to limit LDAP queries to a subset of the directory that\'s being queried.'}
-              placeholder={'memberOf=cn=TeamOne,ou=Users,ou=CORP,dc=corp,dc=pcluster,dc=com'} help={'This property corresponds to the sssd-ldap parameter that\'s called ldap_access_filter. You can use it to limit queries to an AD that supports a large number of users.'} />
-            <HelpToggle name={'Generate SSH Keys'} configKey={'GenerateSshKeysForUsers'} description={'Defines whether AWS ParallelCluster generates SSH key pairs for cluster users after they log in to the head node for the first time.'}
+            <HelpTextInput name={'LDAP Access Filter'} path={dsPath} errorsPath={errorsPath} configKey={'LdapAccessFilter'} description={'Specifies a filter to limit LDAP queries to a subset of the directory that\'s being queried.'}
+              placeholder={'memberOf=cn=TeamOne,ou=Users,ou=CORP,dc=corp,dc=pcluster,dc=com'} help={'This property corresponds to the sssd-ldap parameter that\'s called ldap_access_filter. You can use it to limit queries to an AD that supports a large number of users.'} validationFunction={multiUserValidate} />
+            <HelpToggle name={'Generate SSH Keys'} path={dsPath} errorsPath={errorsPath} configKey={'GenerateSshKeysForUsers'} description={'Defines whether AWS ParallelCluster generates SSH key pairs for cluster users after they log in to the head node for the first time.'}
               help={' The key pair is saved to the user home directory at /home/username/.ssh/. Users can use the SSH key pair for subsequent logins to the cluster head node and compute nodes. With AWS ParallelCluster, logins to cluster compute nodes are disabled by design. If a user hasn\'t logged into the head node, SSH keys aren\'t generated and the user won\'t be able to log in to compute nodes.'}
-              defaultValue={true}/>
+              defaultValue={true} validationFunction={multiUserValidate}/>
           <AdditionalSssdOptions />
         </SpaceBetween>
       </ExpandableSection>

--- a/frontend/src/old-pages/Configure/MultiUser.tsx
+++ b/frontend/src/old-pages/Configure/MultiUser.tsx
@@ -149,24 +149,24 @@ function MultiUser() {
           href={"https://docs.aws.amazon.com/parallelcluster/latest/ug/tutorials_05_multi-user-ad.html"}>this tutorial</Link>.
       </span>
       <HelpTextInput name={t("wizard.multiuser.domainName.name")} path={dsPath} errorsPath={errorsPath} configKey={'DomainName'} description={t("wizard.multiuser.domainName.description")}
-                     placeholder={'dc=corp,dc=pcluster,dc=com'} help={t("wizard.multiuser.domainName.help")} validationFunction={multiUserValidate}/>
+                     placeholder={'dc=corp,dc=pcluster,dc=com'} help={t("wizard.multiuser.domainName.help")} onChange={({detail}) => { setState([...dsPath, 'DomainName'], detail.value); multiUserValidate(); }}/>
       <HelpTextInput name={t("wizard.multiuser.domainAddress.name")} path={dsPath} errorsPath={errorsPath} configKey={'DomainAddr'} description={t("wizard.multiuser.domainAddress.description")}
-                     placeholder={'ldaps://corp.pcluster.com'} help={t("wizard.multiuser.domainAddress.help")} validationFunction={multiUserValidate}/>
+                     placeholder={'ldaps://corp.pcluster.com'} help={t("wizard.multiuser.domainAddress.help")} onChange={({detail}) => { setState([...dsPath, 'DomainAddr'], detail.value); multiUserValidate(); }}/>
       <HelpTextInput name={t("wizard.multiuser.passwordSecretArn.name")} path={dsPath} errorsPath={errorsPath} configKey={'PasswordSecretArn'} description={t("wizard.multiuser.passwordSecretArn.description")}
-                     placeholder={'arn:aws:secretsmanager:region:000000000000:secret:secret_name'} help={t("wizard.multiuser.passwordSecretArn.help")} validationFunction={multiUserValidate} />
+                     placeholder={'arn:aws:secretsmanager:region:000000000000:secret:secret_name'} help={t("wizard.multiuser.passwordSecretArn.help")} onChange={({detail}) => { setState([...dsPath, 'PasswordSecretArn'], detail.value); multiUserValidate(); }} />
       <HelpTextInput name={t("wizard.multiuser.domainReadOnlyUser.name")} path={dsPath} errorsPath={errorsPath} configKey={'DomainReadOnlyUser'} description={t("wizard.multiuser.domainReadOnlyUser.description")}
-                     placeholder={'cn=ReadOnlyUser,ou=Users,ou=CORP,dc=corp,dc=pcluster,dc=com'} help={t("wizard.multiuser.domainReadOnlyUser.help")} validationFunction={multiUserValidate} />
+                     placeholder={'cn=ReadOnlyUser,ou=Users,ou=CORP,dc=corp,dc=pcluster,dc=com'} help={t("wizard.multiuser.domainReadOnlyUser.help")} onChange={({detail}) => { setState([...dsPath, 'DomainReadOnlyUser'], detail.value); multiUserValidate(); }} />
       <ExpandableSection header="Advanced options">
         <SpaceBetween direction="vertical" size="xs">
           <HelpTextInput name={t("wizard.multiuser.caCertificate.name")} path={dsPath} errorsPath={errorsPath} configKey={'LdapTlsCaCert'} description={t("wizard.multiuser.caCertificate.description")}
-                         placeholder={'/path/to/certificate.pem'} help={t("wizard.multiuser.caCertificate.help")} validationFunction={multiUserValidate} />
+                         placeholder={'/path/to/certificate.pem'} help={t("wizard.multiuser.caCertificate.help")} onChange={({detail}) => { setState([...dsPath, 'LdapTlsCaCert'], detail.value); multiUserValidate(); }} />
           <HelpTextInput name={t("wizard.multiuser.requireCertificate.name")} path={dsPath} errorsPath={errorsPath} configKey={'LdapTlsReqCert'} description={t("wizard.multiuser.requireCertificate.description")}
-                         placeholder={'hard'} help={t("wizard.multiuser.requireCertificate.help")} />
+                         placeholder={'hard'} help={t("wizard.multiuser.requireCertificate.help")} onChange={({detail}) => { setState([...dsPath, 'LdapTlsReqCert'], detail.value); multiUserValidate(); }}/>
           <HelpTextInput name={t("wizard.multiuser.LDAPAccessFilter.name")} path={dsPath} errorsPath={errorsPath} configKey={'LdapAccessFilter'} description={t("wizard.multiuser.LDAPAccessFilter.description")}
-                         placeholder={'memberOf=cn=TeamOne,ou=Users,ou=CORP,dc=corp,dc=pcluster,dc=com'} help={t("wizard.multiuser.LDAPAccessFilter.help")} validationFunction={multiUserValidate} />
-          <HelpToggle name={t("wizard.multiuser.generateSSHKeys.name")} path={dsPath} errorsPath={errorsPath} configKey={'GenerateSshKeysForUsers'} description={t("wizard.multiuser.generateSSHKeys.description")}
+                         placeholder={'memberOf=cn=TeamOne,ou=Users,ou=CORP,dc=corp,dc=pcluster,dc=com'} help={t("wizard.multiuser.LDAPAccessFilter.help")} onChange={({detail}) => { setState([...dsPath, 'LdapAccessFilter'], detail.value); multiUserValidate(); }} />
+          <HelpToggle name={t("wizard.multiuser.generateSSHKeys.name")} configKey={'GenerateSshKeysForUsers'} description={t("wizard.multiuser.generateSSHKeys.description")}
                       help={t("wizard.multiuser.generateSSHKeys.help")}
-                      defaultValue={true} validationFunction={multiUserValidate}/>
+                      defaultValue={true}/>
           <AdditionalSssdOptions />
         </SpaceBetween>
       </ExpandableSection>

--- a/frontend/src/old-pages/Configure/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues.tsx
@@ -221,10 +221,11 @@ function ComputeResource({
 
   const setSchedulableMemory = (schedulableMemoryPath: string[], schedulableMemory: string) => {
     let schedulableMemoryNumber = parseInt(schedulableMemory)
-    if (enableMemoryBasedScheduling && !isNaN(schedulableMemoryNumber))
+    if (enableMemoryBasedScheduling && !isNaN(schedulableMemoryNumber)) {
       setState(schedulableMemoryPath, schedulableMemoryNumber);
-    else
+    } else {
       clearState(schedulableMemoryPath)
+    }
   }
 
   const setDisableHT = (disable: any) => {

--- a/frontend/src/old-pages/Configure/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues.tsx
@@ -31,7 +31,17 @@ import {
 import { setState, getState, useState, clearState } from '../../store'
 
 // Components
-import { ActionsEditor, CustomAMISettings, InstanceSelect, LabeledIcon, RootVolume, SubnetSelect, SecurityGroups, IamPoliciesEditor } from './Components'
+import {
+  ActionsEditor,
+  CustomAMISettings,
+  InstanceSelect,
+  LabeledIcon,
+  RootVolume,
+  SubnetSelect,
+  SecurityGroups,
+  IamPoliciesEditor,
+  HelpTextInput
+} from './Components'
 import HelpTooltip from '../../components/HelpTooltip'
 
 // Constants
@@ -166,6 +176,8 @@ function ComputeResource({
 
   const instanceTypePath = [...path, "InstanceType"]
   const instanceType = useState(instanceTypePath);
+  const memoryBasedSchedulingEnabledPath = ['app', 'wizard', 'config', 'Scheduling', 'SlurmSettings', 'EnableMemoryBasedScheduling']
+  const enableMemoryBasedScheduling = useState(memoryBasedSchedulingEnabledPath)
 
   const disableHTPath = [...path, "DisableSimultaneousMultithreading"]
   const disableHT = useState(disableHTPath);
@@ -202,6 +214,14 @@ function ComputeResource({
   const setMaxCount = (dynamicCount: any) => {
     const staticCount = minCount;
     setState([...path, 'MaxCount'], (!isNaN(staticCount) ? staticCount : 0) + (!isNaN(dynamicCount) ? dynamicCount : 0));
+  }
+
+  const setSchedulableMemory = (schedulableMemoryPath: string[], schedulableMemory: string) => {
+    let schedulableMemoryNumber = parseInt(schedulableMemory)
+    if (enableMemoryBasedScheduling && !isNaN(schedulableMemoryNumber))
+      setState(schedulableMemoryPath, schedulableMemoryNumber);
+    else
+      clearState(schedulableMemoryPath)
   }
 
   const setDisableHT = (disable: any) => {
@@ -268,6 +288,17 @@ function ComputeResource({
           <FormField label="Instance Type" errorText={typeError}>
             <InstanceSelect path={instanceTypePath} callback={setInstanceType}/>
           </FormField>
+          {enableMemoryBasedScheduling &&
+              <HelpTextInput name={"Schedulable Memory (MiB)"}
+                             path={path}
+                             errorsPath={errorsPath}
+                             configKey={'SchedulableMemory'}
+                             setterFunction={setSchedulableMemory}
+                             description={"Amount of memory in MiB to be made available to jobs on the compute nodes of the compute resource"}
+                             placeholder={"Leave empty for default"}
+                             help={"The default value is 95 % of the memory advertised by EC2."}
+                             type="number"/>
+          }
         </ColumnLayout>
         <div style={{display: "flex", flexDirection: "row", gap: "20px"}}>
           {/* @ts-expect-error TS(2345) FIXME: Argument of type 'any' is not assignable to parame... Remove this comment to see the full error message */}

--- a/frontend/src/old-pages/Configure/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues.tsx
@@ -296,7 +296,7 @@ function ComputeResource({
                              path={path}
                              errorsPath={errorsPath}
                              configKey={'SchedulableMemory'}
-                             setterFunction={setSchedulableMemory}
+                             onChange={({detail}) => setSchedulableMemory([...path, 'SchedulableMemory'], detail.value)}
                              description={t("wizard.queues.schedulableMemory.description")}
                              placeholder={t("wizard.queues.schedulableMemory.placeholder")}
                              help={t("wizard.queues.schedulableMemory.help")}

--- a/frontend/src/old-pages/Configure/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues.tsx
@@ -43,6 +43,7 @@ import {
   HelpTextInput
 } from './Components'
 import HelpTooltip from '../../components/HelpTooltip'
+import { useTranslation } from 'react-i18next';
 
 // Constants
 const queuesPath = ['app', 'wizard', 'config', 'Scheduling', 'SlurmQueues'];
@@ -198,6 +199,8 @@ function ComputeResource({
   const minCount = useState([...path, 'MinCount']);
   const maxCount = useState([...path, 'MaxCount']);
 
+  const { t } = useTranslation()
+
   const remove = () => {
     setState([...parentPath, 'ComputeResources'], [...computeResources.slice(0, index), ...computeResources.slice(index + 1)]);
   }
@@ -289,14 +292,14 @@ function ComputeResource({
             <InstanceSelect path={instanceTypePath} callback={setInstanceType}/>
           </FormField>
           {enableMemoryBasedScheduling &&
-              <HelpTextInput name={"Schedulable Memory (MiB)"}
+              <HelpTextInput name={t("wizard.queues.schedulableMemory.name")}
                              path={path}
                              errorsPath={errorsPath}
                              configKey={'SchedulableMemory'}
                              setterFunction={setSchedulableMemory}
-                             description={"Amount of memory in MiB to be made available to jobs on the compute nodes of the compute resource"}
-                             placeholder={"Leave empty for default"}
-                             help={"The default value is 95 % of the memory advertised by EC2."}
+                             description={t("wizard.queues.schedulableMemory.description")}
+                             placeholder={t("wizard.queues.schedulableMemory.placeholder")}
+                             help={t("wizard.queues.schedulableMemory.help")}
                              type="number"/>
           }
         </ColumnLayout>


### PR DESCRIPTION
## Description

Add schedulable memory parameter in the queue section of the Wizard to reach feature parity with pcluster 3.2.0

(The flag to enable this param only with 3.2.0 will be added in a subsequent CR in addition to other related parameters)

## Changes

1. Make configurable the HelpTextInput component
2. Add schedulable memory parameter
3. Add localization of strings for the interested part of code

## How Has This Been Tested?

Tested locally connecting to a PC version using 3.2.0b2, see video below

https://user-images.githubusercontent.com/83351137/179985446-761d5677-99c1-4814-98d9-978a3a3a1b84.mp4

## References

This was dependent of the [PR related to the memory based scheduling](https://github.com/aws-samples/pcluster-manager/pull/193)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.