### PR TITLE
Cluster List enhancements 

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -4,6 +4,44 @@
       "home": "Home"
     }
   },
+  "cluster": {
+    "list": {
+      "filtering": {
+        "empty": {
+          "title": "No clusters",
+          "subtitle": "No clusters to display",
+          "action": "Create Cluster"
+        },
+        "noMatch": {
+          "title": "No matches",
+          "subtitle": "No clusters match the filters",
+          "action": "Create filter"
+        }
+      },
+      "cols": {
+        "name": "Name",
+        "status": "Status",
+        "version": "Version"
+      },
+      "loadingText": "Loading clusters...",
+      "countText": "Results:",
+      "filteringAriaLabel": "Filter cluster",
+      "splitPanel": {
+        "preferencesTitle": "Split panel preferences",
+        "preferencesPositionLabel": "Split panel position",
+        "preferencesPositionDescription": "Choose the default split panel position for the service.",
+        "preferencesPositionSide": "Side",
+        "preferencesPositionBottom": "Bottom",
+        "preferencesConfirm": "Confirm",
+        "preferencesCancel": "Cancel",
+        "closeButtonAriaLabel": "Close panel",
+        "openButtonAriaLabel": "Open panel",
+        "resizeHandleAriaLabel": "Resize split panel",
+        "noClusterSelectedText": "No cluster selected",
+        "selectClusterText": "Select a cluster to see its details"
+      }
+    }
+  },
   "wizard": {
     "source" : {
       "validation": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -37,6 +37,7 @@
       "devDependencies": {
         "@awsui/jest-preset": "^2.0.5",
         "@testing-library/react": "^12.1.5",
+        "@testing-library/user-event": "^14.3.0",
         "@types/jest": "^28.1.4",
         "@types/lodash": "^4.14.182",
         "@types/node": "^18.0.0",
@@ -3950,6 +3951,19 @@
       "peerDependencies": {
         "react": "<18.0.0",
         "react-dom": "<18.0.0"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.3.0.tgz",
+      "integrity": "sha512-P02xtBBa8yMaLhK8CzJCIns8rqwnF6FxhR9zs810flHOBXUYCFjLd8Io1rQrAkQRWEmW2PGdZIEdMxf/KLsqFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -17343,6 +17357,13 @@
         "@testing-library/dom": "^8.0.0",
         "@types/react-dom": "<18.0.0"
       }
+    },
+    "@testing-library/user-event": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.3.0.tgz",
+      "integrity": "sha512-P02xtBBa8yMaLhK8CzJCIns8rqwnF6FxhR9zs810flHOBXUYCFjLd8Io1rQrAkQRWEmW2PGdZIEdMxf/KLsqFA==",
+      "dev": true,
+      "requires": {}
     },
     "@tootallnate/once": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,6 +55,7 @@
   "devDependencies": {
     "@awsui/jest-preset": "^2.0.5",
     "@testing-library/react": "^12.1.5",
+    "@testing-library/user-event": "^14.3.0",
     "@types/jest": "^28.1.4",
     "@types/lodash": "^4.14.182",
     "@types/node": "^18.0.0",

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -802,7 +802,6 @@ async function LoadInitialState() {
     if(groups && (groups.includes("admin") || groups.includes("user")))
     {
       ListUsers();
-      // @ts-expect-error TS(2554) FIXME: Expected 1 arguments, but got 0.
       ListClusters();
       // @ts-expect-error TS(2554) FIXME: Expected 3 arguments, but got 0.
       ListCustomImages();

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -163,19 +163,18 @@ function DeleteCluster(clusterName: any, callback=null) {
   })
 }
 
-function ListClusters(callback: any) {
+async function ListClusters() {
   var url = 'api?path=/v3/clusters';
-  request('get', url).then((response: any) => {
-    //console.log("List Success", response)
-    if(response.status === 200) {
-      callback && callback(response.data.clusters);
-      setState(['clusters', 'list'], response.data.clusters);
+  try {
+    const { data } = await request('get', url);
+    setState(['clusters', 'list'], data?.clusters);
+    return data?.clusters || [];
+  } catch (error) {
+    if((error as any).response) {
+      notify(`Error: ${(error as any).response.data.message}`, 'error');
     }
-  }).catch((error: any) => {
-    if(error.response)
-      notify(`Error: ${error.response.data.message}`, 'error');
-    console.log(error)
-  });
+    throw error;
+  }
 }
 
 function GetConfiguration(clusterName: any, callback=null) {

--- a/frontend/src/old-pages/Clusters/Clusters.tsx
+++ b/frontend/src/old-pages/Clusters/Clusters.tsx
@@ -15,6 +15,7 @@ import { ListClusters } from '../../model'
 import { useState, clearState, getState, setState, isAdmin } from '../../store'
 import { selectCluster } from './util'
 import { findFirst } from '../../util'
+import { useTranslation } from 'react-i18next';
 
 // UI Elements
 import {
@@ -52,7 +53,6 @@ function updateClusterList(navigate: NavigateFunction) {
 
         if((oldStatus === 'CREATE_IN_PROGRESS' && selectedCluster.clusterStatus === 'CREATE_COMPLETE') ||
           (oldStatus === 'UPDATE_IN_PROGRESS' && selectedCluster.clusterStatus === 'UPDATE_COMPLETE'))
-          // @ts-expect-error TS(2554) FIXME: Expected 2 arguments, but got 1.
           selectCluster(selectedClusterName);
       // If the selected cluster is not found, and was in DELETE_IN_PROGRESS status, deselect it
       } else if (oldStatus === 'DELETE_IN_PROGRESS') {
@@ -68,6 +68,8 @@ function ClusterList() {
   const selectedClusterName = useState(['app', 'clusters', 'selected']);
   let navigate = useNavigate();
   let params = useParams();
+  const { t } = useTranslation();
+
 
   React.useEffect(() => {
     const timerId = (setInterval(() => updateClusterList(navigate), 5000));
@@ -89,16 +91,16 @@ function ClusterList() {
       filtering: {
         empty: (
           <EmptyState
-            title="No clusters"
-            subtitle="No clusters to display."
-            action={<Button onClick={configure} disabled={!isAdmin()}>Create Cluster</Button>}
+            title={t("cluster.list.filtering.empty.title")}
+            subtitle={t("cluster.list.filtering.empty.subtitle")}
+            action={<Button onClick={configure} disabled={!isAdmin()}>{t("cluster.list.filtering.empty.action")}</Button>}
           />
         ),
         noMatch: (
           <EmptyState
-            title="No matches"
-            subtitle="No clusters match the filters."
-            action={<Button onClick={() => actions.setFiltering('')}>Clear filter</Button>}
+            title={t("cluster.list.filtering.noMatch.title")}
+            subtitle={t("cluster.list.filtering.noMatch.subtitle")}
+            action={<Button onClick={() => actions.setFiltering('')}>{t("cluster.list.filtering.noMatch.action")}</Button>}
           />
         ),
       },
@@ -115,19 +117,19 @@ function ClusterList() {
         </Header>} trackBy="clusterName" columnDefinitions={[
         {
             id: "name",
-            header: "Name",
+            header: t("cluster.list.cols.name"),
             cell: item => (item as any).clusterName,
             sortingField: "clusterName"
         },
         {
             id: "status",
-            header: "Status",
+            header: t("cluster.list.cols.status"),
             cell: item => <Status status={(item as any).clusterStatus} cluster={item}/> || "-",
             sortingField: "clusterStatus"
         },
         {
             id: "version",
-            header: "Version",
+            header: t("cluster.list.cols.version"),
             cell: item => (item as any).version || "-"
         }
     
@@ -135,11 +137,11 @@ function ClusterList() {
     loading={clusters === null}
     items={items}
     selectionType="single"
-    loadingText="Loading clusters..."
+    loadingText={t("cluster.list.loadingText")}
     pagination={<Pagination {...paginationProps}/>}
     filter={<TextFilter {...filterProps}
-    countText={`Results: ${filteredItemsCount}`}
-    filteringAriaLabel="Filter cluster"/>}
+    countText={`${t("cluster.list.countText")} ${filteredItemsCount}`}
+    filteringAriaLabel={t("cluster.list.filteringAriaLabel")}/>}
     selectedItems={(items || []).filter((c) => (c as any).clusterName === selectedClusterName)}
     // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
     onSelectionChange={({ detail }) => { navigate(`/clusters/${detail.selectedItems[0].clusterName}`); }}
@@ -153,6 +155,7 @@ export default function Clusters () {
   const clusters = useState(['clusters', 'list']);
   let navigate = useNavigate();
   const [ splitOpen, setSplitOpen ] = React.useState(true);
+  const { t } = useTranslation();
 
   const configure = () => {
     wizardShow(navigate);
@@ -176,17 +179,16 @@ export default function Clusters () {
         <SplitPanel
           className="bottom-panel"
           i18nStrings={{
-            preferencesTitle: "Split panel preferences",
-            preferencesPositionLabel: "Split panel position",
-            preferencesPositionDescription:
-            "Choose the default split panel position for the service.",
-            preferencesPositionSide: "Side",
-            preferencesPositionBottom: "Bottom",
-            preferencesConfirm: "Confirm",
-            preferencesCancel: "Cancel",
-            closeButtonAriaLabel: "Close panel",
-            openButtonAriaLabel: "Open panel",
-            resizeHandleAriaLabel: "Resize split panel"
+            preferencesTitle: t("cluster.list.splitPanel.preferencesTitle"),
+            preferencesPositionLabel: t("cluster.list.splitPanel.preferencesPositionLabel"),
+            preferencesPositionDescription: t("cluster.list.splitPanel.preferencesPositionDescription"),
+            preferencesPositionSide: t("cluster.list.splitPanel.preferencesPositionSide"),
+            preferencesPositionBottom: t("cluster.list.splitPanel.preferencesPositionBottom"),
+            preferencesConfirm: t("cluster.list.splitPanel.preferencesConfirm"),
+            preferencesCancel: t("cluster.list.splitPanel.preferencesCancel"),
+            closeButtonAriaLabel: t("cluster.list.splitPanel.closeButtonAriaLabel"),
+            openButtonAriaLabel: t("cluster.list.splitPanel.openButtonAriaLabel"),
+            resizeHandleAriaLabel: t("cluster.list.splitPanel.resizeHandleAriaLabel"),
           }}
           // @ts-expect-error TS(2322) FIXME: Type 'Element' is not assignable to type 'string'.
           header={
@@ -194,10 +196,10 @@ export default function Clusters () {
               variant="h2"
               // @ts-expect-error TS(2322) FIXME: Type '{ className: string; }' is not assignable to... Remove this comment to see the full error message
               actions={cluster && <Actions className="spacer" />}>
-              {clusterName ? `Cluster: ${clusterName}` : "No cluster selected" }
+              {clusterName ? `Cluster: ${clusterName}` : t("cluster.list.splitPanel.noClusterSelectedText") }
             </Header>
           }>
-          {clusterName ? <Details /> : <div>Select a cluster to see its details.</div>}
+          {clusterName ? <Details /> : <div>{t("cluster.list.splitPanel.selectClusterText")}</div>}
         </SplitPanel>
       }
       content={<ClusterList />

--- a/frontend/src/old-pages/Clusters/Clusters.tsx
+++ b/frontend/src/old-pages/Clusters/Clusters.tsx
@@ -34,7 +34,7 @@ import Details from "./Details";
 import { wizardShow } from '../Configure/Configure';
 
 
-interface Cluster {
+export interface Cluster {
   cloudformationStackArn: string,
   cloudformationStackStatus: string,
   clusterName: string,
@@ -86,7 +86,7 @@ function ClusterList({ clusters }: ClusterListProps) {
   React.useEffect(() => {
     if(params.clusterName && selectedClusterName !== params.clusterName)
       selectCluster(params.clusterName, navigate);
-  }, [selectedClusterName, params])
+  }, [selectedClusterName, params, navigate])
 
   const configure = () => {
     wizardShow(navigate);
@@ -158,14 +158,9 @@ function ClusterList({ clusters }: ClusterListProps) {
 export default function Clusters () {
   const clusterName = useState(['app', 'clusters', 'selected']);
   const cluster = useState(['clusters', 'index', clusterName]);
-  let navigate = useNavigate();
   const [ splitOpen, setSplitOpen ] = React.useState(true);
   const { t } = useTranslation();
   const { data } = useQuery('LIST_CLUSTERS', () => ListClusters());
-
-  const configure = () => {
-    wizardShow(navigate);
-  }
 
   return (
     <AppLayout

--- a/frontend/src/old-pages/Clusters/__tests__/Clusters.test.tsx
+++ b/frontend/src/old-pages/Clusters/__tests__/Clusters.test.tsx
@@ -96,7 +96,6 @@ describe('given a component to show the clusters list', () => {
           </MockProviders>
         ))       
         
-        //await userEvent.click(output.getByRole('button', {name: /Create Cluster/i}))
         await userEvent.click(output.getByText('Create Cluster'))
         expect(mockedUseNavigate).toHaveBeenCalledWith('/configure')
       })

--- a/frontend/src/old-pages/Clusters/__tests__/Clusters.test.tsx
+++ b/frontend/src/old-pages/Clusters/__tests__/Clusters.test.tsx
@@ -1,0 +1,121 @@
+import { ThemeProvider } from '@emotion/react'
+import { createTheme } from '@mui/material'
+import { render, waitFor, screen, prettyDOM } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SnackbarProvider } from 'notistack'
+import { I18nextProvider } from 'react-i18next'
+import { QueryClient, QueryClientProvider } from 'react-query'
+import { Provider } from 'react-redux'
+import { BrowserRouter, useNavigate } from 'react-router-dom'
+import i18n from '../../../i18n'
+import { ListClusters } from '../../../model'
+import { store, isAdmin } from '../../../store'
+import Clusters from '../Clusters'
+
+
+const queryClient = new QueryClient();
+const mockClusters = [{
+  clusterName: 'test-cluster',
+  clusterStatus: 'CREATE_COMPLETE',
+  version: '3.1.4',
+  cloudformationStackArn: 'arn',
+  region: 'region',
+  cloudformationStackStatus: 'status'
+}];
+
+const MockProviders = (props: any) => (
+  <QueryClientProvider client={queryClient}>
+    <I18nextProvider i18n={i18n}>
+      <Provider store={store}>
+        <ThemeProvider theme={createTheme()}>
+          <SnackbarProvider>
+            <BrowserRouter>
+              {props.children}
+            </BrowserRouter>
+          </SnackbarProvider>
+        </ThemeProvider>
+      </Provider>
+    </I18nextProvider>
+  </QueryClientProvider>
+)
+
+jest.mock('../../../model', () => ({
+  ListClusters: jest.fn(),
+}));
+
+jest.mock('../../../store', () => ({
+  ...jest.requireActual('../../../store') as any,
+  isAdmin: () => true,
+}));
+
+const mockedUseNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+   ...jest.requireActual('react-router-dom') as any,
+  useNavigate: () => mockedUseNavigate,
+}));
+
+describe('given a component to show the clusters list', () => {
+
+  describe('when the clusters list is available', () => {
+    beforeEach(() => {
+      (ListClusters as jest.Mock).mockResolvedValue(mockClusters);
+      mockedUseNavigate.mockReset();
+    });
+
+    it('should render the clusters', async () => {
+      const { getByText } = await waitFor(() => render(
+        <MockProviders>
+          <Clusters />
+        </MockProviders>
+      ))   
+
+      expect(getByText('test-cluster')).toBeTruthy()
+      expect(getByText('CREATE COMPLETE')).toBeTruthy()
+      expect(getByText('3.1.4')).toBeTruthy()
+    })
+
+    describe('when the user selects a cluster', () => { 
+      it('should populate the split panel', async () => {
+        const output = await waitFor(() => render(
+          <MockProviders>
+            <Clusters />
+          </MockProviders>
+        ))       
+        
+        await userEvent.click(output.getByRole('radio'))
+        expect(mockedUseNavigate).toHaveBeenCalledWith('/clusters/test-cluster')
+      })
+    })
+
+    describe('when the user clicks on "Create Cluster" button', () => {
+      it('should redirect to configure', async () => {
+        const output = await waitFor(() => render(
+          <MockProviders>
+            <Clusters />
+          </MockProviders>
+        ))       
+        
+        //await userEvent.click(output.getByRole('button', {name: /Create Cluster/i}))
+        await userEvent.click(output.getByText('Create Cluster'))
+        expect(mockedUseNavigate).toHaveBeenCalledWith('/configure')
+      })
+    })
+  })
+  
+  describe('when there are no clusters available', () => {
+    beforeEach(() => {
+      (ListClusters as jest.Mock).mockResolvedValue([]);
+    });
+
+    it('should show the empty state', async () => {
+      const { getByText } = await waitFor(() => render(
+        <MockProviders>
+          <Clusters />
+        </MockProviders>
+      ))
+
+      expect(getByText('No clusters to display')).toBeTruthy()
+    }) 
+  }) 
+})

--- a/frontend/src/old-pages/Configure/Create.tsx
+++ b/frontend/src/old-pages/Configure/Create.tsx
@@ -57,7 +57,6 @@ function handleCreate(handleClose: any, navigate: any) {
     // @ts-expect-error TS(2554) FIXME: Expected 2 arguments, but got 1.
     DescribeCluster(clusterName)
     setState(['app', 'clusters', 'selected'], clusterName);
-    // @ts-expect-error TS(2554) FIXME: Expected 1 arguments, but got 0.
     ListClusters();
     handleClose();
     navigate(href);


### PR DESCRIPTION
## Description

Rewrite Cluster list page incorporating a list of best-practices enhancements.

## Changes
* Added i18n strings
* Leveraged userQuery in ListClusters() function
* Removed TS errors
* Added unit tests for `Clusters.tsx` 

## How Has This Been Tested?
`npm run dev` opened and navigated in cluster list page 

```
$ npm run test
Test Suites: 3 passed, 3 total
Tests:       18 passed, 18 total
Snapshots:   0 total
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.