### PR TITLE
Fix ListUsers being called by non-admin accounts

### DIFF
--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -799,9 +799,16 @@ async function LoadInitialState() {
   await GetAppConfig()
   GetIdentity((identity: any) => {
     let groups = identity[USER_ROLES_CLAIM];
-    if(groups && (groups.includes("admin") || groups.includes("user")))
-    {
+
+    if (!groups) {
+      return
+    }
+
+    if(groups.includes("admin")) {
       ListUsers();
+    }
+
+    if(groups.includes("admin") || groups.includes("user")) {
       ListClusters();
       // @ts-expect-error TS(2554) FIXME: Expected 3 arguments, but got 0.
       ListCustomImages();


### PR DESCRIPTION
## Description

This PR fixes an issue arising when non-admin accounts get to fetch the users' list. This may require a more structural fix in the long term, but we need a simple fix as right now non-admin users cannot access PCM

## Changes

- only call `ListUsers` when the current user belongs to the admin group

## How Has This Been Tested?

- logged in as simple user and see that you can access the app

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.