### PR TITLE
Allow to specify reqired memory when launching a job

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -11,5 +11,11 @@
          "help": "If enabled, users may use <i>--mem</i> to specify the amount of memory per node required by a job. For more information, see the <0>Slurm documentation for ConstrainRAMSpace</0>"
        }
     }
+  },
+  "JobSubmitDialog": {
+    "requiredMemory": {
+      "header": "Required memory",
+      "description": "Real memory required per node, in MB. A memory size specification of zero is treated as a special case and grants the job access to all of the memory on each node. [optional]"
+    }
   }
 }

--- a/frontend/src/old-pages/Clusters/JobSubmitDialog.tsx
+++ b/frontend/src/old-pages/Clusters/JobSubmitDialog.tsx
@@ -9,6 +9,7 @@
 // OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 import { useState, setState, getState, clearState } from '../../store'
 import { findFirst, clusterDefaultUser } from '../../util'
 import { SubmitJob, PriceEstimate } from '../../model'
@@ -147,9 +148,11 @@ function JobCostEstimate() {
 export default function JobSubmitDialog({
   submitCallback
 }: any) {
+  const { t } = useTranslation();
   const open = useState([...submitPath, 'dialog']);
   const error = useState([...submitPath, 'error']);
   const jobPath = [...submitPath, 'job'];
+  const clusterName = getState(['app', 'clusters', 'selected']);
 
   const job = useState(jobPath);
   const submitting = useState([...submitPath, 'pending']);
@@ -157,11 +160,15 @@ export default function JobSubmitDialog({
   let chdir = useState([...jobPath, 'chdir']);
   let nodes = useState([...jobPath, 'nodes']);
   let ntasks = useState([...jobPath, 'ntasks']);
+  let mem = useState([...jobPath, 'mem']);
   let command = useState([...jobPath, 'command']);
   let wrap = useState([...jobPath, 'wrap']) || false;
 
+  let isMemBasedSchedulingEnabled = useState(
+      ['clusters', 'index', clusterName, 'config', 'Scheduling', 'SlurmSettings', 'EnableMemoryBasedScheduling']
+  ) || false;
+
   const submitJob = () => {
-    const clusterName = getState(['app', 'clusters', 'selected']);
     const clusterPath = ['clusters', 'index', clusterName];
     const cluster = getState(clusterPath);
     let user = clusterDefaultUser(cluster);
@@ -262,6 +269,23 @@ export default function JobSubmitDialog({
             />
           </FormField>
         </SpaceBetween>
+
+        {
+          isMemBasedSchedulingEnabled && <SpaceBetween direction="vertical" size="xxs" key="mem">
+          <Header variant="h2"
+            description={t("JobSubmitDialog.requiredMemory.description")}>
+            {t("JobSubmitDialog.requiredMemory.header")}
+          </Header>
+          <FormField>
+            <Input
+              onChange={({ detail }) => {setState([...jobPath, 'mem'], detail.value);}}
+              value={mem}
+              inputMode='numeric'
+              placeholder="0"
+            />
+          </FormField>
+        </SpaceBetween>
+        }
 
         <QueueSelect />
 


### PR DESCRIPTION
### Notes
This patch allows the user to specify teh required memory when launching a job, if it is run on a Slurm cluster with memory based scheduling enabled.

### Tests
- Tested with a cluster with memory based scheduling enabled, observed that the correct parameter `--mem <specified value>` was present in the request to `sbatch`.
- Tested with a cluster with memory based scheduling, without specifying the value, verified that it was not present in the `sbatch` parameters.
- Tested with a cluster without memory based scheduling, verified that the part of the dialogue that allows to specify the required memory for the job is not show.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.