### PR TITLE
`[Configure/Source]` Validate the cluster's name regex

### DIFF
--- a/frontend/src/old-pages/Configure/Source.tsx
+++ b/frontend/src/old-pages/Configure/Source.tsx
@@ -68,6 +68,9 @@ function sourceValidate(suppressUpload = false) {
   } else if(clusterNames.has(clusterName)) {
     setState([...sourceErrorsPath, 'clusterName'], `Cluster with name ${clusterName} already exists. Please choose a unique name.`);
     valid = false;
+  } else if(!/^[a-zA-Z][a-zA-Z0-9-]+$/.test(clusterName)) {
+    setState([...sourceErrorsPath, 'clusterName'], `Cluster name ${clusterName} doesn't match the format /^[a-zA-Z][a-zA-Z0-9-]+$/. Please choose a name consisting of only upper and lower-case letters, numbers and dashes.`);
+    valid = false;
   } else {
     clearState([...sourceErrorsPath, 'clusterName']);
   }


### PR DESCRIPTION

## Description

Validate the cluster name regex in the Source tab.

## Changes

Use the same regular expression that will be used in cluster creation in the source tab so that the error is fixed earlier.

## How Has This Been Tested?

This has been tested manually.
![image](https://user-images.githubusercontent.com/6087509/180489360-24d22584-ef14-4f05-bdee-39e11bdfa432.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.