### PR TITLE
`[Configure/Components/ActionEditor]` Fix bug in deleting custom acti…

### DIFF
--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -445,8 +445,8 @@ function ActionEditor({
   const toggleUseMultiRunner = () => {
     if(useMultiRunner)
     {
-      editScript([...path, 'Script'], '');
       clearState([...path, 'Args']);
+      editScript([...path, 'Script'], '');
     } else {
       editScript([...path, 'Script'], multiRunner);
     }


### PR DESCRIPTION
…ons.

## Description

Fix bug in dsisabling the MultiRunner script.

Previously, if you enabled and then disabled the MultiRunner script, it would leave a dangling `OnNodeStart: {}` in the config file which made it invalid. This was due to an invalid order between when we were clearing the script and clearing the args. If we were to clear the script first and then clear the args, the `clearState` call was creating the empty (dangling) `OnNodeStart: {}`. If we, instead, call the `clearState` on the `Args` portion first, then when we make the call to `editScript` it will call the recursive `clearEmptyNest` call which will remove the dangling empty maps.

## Changes

Change the order in which clear args and edit the script (to be empty) so that we call the `clearEmtpyNest` function after clearing the args which ensures that the dangling script is removed.

## How Has This Been Tested?

Manually by enabling and disabling the MultiRunner script which would previously leave an empty dictionary around for the script, now it is removed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.