### PR TITLE
Return 4xx in case of unauthenticated/unauthorized requests

### DIFF
--- a/api/tests/test_authenticate.py
+++ b/api/tests/test_authenticate.py
@@ -1,6 +1,7 @@
 import os
 from unittest import mock
 from api.PclusterApiHandler import authenticate
+from jose import jwt
 
 
 @mock.patch.dict(os.environ,{"ENABLE_AUTH": "false"})
@@ -11,3 +12,67 @@ def test_authenticate():
         Then it should do nothing
     """
     assert authenticate('any-group') is None
+
+
+def test_authenticate_with_no_access_token_returns_401(mocker, app):
+    with app.test_request_context():
+        mock_abort = mocker.patch('api.PclusterApiHandler.abort')
+
+        authenticate('any-group')
+
+        mock_abort.assert_called_once_with(401)
+
+
+def test_authenticate_with_expired_signature_returns_401(mocker, app):
+    with app.test_request_context(headers={'Cookie': 'accessToken=access-token'}):
+        mock_abort = mocker.patch('api.PclusterApiHandler.abort')
+        mocker.patch('api.PclusterApiHandler.jwt_decode',
+                     side_effect=jwt.ExpiredSignatureError())
+
+        authenticate('any-group')
+
+        mock_abort.assert_called_once_with(401)
+
+
+def test_authenticate_with_signature_exception_returns_401(mocker, app):
+    with app.test_request_context(headers={'Cookie': 'accessToken=access-token'}):
+        mock_abort = mocker.patch('api.PclusterApiHandler.abort')
+        mocker.patch('api.PclusterApiHandler.jwt_decode',
+                     side_effect=Exception())
+
+        authenticate('any-group')
+
+        mock_abort.assert_called_once_with(401)
+
+
+def test_authenticate_with_non_guest_group_not_in_user_roles_claim_returns_403(mocker, app):
+    with app.test_request_context(headers={'Cookie': 'accessToken=access-token'}):
+        mock_abort = mocker.patch('api.PclusterApiHandler.abort')
+        mocker.patch('api.PclusterApiHandler.jwt_decode',
+                     return_value={'cognito:groups': ['other-group']})
+
+        authenticate('any-group')
+
+        mock_abort.assert_called_once_with(403)
+
+
+def test_authenticate_with_guest_group_succeeds(mocker, app):
+    with app.test_request_context(headers={'Cookie': 'accessToken=access-token'}):
+        mock_abort = mocker.patch('api.PclusterApiHandler.abort')
+        mocker.patch('api.PclusterApiHandler.jwt_decode',
+                     return_value={'cognito:groups': ['other-group']})
+
+        authenticate('guest')
+
+        mock_abort.assert_not_called()
+
+
+def test_authenticate_with_group_in_user_role_claim_succeeds(mocker, app):
+    with app.test_request_context(headers={'Cookie': 'accessToken=access-token'}):
+        mock_abort = mocker.patch('api.PclusterApiHandler.abort')
+        mocker.patch('api.PclusterApiHandler.jwt_decode',
+                     return_value={'cognito:groups': ['my-group']})
+
+        authenticate('my-group')
+
+        mock_abort.assert_not_called()

--- a/api/tests/test_pcluster_api_handler.py
+++ b/api/tests/test_pcluster_api_handler.py
@@ -1,5 +1,5 @@
 from unittest import mock
-from api.PclusterApiHandler import _get_user_roles
+from api.PclusterApiHandler import _get_user_roles, login
 
 
 @mock.patch("api.PclusterApiHandler.USER_ROLES_CLAIM", "user_roles")
@@ -32,3 +32,23 @@ def test_on_successful_login_auth_cookies_are_set(mock_post, client):
         assert "accessToken=testAccessToken; Secure; HttpOnly; Path=/; SameSite=Lax" in cookie_list
         assert "idToken=testIdToken; Secure; HttpOnly; Path=/; SameSite=Lax" in cookie_list
         assert "refreshToken=testRefreshToken; Secure; HttpOnly; Path=/; SameSite=Lax" in cookie_list
+
+
+def test_login_request_with_no_code_return_400(mocker, app):
+    with app.test_request_context('/login'):
+        mock_abort = mocker.patch('api.PclusterApiHandler.abort')
+
+        login()
+
+        mock_abort.assert_called_once_with(400)
+
+
+def test_login_with_no_access_token_returns_401(mocker, app):
+    with app.test_request_context('/login', query_string='code=testCode'):
+        mock_abort = mocker.patch('api.PclusterApiHandler.abort')
+        mock_post = mocker.patch('api.PclusterApiHandler.requests.post')
+        mock_post.return_value.json.return_value = {'access_token': None}
+
+        login()
+
+        mock_abort.assert_called_once_with(401)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests
 python-jose
 pyyaml
 pytest
+pytest-mock


### PR DESCRIPTION
### Notes
This patch makes the API return:
- 400 if the login request does not contain a `code` (in the case of the OIDC provider redirecting the user after a successful login).
- 401 if the access token in the login or authenticate calls is missing.
- 401 if during authentication there is an issue with the signature.
- 403 if during authentication the group is not guest and is not among the groups in the decoded JWT.

### Tests
- Unit tests
- Manual tests with Postman:
  - Invoke a protected API without authentication, expecting 401.
  - Through Postman, get a JWT through Cognito and invoke the same API attaching the JWT of the authentication, and get a 200.
  - Modify a character in the JWT in the central part of the token to generate an invalid signature, expecting 401.
  - Create a user on Cognito that is not assigned to any group, generate a JWT and then expect a 403.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.