### PR TITLE
Redirect to authorization server upon 401/403 status codes

### DIFF
--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -154,7 +154,7 @@ def get_scopes_list():
     return SCOPES_LIST + " openid"
   return SCOPES_LIST
 
-def get_redirect_url():
+def get_redirect_uri():
   return f"{SITE_URL}/login"
   
 # Local Endpoints
@@ -165,10 +165,10 @@ def get_version():
 
 def get_app_config():
   return {
-    "auth_path": AUTH_PATH,
+    "auth_url": AUTH_URL,
     "client_id": CLIENT_ID,
     "scopes": get_scopes_list(),
-    "redirect_url": get_redirect_url()
+    "redirect_uri": get_redirect_uri()
   }
 
 def ec2_action():
@@ -654,7 +654,7 @@ def login():
     url = TOKEN_URL
     code_resp = requests.post(
         url,
-        data={"grant_type": grant_type, "code": code, "client_id": CLIENT_ID, "redirect_uri": get_redirect_url()},
+        data={"grant_type": grant_type, "code": code, "client_id": CLIENT_ID, "redirect_uri": get_redirect_uri()},
         auth=auth,
         headers={"Content-Type": "application/x-www-form-urlencoded"},
     )

--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -42,7 +42,6 @@ AUTH_URL = os.getenv("AUTH_URL", f"{AUTH_PATH}/login")
 JWKS_URL = os.getenv("JWKS_URL")
 AUDIENCE = os.getenv("AUDIENCE")
 USER_ROLES_CLAIM = os.getenv("USER_ROLES_CLAIM", "cognito:groups")
-REDIRECT_URL = f"{SITE_URL}/login"
 
 try:
     if (not USER_POOL_ID or USER_POOL_ID == "") and SECRET_ID:
@@ -54,18 +53,9 @@ try:
 except Exception:
     pass
 
-if not SCOPES_LIST:
-    SCOPES_LIST = "openid"
-elif "openid" not in SCOPES_LIST:
-    SCOPES_LIST += " openid"
 if not JWKS_URL:
     JWKS_URL = os.getenv("JWKS_URL",
                          f"https://cognito-idp.{REGION}.amazonaws.com/{USER_POOL_ID}/" ".well-known/jwks.json")
-
-AUTH_URL_WITH_PARAMS = f"{AUTH_URL}?response_type=code&client_id={CLIENT_ID}" \
-                       f"&scope={SCOPES_LIST}" \
-                       f"&redirect_uri={REDIRECT_URL} "
-
 
 def jwt_decode(token, audience=None, access_token=None):
     return jwt.decode(token, requests.get(JWKS_URL).json(), audience=audience, access_token=access_token)
@@ -127,11 +117,6 @@ def sigv4_request(method, host, path, params={}, headers={}, body=None):
 
 # Wrappers
 
-
-def auth_redirect():
-    return redirect(AUTH_URL_WITH_PARAMS, code=302)
-
-
 def authenticate(group):
     if disable_auth():
         return
@@ -162,13 +147,29 @@ def authenticated(group="user"):
 
     return _authenticated
 
+def get_scopes_list():
+  if not SCOPES_LIST:
+    return "openid"
+  elif "openid" not in SCOPES_LIST:
+    return SCOPES_LIST + " openid"
+  return SCOPES_LIST
 
+def get_redirect_url():
+  return f"{SITE_URL}/login"
+  
 # Local Endpoints
 
 
 def get_version():
     return {"version": API_VERSION, "enable_mfa": ENABLE_MFA == "true"}
 
+def get_app_config():
+  return {
+    "auth_path": AUTH_PATH,
+    "client_id": CLIENT_ID,
+    "scopes": get_scopes_list(),
+    "redirect_url": get_redirect_url()
+  }
 
 def ec2_action():
     if request.args.get("region"):
@@ -653,7 +654,7 @@ def login():
     url = TOKEN_URL
     code_resp = requests.post(
         url,
-        data={"grant_type": grant_type, "code": code, "client_id": CLIENT_ID, "redirect_uri": REDIRECT_URL},
+        data={"grant_type": grant_type, "code": code, "client_id": CLIENT_ID, "redirect_uri": get_redirect_url()},
         auth=auth,
         headers={"Content-Type": "application/x-www-form-urlencoded"},
     )

