### PR TITLE
`[components/ValidationErrors]` Remove MUI.

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -335,6 +335,14 @@
       }
     }
   },
+  "components": {
+    "ValidationErrors": {
+      "update": "Update",
+      "validation": "Validation",
+      "errors": "Errors",
+      "warnings": "Warnings"
+    }
+  },
   "JobSubmitDialog": {
     "requiredMemory": {
       "header": "Required memory",

--- a/frontend/src/components/ValidationErrors.tsx
+++ b/frontend/src/components/ValidationErrors.tsx
@@ -10,57 +10,45 @@
 // limitations under the License.
 
 // UI Elements
-import { useTheme } from '@mui/material/styles';
+import { Icon } from "@awsui/components-react";
 
-import List from '@mui/material/List';
-import ListItem from '@mui/material/ListItem';
-import ListItemText from '@mui/material/ListItemText';
-
-// Icons
-import CheckIcon from '@mui/icons-material/Check';
-import CloseIcon from '@mui/icons-material/Close';
-
-export default function ValidationErrors(props: any) {
-  const theme = useTheme();
+export default function ValidationErrors({errors}: any) {
   const colorMap = (level: any) => {
     // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     return {
-      "ERROR": theme.palette.error.main,
-      "WARNING": theme.palette.warning.main,
-      "SUCCESS": theme.palette.success.main
-    }[level] || "blue";
+      "ERROR": 'red',
+      "WARNING": 'orange',
+      "SUCCESS": 'green'
+    }[level];
   };
 
   const colored = (text: any, success: any) => <div style={{
-    color: success ? theme.palette.success.main : theme.palette.error.main,
+    color: success ? 'green' : 'red',
     display: 'flex',
     alignItems: 'center',
     flexWrap: 'wrap',
+    padding: '4px 0'
   }}>
-    {success ? <CheckIcon /> : <CloseIcon />}
+    <Icon name={success ? 'status-positive' : 'status-negative'} />
     <div style={{display: 'inline-block', paddingLeft: '10px'}}> {text}</div>
   </div>
 
-  var success = props.errors.message && props.errors.message.includes("succeeded");
-  var configErrors = props.errors.configurationValidationErrors || props.errors.validationMessages;
-  var updateErrors = props.errors.updateValidationErrors;
+  var success = errors.message && errors.message.includes("succeeded");
+  var configErrors = errors.configurationValidationErrors || errors.validationMessages;
+  var updateErrors = errors.updateValidationErrors;
   return (
     <div>
-      {colored(props.errors.message, success)}
+      {colored(errors.message, success)}
       {configErrors &&
         <div className="validation-errors">
-          Validation {props.errors.configurationValidationErrors ? "Errors" : "Warnings"}:
-          <List>
-            {configErrors.map((error: any, i: any) => <ListItem disablePadding key={i}><ListItemText primaryTypographyProps={{ style: {color: colorMap(error.level)} }} primary={`${error.type}: ${error.message}`} /></ListItem>)}
-          </List>
+          Validation {errors.configurationValidationErrors ? "Errors" : "Warnings"}:
+          {configErrors.map((error: any, i: any) => <div style={{color: colorMap(error.level)}} key={i}>{`${error.type}: ${error.message}`}</div>)}
         </div>
       }
       {updateErrors &&
         <div className="validation-errors">
           Update Errors:
-          <List>
-            {updateErrors.map((error: any, i: any) => <ListItem disablePadding key={i}><ListItemText primaryTypographyProps={{ style: {color: colorMap("ERROR")} }} primary={`${error.message}`} /></ListItem>)}
-          </List>
+          {updateErrors.map((error: any, i: any) => <div style={{color: colorMap(error.level)}} key={i}>{`${error.message}`}</div>)}
         </div>
       }
     </div>

--- a/frontend/src/components/ValidationErrors.tsx
+++ b/frontend/src/components/ValidationErrors.tsx
@@ -10,11 +10,11 @@
 // limitations under the License.
 
 // UI Elements
+import { Trans } from 'react-i18next';
 import { Icon } from "@awsui/components-react";
 
 export default function ValidationErrors({errors}: any) {
-  const colorMap = (level: any) => {
-    // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+  const colorMap = (level: string) => {
     return {
       "ERROR": 'red',
       "WARNING": 'orange',
@@ -41,13 +41,18 @@ export default function ValidationErrors({errors}: any) {
       {colored(errors.message, success)}
       {configErrors &&
         <div className="validation-errors">
-          Validation {errors.configurationValidationErrors ? "Errors" : "Warnings"}:
+          <Trans i18nKey="components.ValidationErrors.validation" />
+          {errors.configurationValidationErrors ?
+            <Trans i18nKey="components.ValidationErrors.errors" /> :
+            <Trans i18nKey="components.ValidationErrors.warnings" />
+          }:
           {configErrors.map((error: any, i: any) => <div style={{color: colorMap(error.level)}} key={i}>{`${error.type}: ${error.message}`}</div>)}
         </div>
       }
       {updateErrors &&
         <div className="validation-errors">
-          Update Errors:
+          <Trans i18nKey="components.ValidationErrors.update" />
+          <Trans i18nKey="components.ValidationErrors.errors" />:
           {updateErrors.map((error: any, i: any) => <div style={{color: colorMap(error.level)}} key={i}>{`${error.message}`}</div>)}
         </div>
       }


### PR DESCRIPTION
## Description

Remove the use of MUI in the ValidationErrors component.

## Changes

<!-- List of relevant changes introduced -->

## How Has This Been Tested?

Looking at the 3 options for success, warning and error for a cluster config:

![image](https://user-images.githubusercontent.com/6087509/180596750-4298787c-7ff4-4cf8-8f9f-0bb101382b26.png)

![image](https://user-images.githubusercontent.com/6087509/180596765-6ccf0ba2-ff74-42f2-8856-e8d0a64d2524.png)


## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.