### PR TITLE
fix(frontend) Fix a wrong message in the Password Secret ARN field

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -32,8 +32,8 @@
       },
       "passwordSecretArn" : {
         "name": "Password Secret ARN*",
-        "description": "The URI or URIs that point to the AD domain controller that's used as the LDAP server.",
-        "help": "The URI corresponds to the sssd-ldap parameter that's called ldap_uri. The value can be a comma separated string of URIs. To use LDAP, you must add ldap:// to the beginning of the each URI."
+        "description": "The Amazon Resource Name (ARN) of the AWS Secrets Manager secret that contains the DomainReadOnlyUser plaintext password.",
+        "help": "The content of the secret corresponds to SSSD-LDAP parameter that's called ldap_default_authtok."
       },
       "domainReadOnlyUser": {
         "name": "Domain Read Only User*",


### PR DESCRIPTION
## Description

fix(frontend) Fix a wrong message in the Password Secret ARN field

The text was taken from https://docs.aws.amazon.com/parallelcluster/latest/ug/DirectoryService-v3.html#yaml-DirectoryService-PasswordSecretArn
## Changes

fix(frontend) Fix a wrong message in the Password Secret ARN field

## How Has This Been Tested?

Locally, verifying new text appears

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.