--- a/api/tests/test_get_app_config.py
+++ b/api/tests/test_get_app_config.py
@@ -6,15 +6,15 @@ def test_get_app_config(monkeypatch):
       When authentication variables are set
         Then it should return a the application config
     """
-    monkeypatch.setattr('api.PclusterApiHandler.AUTH_PATH', 'some-path')
+    monkeypatch.setattr('api.PclusterApiHandler.AUTH_URL', 'some-url')
     monkeypatch.setattr('api.PclusterApiHandler.CLIENT_ID', 'some-id')
     monkeypatch.setattr('api.PclusterApiHandler.SCOPES_LIST', 'some-scope')
     monkeypatch.setattr('api.PclusterApiHandler.SITE_URL', 'some-url')
     assert get_app_config() == {
-        "auth_path": 'some-path',
+        "auth_url": 'some-url',
         "client_id": 'some-id',
         "scopes": 'some-scope openid',
-        "redirect_url": 'some-url/login'
+        "redirect_uri": 'some-url/login'
     }
 
 def test_get_app_config_with_empty_scopes_list(monkeypatch):
@@ -23,15 +23,15 @@ def test_get_app_config_with_empty_scopes_list(monkeypatch):
       When the scopes list is empty
         Then it should return openid as scope
     """
-    monkeypatch.setattr('api.PclusterApiHandler.AUTH_PATH', 'some-path')
+    monkeypatch.setattr('api.PclusterApiHandler.AUTH_URL', 'some-url')
     monkeypatch.setattr('api.PclusterApiHandler.CLIENT_ID', 'some-id')
     monkeypatch.setattr('api.PclusterApiHandler.SCOPES_LIST', '')
     monkeypatch.setattr('api.PclusterApiHandler.SITE_URL', 'some-url')
     assert get_app_config() == {
-        "auth_path": 'some-path',
+        "auth_url": 'some-url',
         "client_id": 'some-id',
         "scopes": 'openid',
-        "redirect_url": 'some-url/login'
+        "redirect_uri": 'some-url/login'
     }
 
 def test_get_app_config_with_openid_as_scope(monkeypatch):
