### PR TITLE
Use "state" parameter for OAuth2 initiated login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ infrastructure/cognitolambda/node_modules
 .DS_Store
 .hugo_build.lock
 public/*
-.idea
+/frontend/tsconfig.tsbuildinfo

--- a/frontend/src/auth/__tests__/handleNotAuthorizedErrors.test.ts
+++ b/frontend/src/auth/__tests__/handleNotAuthorizedErrors.test.ts
@@ -40,10 +40,14 @@ describe('given the application config', () => {
         handleNotAuthorizedErrors(mockAppConfig)(mockRequestPromise).catch(() => {
             expect(global.window.location.replace).toHaveBeenCalledTimes(1)
             expect(global.window.location.replace).toHaveBeenCalledWith(
-                expect.stringMatching(/some-url\?response_type=code&client_id=some-id&scope=some-list&redirect_uri=some-uri&state=[a-zA-Z0-9]{1,32}/)
+                expect.stringContaining('some-url?response_type=code&client_id=some-id&scope=some-list&redirect_uri=some-uri')
             )
-          })
+            // 'as any' to avoid breaking npx tsc -p tsconfig.json
+            const urlString = `'${(global.window.location.replace as any).mock.calls[0][0]}`;
+            const queryParams = urlString.split('?')[1].split('&').map(keyvalue => keyvalue.split('='))
+            expect(queryParams.filter(([key, value]) => key === 'state').length).toBeGreaterThan(0)
 
+          })
         rejectPromise({ response: { status: 401 } })
       })
     })

--- a/frontend/src/auth/__tests__/handleNotAuthorizedErrors.test.ts
+++ b/frontend/src/auth/__tests__/handleNotAuthorizedErrors.test.ts
@@ -42,7 +42,7 @@ describe('given the application config', () => {
             expect(global.window.location.replace).toHaveBeenCalledWith(
                 expect.stringContaining('some-url?response_type=code&client_id=some-id&scope=some-list&redirect_uri=some-uri')
             )
-            // 'as any' to avoid breaking npx tsc -p tsconfig.json
+
             const urlString = `'${(global.window.location.replace as any).mock.calls[0][0]}`;
             const queryParams = urlString.split('?')[1].split('&').map(keyvalue => keyvalue.split('='))
             expect(queryParams.filter(([key, value]) => key === 'state').length).toBeGreaterThan(0)

--- a/frontend/src/auth/__tests__/handleNotAuthorizedErrors.test.ts
+++ b/frontend/src/auth/__tests__/handleNotAuthorizedErrors.test.ts
@@ -19,7 +19,7 @@ describe('given the application config', () => {
 
   beforeEach(() => {
     mockAppConfig = {
-      authUrl: 'some-url',
+      authUrl: 'http://somepath.com',
       clientId: 'some-id',
       redirectUri: 'some-uri',
       scopes: 'some-list'
@@ -40,13 +40,12 @@ describe('given the application config', () => {
         handleNotAuthorizedErrors(mockAppConfig)(mockRequestPromise).catch(() => {
             expect(global.window.location.replace).toHaveBeenCalledTimes(1)
             expect(global.window.location.replace).toHaveBeenCalledWith(
-                expect.stringContaining('some-url?response_type=code&client_id=some-id&scope=some-list&redirect_uri=some-uri')
+                expect.stringContaining('http://somepath.com?response_type=code&client_id=some-id&scope=some-list&redirect_uri=some-uri')
             )
 
-            const urlString = `'${(global.window.location.replace as any).mock.calls[0][0]}`;
-            const queryParams = urlString.split('?')[1].split('&').map(keyvalue => keyvalue.split('='))
-            expect(queryParams.filter(([key, value]) => key === 'state').length).toBeGreaterThan(0)
-
+            const urlString = `${(global.window.location.replace as any).mock.calls[0][0]}`;
+            const searchParams = new URL(urlString).searchParams
+            expect(searchParams.get('state')).toBeTruthy()
           })
         rejectPromise({ response: { status: 401 } })
       })

--- a/frontend/src/auth/__tests__/handleNotAuthorizedErrors.test.ts
+++ b/frontend/src/auth/__tests__/handleNotAuthorizedErrors.test.ts
@@ -39,7 +39,9 @@ describe('given the application config', () => {
       it('should redirect to the authorization server', () => {
         handleNotAuthorizedErrors(mockAppConfig)(mockRequestPromise).catch(() => {
             expect(global.window.location.replace).toHaveBeenCalledTimes(1)
-            expect(global.window.location.replace).toHaveBeenCalledWith('some-url?response_type=code&client_id=some-id&scope=some-list&redirect_uri=some-uri')
+            expect(global.window.location.replace).toHaveBeenCalledWith(
+                expect.stringMatching(/some-url\?response_type=code&client_id=some-id&scope=some-list&redirect_uri=some-uri&state=[a-zA-Z0-9]{1,32}/)
+            )
           })
 
         rejectPromise({ response: { status: 401 } })

--- a/frontend/src/auth/handleNotAuthorizedErrors.ts
+++ b/frontend/src/auth/handleNotAuthorizedErrors.ts
@@ -26,10 +26,10 @@ export const handleNotAuthorizedErrors = ({authUrl, clientId, scopes, redirectUr
 }
 
 function redirectToAuthServer(authUrl: string, clientId: string, scopes: string, redirectUri: string) {
-  const url = `${authUrl}?response_type=code&client_id=${clientId}&scope=${encodeURIComponent(scopes)}&redirect_uri=${redirectUri}&state=${oauth2_state_parameter()}`
+  const url = `${authUrl}?response_type=code&client_id=${clientId}&scope=${encodeURIComponent(scopes)}&redirect_uri=${redirectUri}&state=${oauth2StateParameter()}`
   window.location.replace(url)
 }
 
-function oauth2_state_parameter(length = 16): string {
+function oauth2StateParameter(length = 16): string {
     return Math.random().toString(20).substring(2, length)
 }

--- a/frontend/src/auth/handleNotAuthorizedErrors.ts
+++ b/frontend/src/auth/handleNotAuthorizedErrors.ts
@@ -26,6 +26,10 @@ export const handleNotAuthorizedErrors = ({authUrl, clientId, scopes, redirectUr
 }
 
 function redirectToAuthServer(authUrl: string, clientId: string, scopes: string, redirectUri: string) {
-  const url = `${authUrl}?response_type=code&client_id=${clientId}&scope=${encodeURIComponent(scopes)}&redirect_uri=${redirectUri}`
+  const url = `${authUrl}?response_type=code&client_id=${clientId}&scope=${encodeURIComponent(scopes)}&redirect_uri=${redirectUri}&state=${oauth2_state_parameter()}`
   window.location.replace(url)
+}
+
+function oauth2_state_parameter(length = 16): string {
+    return Math.random().toString(20).substring(2, length)
 }


### PR DESCRIPTION
## Use `state` parameter for OAuth2 initiated login
This PR introduces the use of the state parameter on the frontend, populated with a random string.
This is part of the [RFC for OAuth2](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1)

State parameter is currently [supported by Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/login-endpoint.html).

### Reason
Right now we don't actually make use of the state parameter but introducing it allows us to better support other OIDC providers like Okta that request it as mandatory (even if the RFC puts it as recommended).

## Changes
- added `/frontend/tsconfig.tsbuildinfo` to .gitignore since it's used to check issues with typescript before doing the PR
- added a function to generate a simple random string to set the `state` parameter
- adjusted a test to reflect this change

## How Has This Been Tested?
This has been tested via Postman initially and then via a local deployment of PCM.
Tests have been run both for the frontend and the backend.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.