### PR TITLE
Fixing violation related to Defend Against Reverse Tabnabbing Attack

### DIFF
--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -314,7 +314,7 @@ function HeadNode() {
             checked={memoryBasedSchedulingEnabled || false} onChange={toggleMemoryBasedSchedulingEnabled}><Trans i18nKey="wizard.headNode.memoryBasedSchedulingEnabled.label" /></Toggle>
           <HelpTooltip>
             <Trans i18nKey="wizard.headNode.memoryBasedSchedulingEnabled.help" >
-               <a rel="noreferrer" target="_blank" href='https://slurm.schedmd.com/cgroup.conf.html#OPT_ConstrainRAMSpace'></a>
+               <a rel="noopener noreferrer" target="_blank" href='https://slurm.schedmd.com/cgroup.conf.html#OPT_ConstrainRAMSpace'></a>
             </Trans>
           </HelpTooltip>
         </div>


### PR DESCRIPTION
Reverse tabnabbing is an attack that is possible when a link is
configured to open a new tab in a browser. If done incorrectly,
the new page is able to control the referrer and opener
objects of the parent window, and use that control to replace
the parent site with a phishing site.
The mitigation is add the noopener and noreferrer values in
 the rel attribute in <a> tags.

## Description

Reverse tabnabbing is an attack that is possible when a link is
configured to open a new tab in a browser. If done incorrectly,
the new page is able to control the referrer and opener
objects of the parent window, and use that control to replace
the parent site with a phishing site.
The mitigation is add the noopener and noreferrer values in
 the rel attribute in <a> tags.

## Changes

Added the *noopener* tag

## How Has This Been Tested?

Locally tested. The new tag is added.

## References

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.