### PR TITLE
Fix types and missing imports

### DIFF
--- a/frontend/src/__tests__/storagCreationValidation.test.tsx
+++ b/frontend/src/__tests__/storagCreationValidation.test.tsx
@@ -1,25 +1,26 @@
 import { canCreateStorage, canAttachExistingStorage } from "../old-pages/Configure/Storage";
+import { UIStorageSettings } from "../old-pages/Configure/Storage.types";
 
 
 describe("Given a function to determine whether we can create a storage of a given type", () => {
     describe("when the storage type is not available", () => {
         it("should not allow the creation of a new storage", () => {
-            expect(canCreateStorage(null, [], {})).toBeFalsy();
+            expect(canCreateStorage(null as any, {}, {})).toBeFalsy();
         });
     });
     describe("when the storage type does not support creation", () => {
         it("should not allow the creation of a new storage", () => {
-            expect(canCreateStorage("FsxOntap", [], {})).toBeFalsy();
+            expect(canCreateStorage("FsxOntap", {}, {})).toBeFalsy();
         });
     });
     describe("when the attached storages are not available", () => {
         it("should allow the creation of a new storage", () => {
-            expect(canCreateStorage("Efs", null, {})).toBeTruthy();
+            expect(canCreateStorage("Efs", {}, {})).toBeTruthy();
         });
     });
     describe("when the ui storages details are not available", () => {
         it("should allow the creation of a new storage", () => {
-            expect(canCreateStorage("Efs", [], null)).toBeTruthy();
+            expect(canCreateStorage("Efs", {}, null as any)).toBeTruthy();
         });
     });
     describe("when we have exceeded the amount of storage of a given type we can create", () => {
@@ -27,8 +28,11 @@ describe("Given a function to determine whether we can create a storage of a giv
             expect(
                 canCreateStorage(
                     "FsxLustre",
-                    Array(20).fill({ "StorageType": "FsxLustre" }),
-                    [...Array(20).keys()].reduce((accumulator, number) => {
+                    Array(20).fill({ "StorageType": "FsxLustre" }).reduce((acc, current, key) => {
+                        acc[key] = current;
+                        return acc;
+                    }, {}),
+                    [...Array(20).keys()].reduce<UIStorageSettings>((accumulator, number) => {
                         accumulator[number] = { "useExisting": false };
                         return accumulator
                     }, {})
@@ -38,7 +42,7 @@ describe("Given a function to determine whether we can create a storage of a giv
     });
     describe("when we have not exceeded the amount of storage of a given type we can create", () => {
         it("should allow the creation of a new storage", () => {
-            expect(canCreateStorage("FsxLustre", [{ "storageType": "FsxLustre" }], { 0: { "useExisting": true } })).toBeTruthy();
+            expect(canCreateStorage("FsxLustre", {"0": { "StorageType": "FsxLustre", MountDir: "", Name: "" }}, { 0: { "useExisting": true } })).toBeTruthy();
         });
     });
 });
@@ -47,22 +51,22 @@ describe("Given a function to determine whether we can create a storage of a giv
 describe("Given a function to determine whether we can attach an existing storage of a given type", () => {
     describe("when the storage type is not available", () => {
         it("should not allow the attachment of an existing storage", () => {
-            expect(canAttachExistingStorage(null, [], {})).toBeFalsy();
+            expect(canAttachExistingStorage(null as any, {}, {})).toBeFalsy();
         });
     });
     describe("when the storage type is not available", () => {
         it("should not allow the attachment of an existing storage", () => {
-		expect(canAttachExistingStorage(null, [], {})).toBeFalsy();
+		expect(canAttachExistingStorage(null as any, {}, {})).toBeFalsy();
         });
     });
     describe("when the attached storages are not available", () => {
         it("should allow the attachment of an existing storage", () => {
-            expect(canAttachExistingStorage("Efs", null, {})).toBeTruthy();
+            expect(canAttachExistingStorage("Efs", null as any, {})).toBeTruthy();
         });
     });
     describe("when the ui storages details are not available", () => {
         it("should allow the attachment of an existing storage", () => {
-            expect(canAttachExistingStorage("Efs", [], null)).toBeTruthy();
+            expect(canAttachExistingStorage("Efs", {}, null as any)).toBeTruthy();
         });
     });
     describe("when we have exceeded the amount of existing storage of a given type we can attach", () => {
@@ -70,8 +74,11 @@ describe("Given a function to determine whether we can attach an existing storag
             expect(
                 canAttachExistingStorage(
                     "FsxLustre",
-                    Array(20).fill({ "StorageType": "FsxLustre" }),
-                    [...Array(20).keys()].reduce((accumulator, number) => {
+                    Array(20).fill({ "StorageType": "FsxLustre", Name: "", MountDir: "" }).reduce((acc, current, key) => {
+                        acc[key] = current;
+                        return acc;
+                    }, {}),
+                    [...Array(20).keys()].reduce<UIStorageSettings>((accumulator, number) => {
                         accumulator[number] = { "useExisting": true };
                         return accumulator
                     }, {})
@@ -81,7 +88,7 @@ describe("Given a function to determine whether we can attach an existing storag
     });
     describe("when we have not exceeded the amount of existing storage of a given type we can attach", () => {
         it("should allow the attachment of an existing storage", () => {
-            expect(canAttachExistingStorage("FsxLustre", [{ "storageType": "FsxLustre" }], { 0: { "useExisting": true } })).toBeTruthy();
+            expect(canAttachExistingStorage("FsxLustre", {"0": { "StorageType": "FsxLustre", Name: "", MountDir: ""  }}, { 0: { "useExisting": true } })).toBeTruthy();
         });
     });
 });

--- a/frontend/src/old-pages/Clusters/Clusters.tsx
+++ b/frontend/src/old-pages/Clusters/Clusters.tsx
@@ -8,7 +8,7 @@
 // OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 import React from 'react';
-import { useNavigate, useParams } from "react-router-dom"
+import { NavigateFunction, useNavigate, useParams } from "react-router-dom"
 
 import { ListClusters } from '../../model'
 
@@ -37,7 +37,7 @@ import Actions from './Actions';
 import Details from "./Details";
 import { wizardShow } from '../Configure/Configure';
 
-function updateClusterList(navigate) {
+function updateClusterList(navigate: NavigateFunction) {
   const selectedClusterName = getState(['app', 'clusters', 'selected']);
   const oldStatus = getState(['app', 'clusters', 'selectedStatus']);
 

--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -214,6 +214,8 @@ function CustomAMISettings({
   const osPath = ['app', 'wizard', 'config', 'Image', 'Os'];
   const os = useState(osPath) || "alinux2";
 
+  const { t } = useTranslation();
+
   var suggestions = [];
   for(let image of customImages)
   {
@@ -598,7 +600,7 @@ function RootVolume({
       <Select
         disabled={editing}
         placeholder={t('wizard.components.rootVolume.type.placeholder', {defaultRootVolumeType: defaultRootVolumeType})}
-        // @ts-expect-error TS(2322) FIXME: Type '{ disabled: any; placeholder: string; select... Remove this comment to see the full error message
+        // @ts-expect-error TS(2322) FIXME: Type '{ disabled: any; placeholder: string | undef... Remove this comment to see the full error message
         selectedOption={rootVolumeType && strToOption(rootVolumeType)} label="Volume Type" onChange={({detail}) => {setState(rootVolumeTypePath, detail.selectedOption.value)}}
         options={volumeTypes.map(strToOption)}
       />

--- a/frontend/src/old-pages/Configure/Storage.types.ts
+++ b/frontend/src/old-pages/Configure/Storage.types.ts
@@ -1,0 +1,44 @@
+/*
+ * Used to configure the Storage part of the Cluster wizard:
+ *  - controls whether a storage type can be created or just linked
+ *  - specify if a storage type can be mounted as a file system or just one of its volumes
+ */
+export const STORAGE_TYPE_PROPS = {
+  "FsxLustre": {
+    mountFilesystem: true,
+    maxToCreate: 1,
+    maxExistingToAttach: 20
+  },
+  "FsxOntap": {
+    mountFilesystem: false,
+    maxToCreate: 0,
+    maxExistingToAttach: 20
+  },
+  "FsxOpenZfs": {
+    mountFilesystem: false,
+    maxToCreate: 0,
+    maxExistingToAttach: 20
+  },
+  "Efs": {
+    mountFilesystem: true,
+    maxToCreate: 1,
+    maxExistingToAttach: 20
+  },
+  "Ebs": {
+    mountFilesystem: false,
+    maxToCreate: 5,
+    maxExistingToAttach: 5
+  },
+}
+
+export type StorageType = keyof typeof STORAGE_TYPE_PROPS;
+
+export type Storages = Record<string, {
+  Name: string,
+  StorageType: StorageType,
+  MountDir: string,
+}>;
+
+export type UIStorageSettings = Record<string, {
+  useExisting: boolean,
+}>;


### PR DESCRIPTION
## Description

Restore the pipeline after the introduction of a linting stage with https://github.com/aws-samples/pcluster-manager/pull/221

## Changes

- fix missing imports of `t`
- add proper types to the storage part
- 
## How Has This Been Tested?

- `npm test`
- `npx tsc -p tsconfig.json`
- manual tests inside the Storage part of the wizard

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.