### PR TITLE
Show enable memory based scheduling toggle only on PC >= 3.2.0

### DIFF
--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -254,6 +254,7 @@ function HeadNode() {
   const subnetErrors = useState([...errorsPath, 'subnet']);
   const subnetValue = useState(subnetPath) || "";
   const editing = useState(['app', 'wizard', 'editing']);
+  const versionMinor = useState(['app', 'version', 'minor']);
 
   const toggleImdsSecured = () => {
     const setImdsSecured = !imdsSecured;
@@ -309,15 +310,19 @@ function HeadNode() {
             If enabled, restrict access to IMDS (and thus instance credentials) to users with superuser permissions. For more information, see <a rel="noreferrer" target="_blank" href='https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html#instance-metadata-v2-how-it-works'>How instance metadata service version 2 works</a> in the <i>Amazon EC2 User Guide for Linux Instances</i>.
           </HelpTooltip>
         </div>
-        <div key="memory-based-scheduling-enabled" style={{display: "flex", flexDirection: "row", alignItems: "center", justifyContent: "space-between"}}>
-          <Toggle
-            checked={memoryBasedSchedulingEnabled || false} onChange={toggleMemoryBasedSchedulingEnabled}><Trans i18nKey="wizard.headNode.memoryBasedSchedulingEnabled.label" /></Toggle>
-          <HelpTooltip>
-            <Trans i18nKey="wizard.headNode.memoryBasedSchedulingEnabled.help" >
-               <a rel="noopener noreferrer" target="_blank" href='https://slurm.schedmd.com/cgroup.conf.html#OPT_ConstrainRAMSpace'></a>
-            </Trans>
-          </HelpTooltip>
-        </div>
+        {
+          (versionMinor && versionMinor >= 2) &&
+          <div key="memory-based-scheduling-enabled" style={{display: "flex", flexDirection: "row", alignItems: "center", justifyContent: "space-between"}}>
+            <Toggle
+                  checked={memoryBasedSchedulingEnabled || false} onChange={toggleMemoryBasedSchedulingEnabled}><Trans i18nKey="wizard.headNode.memoryBasedSchedulingEnabled.label" />
+            </Toggle>
+            <HelpTooltip>
+              <Trans i18nKey="wizard.headNode.memoryBasedSchedulingEnabled.help" >
+                 <a rel="noopener noreferrer" target="_blank" href='https://slurm.schedmd.com/cgroup.conf.html#OPT_ConstrainRAMSpace'></a>
+              </Trans>
+            </HelpTooltip>
+          </div>
+        }
         <div key="sgs" style={{display: "flex", flexDirection: "row", alignItems: "center", justifyContent: "space-between"}}>
           <FormField label="Additional Security Groups">
             <SecurityGroups basePath={headNodePath} />


### PR DESCRIPTION
## Description

Show enable memory based scheduling toggle only on PC >= 3.2.0
This is the approach currently used in the application, a new feature toggle mechanism will be enabled in the future

## Changes

[fix(frontend) Show enable memory based scheduling toggle only if vers…](https://github.com/aws-samples/pcluster-manager/commit/d8b9ba63e4e45f6d10758dcec580842cabb5b70e)

## How Has This Been Tested?

Tested without defining API_VERSION env var (default is 3.1.0) and the toggle is not visible
Tested defining API_VERSION to 3.2.0 and toggle is visible and usable

## References

Approach used in https://github.com/aws-samples/pcluster-manager/pull/164

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.