@@ -40,13 +40,13 @@ def test_get_app_config_with_openid_as_scope(monkeypatch):
       When the scopes list contains openid
         Then it should return thes scopes list as is
     """
-    monkeypatch.setattr('api.PclusterApiHandler.AUTH_PATH', 'some-path')
+    monkeypatch.setattr('api.PclusterApiHandler.AUTH_URL', 'some-url')
     monkeypatch.setattr('api.PclusterApiHandler.CLIENT_ID', 'some-id')
     monkeypatch.setattr('api.PclusterApiHandler.SCOPES_LIST', 'some-scope openid')
     monkeypatch.setattr('api.PclusterApiHandler.SITE_URL', 'some-url')
     assert get_app_config() == {
-        "auth_path": 'some-path',
+        "auth_url": 'some-url',
         "client_id": 'some-id',
         "scopes": 'some-scope openid',
-        "redirect_url": 'some-url/login'
+        "redirect_uri": 'some-url/login'
     }

--- a/api/tests/test_get_app_config.py
+++ b/api/tests/test_get_app_config.py
@@ -1,0 +1,52 @@
+from api.PclusterApiHandler import get_app_config
+
+def test_get_app_config(monkeypatch):
+    """
+    Given an handler for the /get-app-config endpoint
+      When authentication variables are set
+        Then it should return a the application config
+    """
+    monkeypatch.setattr('api.PclusterApiHandler.AUTH_PATH', 'some-path')
+    monkeypatch.setattr('api.PclusterApiHandler.CLIENT_ID', 'some-id')
+    monkeypatch.setattr('api.PclusterApiHandler.SCOPES_LIST', 'some-scope')
+    monkeypatch.setattr('api.PclusterApiHandler.SITE_URL', 'some-url')
+    assert get_app_config() == {
+        "auth_path": 'some-path',
+        "client_id": 'some-id',
+        "scopes": 'some-scope openid',
+        "redirect_url": 'some-url/login'
+    }
+
+def test_get_app_config_with_empty_scopes_list(monkeypatch):
+    """
+    Given an handler for the /get-app-config endpoint
+      When the scopes list is empty
+        Then it should return openid as scope
+    """
+    monkeypatch.setattr('api.PclusterApiHandler.AUTH_PATH', 'some-path')
+    monkeypatch.setattr('api.PclusterApiHandler.CLIENT_ID', 'some-id')
+    monkeypatch.setattr('api.PclusterApiHandler.SCOPES_LIST', '')
+    monkeypatch.setattr('api.PclusterApiHandler.SITE_URL', 'some-url')
+    assert get_app_config() == {
+        "auth_path": 'some-path',
+        "client_id": 'some-id',
+        "scopes": 'openid',
+        "redirect_url": 'some-url/login'
+    }
+
+def test_get_app_config_with_openid_as_scope(monkeypatch):
+    """
+    Given an handler for the /get-app-config endpoint
+      When the scopes list contains openid
+        Then it should return thes scopes list as is
+    """
+    monkeypatch.setattr('api.PclusterApiHandler.AUTH_PATH', 'some-path')
+    monkeypatch.setattr('api.PclusterApiHandler.CLIENT_ID', 'some-id')
+    monkeypatch.setattr('api.PclusterApiHandler.SCOPES_LIST', 'some-scope openid')
+    monkeypatch.setattr('api.PclusterApiHandler.SITE_URL', 'some-url')
+    assert get_app_config() == {
+        "auth_path": 'some-path',
+        "client_id": 'some-id',
+        "scopes": 'some-scope openid',
+        "redirect_url": 'some-url/login'
+    }

--- a/app.py
+++ b/app.py
@@ -25,6 +25,7 @@ from api.PclusterApiHandler import (
     create_user,
     delete_user,
     ec2_action,
+    get_app_config,
     get_aws_config,
     get_cluster_config,
     get_custom_image_config,
@@ -117,6 +118,10 @@ def run():
     @app.route("/manager/get_version")
     def get_version_():
         return get_version()
+
+    @app.route("/manager/get_app_config")
+    def get_app_config_():
+        return get_app_config()
 
     @app.route("/manager/list_users")
     @authenticated("admin")

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "axios": "^0.21.4",
         "i18next": "^21.8.13",
         "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
         "next": "^12.2.0",
         "next-transpile-modules": "^9.0.0",
         "notistack": "^2.0.2",
@@ -37,13 +38,13 @@
         "@awsui/jest-preset": "^2.0.5",
         "@testing-library/react": "^12.1.5",
         "@types/jest": "^28.1.4",
+        "@types/lodash": "^4.14.182",
         "@types/node": "^18.0.0",
         "eslint": "^8.19.0",
         "eslint-config-next": "12.2.0",
         "jest": "^28.1.2",
         "jest-environment-jsdom": "^28.1.2",
         "jest-mock-extended": "^2.0.6",
-        "lodash": "^4.17.21",
         "ts-migrate": "^0.1.30",
         "typescript": "^4.7.4"
       }
@@ -4149,6 +4150,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.182",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
+      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -10517,8 +10524,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -17527,6 +17533,12 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.182",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
+      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
+      "dev": true
+    },
     "@types/node": {
       "version": "18.0.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
@@ -22385,8 +22397,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "axios": "^0.21.4",
     "i18next": "^21.8.13",
     "js-yaml": "^4.1.0",
+    "lodash": "^4.17.21",
     "next": "^12.2.0",
     "next-transpile-modules": "^9.0.0",
     "notistack": "^2.0.2",
@@ -54,13 +55,13 @@
     "@awsui/jest-preset": "^2.0.5",
     "@testing-library/react": "^12.1.5",
     "@types/jest": "^28.1.4",
+    "@types/lodash": "^4.14.182",
     "@types/node": "^18.0.0",
     "eslint": "^8.19.0",
     "eslint-config-next": "12.2.0",
     "jest": "^28.1.2",
     "jest-environment-jsdom": "^28.1.2",
     "jest-mock-extended": "^2.0.6",
-    "lodash": "^4.17.21",
     "ts-migrate": "^0.1.30",
     "typescript": "^4.7.4"
   }

--- a/frontend/src/app-config/__tests__/index.test.ts
+++ b/frontend/src/app-config/__tests__/index.test.ts
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { AxiosInstance } from "axios"
+import { mock, MockProxy } from "jest-mock-extended"
+import { getAppConfig } from ".."
+
+describe('given a function to fetch the application configuration', () => {
+  describe('and an axios instance', () => {
+    let mockGet: jest.Mock;
+    let mockAxiosInstance: MockProxy<AxiosInstance>;
+    beforeEach(() => {
+      mockGet = jest.fn()
+      mockAxiosInstance = mock<AxiosInstance>()
+    })
+    describe('when the configuration is available', () => {
+      beforeEach(() => {
+        const mockAppConfig = {
+          auth_path: 'some-path',
+          client_id: 'some-id',
+          scopes: 'some-list',
+          redirect_url: 'some-url',
+        }
+        mockAxiosInstance.get.mockResolvedValueOnce({data: mockAppConfig})
+      })
+      it('should map the received configuration to the known AppConfig', async () => {
+        const config = await getAppConfig(mockAxiosInstance)
+        expect(config).toEqual({
+          authPath: 'some-path',
+          clientId: 'some-id',
+          redirectUrl: 'some-url',
+          scopes: 'some-list'
+        })
+      })
+    })
+  })
+})

--- a/frontend/src/app-config/__tests__/index.test.ts
+++ b/frontend/src/app-config/__tests__/index.test.ts
@@ -23,19 +23,19 @@ describe('given a function to fetch the application configuration', () => {
     describe('when the configuration is available', () => {
       beforeEach(() => {
         const mockAppConfig = {
-          auth_path: 'some-path',
+          auth_url: 'some-url',
           client_id: 'some-id',
           scopes: 'some-list',
-          redirect_url: 'some-url',
+          redirect_uri: 'some-uri',
         }
         mockAxiosInstance.get.mockResolvedValueOnce({data: mockAppConfig})
       })
       it('should map the received configuration to the known AppConfig', async () => {
         const config = await getAppConfig(mockAxiosInstance)
         expect(config).toEqual({
-          authPath: 'some-path',
+          authUrl: 'some-url',
           clientId: 'some-id',
-          redirectUrl: 'some-url',
+          redirectUri: 'some-uri',
           scopes: 'some-list'
         })
       })

--- a/frontend/src/app-config/index.ts
+++ b/frontend/src/app-config/index.ts
@@ -12,17 +12,17 @@ import { AxiosInstance } from "axios";
 import { AppConfig } from "./types";
 
 interface RawAppConfig {
-  auth_path: string;
+  auth_url: string;
   client_id: string;
   scopes: string;
-  redirect_url: string;
+  redirect_uri: string;
 }
 
 function mapAppConfig(data: RawAppConfig): AppConfig {
   return {
-    authPath: data.auth_path,
+    authUrl: data.auth_url,
     clientId: data.client_id,
-    redirectUrl: data.redirect_url,
+    redirectUri: data.redirect_uri,
     scopes: data.scopes,
   }
 }

--- a/frontend/src/app-config/index.ts
+++ b/frontend/src/app-config/index.ts
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { AxiosInstance } from "axios";
+import { AppConfig } from "./types";
+
+interface RawAppConfig {
+  auth_path: string;
+  client_id: string;
+  scopes: string;
+  redirect_url: string;
+}
+
+function mapAppConfig(data: RawAppConfig): AppConfig {
+  return {
+    authPath: data.auth_path,
+    clientId: data.client_id,
+    redirectUrl: data.redirect_url,
+    scopes: data.scopes,
+  }
+}
+
+export async function getAppConfig(axiosInstance: AxiosInstance): Promise<AppConfig | {}> {
+  const { data } = await axiosInstance.get('manager/get_app_config');
+  return data ? mapAppConfig(data) : {}
+}

--- a/frontend/src/app-config/types.ts
+++ b/frontend/src/app-config/types.ts
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+export interface AppConfig {
+  authPath: string;
+  clientId: string;
+  scopes: string;
+  redirectUrl: string;
+}

--- a/frontend/src/app-config/types.ts
+++ b/frontend/src/app-config/types.ts
@@ -9,8 +9,8 @@
 // limitations under the License.
 
 export interface AppConfig {
-  authPath: string;
+  authUrl: string;
   clientId: string;
   scopes: string;
-  redirectUrl: string;
+  redirectUri: string;
 }

--- a/frontend/src/auth/__tests__/handleNotAuthorizedErrors.test.ts
+++ b/frontend/src/auth/__tests__/handleNotAuthorizedErrors.test.ts
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { AppConfig } from '../../app-config/types';
+import { handleNotAuthorizedErrors } from "../handleNotAuthorizedErrors"
+
+delete (global.window as any).location;
+global.window.location = { replace: jest.fn() } as any;
+
+describe('given the application config', () => {
+  let mockAppConfig: AppConfig
+
+  beforeEach(() => {
+    mockAppConfig = {
+      authPath: 'some-path',
+      clientId: 'some-id',
+      redirectUrl: 'some-url',
+      scopes: 'some-list'
+    }
+  })
+
+  describe('and an HTTP request promise', () => {
+    let mockRequestPromise: Promise<any>
+    let rejectPromise: any
+
+    describe('when the request fails with 401', () => {
+      beforeEach(() => {
+        mockRequestPromise = new Promise((resolve, reject) => {
+          rejectPromise = reject
+        })
+      })
+      it('should redirect to the authorization server', () => {
+        handleNotAuthorizedErrors(mockAppConfig)(mockRequestPromise).catch(() => {
+            expect(global.window.location.replace).toHaveBeenCalledTimes(1)
+            expect(global.window.location.replace).toHaveBeenCalledWith('some-path/login?response_type=code&client_id=some-id&scope=some-list&redirect_uri=some-url')
+          })
+
+        rejectPromise({ response: { status: 401 } })
+      })
+    })
+  })
+})

--- a/frontend/src/auth/__tests__/handleNotAuthorizedErrors.test.ts
+++ b/frontend/src/auth/__tests__/handleNotAuthorizedErrors.test.ts
@@ -39,7 +39,7 @@ describe('given the application config', () => {
       it('should redirect to the authorization server', () => {
         handleNotAuthorizedErrors(mockAppConfig)(mockRequestPromise).catch(() => {
             expect(global.window.location.replace).toHaveBeenCalledTimes(1)
-            expect(global.window.location.replace).toHaveBeenCalledWith('some-path/login?response_type=code&client_id=some-id&scope=some-list&redirect_uri=some-url')
+            expect(global.window.location.replace).toHaveBeenCalledWith('some-path?response_type=code&client_id=some-id&scope=some-list&redirect_uri=some-url')
           })
 
         rejectPromise({ response: { status: 401 } })

--- a/frontend/src/auth/__tests__/handleNotAuthorizedErrors.test.ts
+++ b/frontend/src/auth/__tests__/handleNotAuthorizedErrors.test.ts
@@ -19,9 +19,9 @@ describe('given the application config', () => {
 
   beforeEach(() => {
     mockAppConfig = {
-      authPath: 'some-path',
+      authUrl: 'some-url',
       clientId: 'some-id',
-      redirectUrl: 'some-url',
+      redirectUri: 'some-uri',
       scopes: 'some-list'
     }
   })
@@ -39,7 +39,7 @@ describe('given the application config', () => {
       it('should redirect to the authorization server', () => {
         handleNotAuthorizedErrors(mockAppConfig)(mockRequestPromise).catch(() => {
             expect(global.window.location.replace).toHaveBeenCalledTimes(1)
-            expect(global.window.location.replace).toHaveBeenCalledWith('some-path?response_type=code&client_id=some-id&scope=some-list&redirect_uri=some-url')
+            expect(global.window.location.replace).toHaveBeenCalledWith('some-url?response_type=code&client_id=some-id&scope=some-list&redirect_uri=some-uri')
           })
 
         rejectPromise({ response: { status: 401 } })

--- a/frontend/src/auth/handleNotAuthorizedErrors.ts
+++ b/frontend/src/auth/handleNotAuthorizedErrors.ts
@@ -20,6 +20,7 @@ export const handleNotAuthorizedErrors = ({authPath, clientId, scopes, redirectU
           redirectToAuthServer(authPath, clientId, scopes, redirectUrl)
           return Promise.reject(error)
       }
+      return Promise.reject(error)
     }
   )
 }

--- a/frontend/src/auth/handleNotAuthorizedErrors.ts
+++ b/frontend/src/auth/handleNotAuthorizedErrors.ts
@@ -11,13 +11,13 @@
 import { AxiosError } from 'axios';
 import { AppConfig } from '../app-config/types';
 
-export const handleNotAuthorizedErrors = ({authPath, clientId, scopes, redirectUrl}: AppConfig) => async (requestPromise: Promise<any>) => {
+export const handleNotAuthorizedErrors = ({authUrl, clientId, scopes, redirectUri}: AppConfig) => async (requestPromise: Promise<any>) => {
   return requestPromise.catch(
     error => {
       switch ((error as AxiosError).response?.status) {
         case 401:
         case 403:
-          redirectToAuthServer(authPath, clientId, scopes, redirectUrl)
+          redirectToAuthServer(authUrl, clientId, scopes, redirectUri)
           return Promise.reject(error)
       }
       return Promise.reject(error)
@@ -25,7 +25,7 @@ export const handleNotAuthorizedErrors = ({authPath, clientId, scopes, redirectU
   )
 }
 
-function redirectToAuthServer(authPath: string, clientId: string, scopes: string, redirectUrl: string) {
-  const url = `${authPath}?response_type=code&client_id=${clientId}&scope=${encodeURIComponent(scopes)}&redirect_uri=${redirectUrl}`
+function redirectToAuthServer(authUrl: string, clientId: string, scopes: string, redirectUri: string) {
+  const url = `${authUrl}?response_type=code&client_id=${clientId}&scope=${encodeURIComponent(scopes)}&redirect_uri=${redirectUri}`
   window.location.replace(url)
 }

--- a/frontend/src/auth/handleNotAuthorizedErrors.ts
+++ b/frontend/src/auth/handleNotAuthorizedErrors.ts
@@ -26,6 +26,6 @@ export const handleNotAuthorizedErrors = ({authPath, clientId, scopes, redirectU
 }
 
 function redirectToAuthServer(authPath: string, clientId: string, scopes: string, redirectUrl: string) {
-  const url = `${authPath}/login?response_type=code&client_id=${clientId}&scope=${encodeURIComponent(scopes)}&redirect_uri=${redirectUrl}`
+  const url = `${authPath}?response_type=code&client_id=${clientId}&scope=${encodeURIComponent(scopes)}&redirect_uri=${redirectUrl}`
   window.location.replace(url)
 }

--- a/frontend/src/auth/handleNotAuthorizedErrors.ts
+++ b/frontend/src/auth/handleNotAuthorizedErrors.ts
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { AxiosError } from 'axios';
+import { AppConfig } from '../app-config/types';
+
+export const handleNotAuthorizedErrors = ({authPath, clientId, scopes, redirectUrl}: AppConfig) => async (requestPromise: Promise<any>) => {
+  return requestPromise.catch(
+    error => {
+      switch ((error as AxiosError).response?.status) {
+        case 401:
+        case 403:
+          redirectToAuthServer(authPath, clientId, scopes, redirectUrl)
+          return Promise.reject(error)
+      }
+    }
+  )
+}
+
+function redirectToAuthServer(authPath: string, clientId: string, scopes: string, redirectUrl: string) {
+  const url = `${authPath}/login?response_type=code&client_id=${clientId}&scope=${encodeURIComponent(scopes)}&redirect_uri=${redirectUrl}`
+  window.location.replace(url)
+}

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -16,6 +16,14 @@ import { USER_ROLES_CLAIM } from './auth/constants';
 
 // UI Elements
 import Button from '@mui/material/Button';
+import { handleNotAuthorizedErrors } from './auth/handleNotAuthorizedErrors';
+import { AppConfig } from './app-config/types';
+import identityFn from 'lodash/identity';
+import { getAppConfig } from './app-config';
+
+const axiosInstance = axios.create({
+  baseURL: getHost(),
+});
 
 function notify(text: any, type = 'info', duration = 5000, dismissButton = false) {
   // @ts-expect-error TS(2556) FIXME: A spread argument must either have a tuple type or... Remove this comment to see the full error message
@@ -36,21 +44,23 @@ function getHost() {
   return '/';
 }
 
-function request(method: any, url: any, body = null) {
-  let host = getHost();
+type HTTPMethod = 'get' | 'put' | 'post' | 'patch' | 'delete'
 
-  // @ts-expect-error TS(7052) FIXME: Element implicitly has an 'any' type because type ... Remove this comment to see the full error message
-  const requestFunc = {'put': axios.put,
-    'post': axios.post,
-    'get': axios.get,
-    'patch': axios.patch,
-    'delete': axios.delete}[method]
+function request(method: HTTPMethod, url: string, body = undefined) {
+  const requestFunc = {'put': axiosInstance.put,
+    'post': axiosInstance.post,
+    'get': axiosInstance.get,
+    'patch': axiosInstance.patch,
+    'delete': axiosInstance.delete}[method]
 
+  const appConfig: AppConfig = getState(['app', 'appConfig'])
   const region = getState(['app', 'selectedRegion']);
-  url = host + ((region && !url.includes('region')) ? (url.includes('?') ? `${url}&region=${region}` : `${url}?region=${region}` ) : url)
+  url = (region && !url.includes('region')) ? (url.includes('?') ? `${url}&region=${region}` : `${url}?region=${region}` ) : url
   const headers = {"Content-Type": "application/json"}
 
-  return requestFunc(url, body, headers)
+  const handle401and403 = appConfig ? handleNotAuthorizedErrors(appConfig) : identityFn<Promise<any>>
+
+  return handle401and403(requestFunc(url, body, {headers}))
 }
 
 function CreateCluster(clusterName: any, clusterConfig: any, region: any, disableRollback=false, dryrun=false, successCallback=null, errorCallback=null) {
@@ -753,12 +763,13 @@ function SlurmAccounting(clusterName: any, instanceId: any, user: any, args: any
 
 function GetIdentity(callback: any) {
   const url = "manager/get_identity"
-  axios.get(getHost() + url).then(response => {
+  request('get', url).then(response => {
     if(response.status === 200) {
       setState(['identity'], response.data);
       callback && callback(response.data)
     }
-  }).catch(error => {
+  })
+  .catch(error => {
     if(error.response)
     {
       console.log(error.response)
@@ -768,11 +779,25 @@ function GetIdentity(callback: any) {
   })
 }
 
-function LoadInitialState() {
+async function GetAppConfig() {
+  try {
+    const appConfig = await getAppConfig(axiosInstance)
+    setState(['app', 'appConfig'], appConfig);
+    return appConfig;
+  } catch (error) {
+    if((error as any).response) {
+      notify(`Error: ${(error as any).response.data.message}`, 'error');
+    }
+    throw error;
+  }
+}
+
+async function LoadInitialState() {
   const region = getState(['app', 'selectedRegion']);
   clearState(['app', 'aws']);
   clearAllState();
   GetVersion();
+  await GetAppConfig()
   GetIdentity((identity: any) => {
     let groups = identity[USER_ROLES_CLAIM];
     if(groups && (groups.includes("admin") || groups.includes("user")))


### PR DESCRIPTION
## Description

This PR makes it so the frontend redirects unauthenticated or unauthorized users to the authorization server. As it is now, it basically replicates the behavior that [was previously on the backend](https://github.com/aws-samples/pcluster-manager/pull/216)

## Changes

- Add `/get-app-config` route to share environment variables (and possibly other configs) to the client
- Add decorator over the `request` function to intercept 401/403 errors and redirect the user to the authorization server

## How Has This Been Tested?

- Manually, creation and deletion of a cluster
- Jest and Pytest

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.