### PR TITLE
`[Clusters]` Deselect a cluster after delete finishes

### DIFF
--- a/frontend/src/old-pages/Clusters/Clusters.tsx
+++ b/frontend/src/old-pages/Clusters/Clusters.tsx
@@ -12,7 +12,7 @@ import { useNavigate, useParams } from "react-router-dom"
 
 import { ListClusters } from '../../model'
 
-import { useState, getState, setState, isAdmin } from '../../store'
+import { useState, clearState, getState, setState, isAdmin } from '../../store'
 import { selectCluster } from './util'
 import { findFirst } from '../../util'
 
@@ -37,7 +37,7 @@ import Actions from './Actions';
 import Details from "./Details";
 import { wizardShow } from '../Configure/Configure';
 
-function updateClusterList() {
+function updateClusterList(navigate) {
   const selectedClusterName = getState(['app', 'clusters', 'selected']);
   const oldStatus = getState(['app', 'clusters', 'selectedStatus']);
 
@@ -54,9 +54,12 @@ function updateClusterList() {
           (oldStatus === 'UPDATE_IN_PROGRESS' && selectedCluster.clusterStatus === 'UPDATE_COMPLETE'))
           // @ts-expect-error TS(2554) FIXME: Expected 2 arguments, but got 1.
           selectCluster(selectedClusterName);
+      // If the selected cluster is not found, and was in DELETE_IN_PROGRESS status, deselect it
+      } else if (oldStatus === 'DELETE_IN_PROGRESS') {
+          clearState(['app', 'clusters', 'selected']);
+          navigate('/clusters');
       }
     }
-
   })
 }
 
@@ -67,7 +70,7 @@ function ClusterList() {
   let params = useParams();
 
   React.useEffect(() => {
-    const timerId = (setInterval(updateClusterList, 5000));
+    const timerId = (setInterval(() => updateClusterList(navigate), 5000));
     return () => { clearInterval(timerId); }
   }, [])
 


### PR DESCRIPTION

## Description

This change deselects the cluster after the delete process finishes.

## Changes

Once the cluster is deleted by the backend it is no longer in the list. If that cluster is still selected, then we deslect it by removing the selection in the app state and the URL.

## How Has This Been Tested?

By creating a cluster, deleting it and leaving it selected and verifying that the page transitions to an unselected state.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.