### PR TITLE
Move code for getting list of custom bootstrap actions to util.tsx

### DIFF
--- a/frontend/src/old-pages/Clusters/Details.tsx
+++ b/frontend/src/old-pages/Clusters/Details.tsx
@@ -12,7 +12,7 @@ import React from 'react';
 import { useNavigate, useParams } from "react-router-dom"
 
 import { useState } from '../../store'
-import { getIn } from '../../util'
+import { getScripts } from './util'
 
 // UI Elements
 import Tabs from "@awsui/components-react/tabs"
@@ -35,24 +35,7 @@ export default function ClusterTabs() {
   const customActions = useState([...clusterPath, 'config', 'HeadNode', 'CustomActions']);
   const selectedClusterName = useState(['app', 'clusters', 'selected']);
 
-  let allScripts = [];
-  const scriptName = (script: any) => {
-    let suffix = script.slice(script.lastIndexOf('/') + 1);
-    return suffix.slice(0, suffix.lastIndexOf('.'));
-  }
-
-  for(let actionName of ['OnNodeStart', 'OnNodeConfigured'])
-  {
-    if(getIn(customActions, [actionName, 'Script']))
-      allScripts.push(scriptName(getIn(customActions, [actionName, 'Script'])));
-    for(let arg of (getIn(customActions, [actionName, 'Args']) || []))
-    {
-      if(arg.length > 0 && arg[0] !== '-')
-        allScripts.push(scriptName(arg));
-    }
-  }
-
-  let accountingEnabled = allScripts.includes('slurm-accounting');
+  let accountingEnabled = getScripts(customActions).includes('slurm-accounting');
   let navigate = useNavigate();
   let params = useParams();
 

--- a/frontend/src/old-pages/Clusters/__tests__/util.test.tsx
+++ b/frontend/src/old-pages/Clusters/__tests__/util.test.tsx
@@ -1,0 +1,72 @@
+import { getScripts } from "../util";
+
+describe("Given a function to get script names of all custom actions", () => {
+    
+    describe("when a custom action to be run on node startup is provided", () => {
+        it("should return the name of the script", () => {
+            const scriptNames = getScripts({
+                OnNodeStart: {
+                    Script: 'https://www.website.com/test/directory/test-script.sh',
+                    Args: []
+                }
+            })
+            expect(scriptNames).toEqual(['test-script'])
+        })
+    })
+    
+    describe("when a custom action to be run on node configuration is provided", () => {
+        it("should return the name of the script", () => {
+            const scriptNames = getScripts({
+                OnNodeConfigured: {
+                    Script: 'https://www.website.com/test/directory/test-script.sh',
+                    Args: []
+                }
+            })
+            expect(scriptNames).toEqual(['test-script'])
+        })
+    })
+  
+    describe("when a custom action with arguments is provided", () => {
+        it("should return the names of all scripts", () => {
+            const scriptNames = getScripts({
+                OnNodeConfigured: {
+                    Script: 'https://www.website.com/test/test-multi-runner.py',
+                    Args: [
+                        'https://www.website.com/directory/test.sh',
+                        '-123456',
+                        '-abcdef'
+                    ]
+                }
+            })
+            expect(scriptNames.sort()).toEqual(['test', 'test-multi-runner'])
+        })
+    })
+
+    describe("when multiple custom actions and arguments are provided", () => {
+        it("should return the names of all scripts", () => {
+            const scriptNames = getScripts({
+                OnNodeStart: {
+                    Script: 'https://www.website.com/test/directory/testing.sh',
+                    Args: ['-abcdef']
+                },
+                OnNodeConfigured: {
+                    Script: 'https://www.website.com/test/test.py',
+                    Args: [
+                        'https://www.website.com/directory/tests.sh',
+                        '-123456',
+                        '-abcdef',
+                        'https://www.website.com/test/directory/test-multi-runner.py'
+                    ]
+                }
+            })
+            expect(scriptNames.sort()).toEqual(['test', 'test-multi-runner', 'testing', 'tests'])
+        })
+    })
+
+    describe("when no custom actions are provided", () => {
+        it("should return an empty array", () => {
+           const scriptNames = getScripts(null)
+           expect(scriptNames).toEqual([])
+        })
+    })
+})

--- a/frontend/src/old-pages/Clusters/util.tsx
+++ b/frontend/src/old-pages/Clusters/util.tsx
@@ -12,6 +12,7 @@ import jsyaml from 'js-yaml';
 
 import { DescribeCluster, GetConfiguration } from '../../model'
 import { clearState, getState, setState } from '../../store'
+import { getIn } from '../../util'
 
 export function selectCluster(clusterName: any, navigate: any)
 {
@@ -25,4 +26,24 @@ export function selectCluster(clusterName: any, navigate: any)
   DescribeCluster(name, () => {navigate && navigate('/clusters')});
   if(oldClusterName !== clusterName)
     setState(['app', 'clusters', 'selected'], name);
+}
+
+export function getScripts(customActions: Record<string, any> | null) {
+  const scriptName = (script: string) => {
+    let suffix = script.slice(script.lastIndexOf('/') + 1);
+    return suffix.slice(0, suffix.lastIndexOf('.'));
+  }
+  
+  let allScripts = [];
+  for(let actionName of ['OnNodeStart', 'OnNodeConfigured'])
+  {
+    if(getIn(customActions, [actionName, 'Script']))
+      allScripts.push(scriptName(getIn(customActions, [actionName, 'Script'])));
+    for(let arg of (getIn(customActions, [actionName, 'Args']) || []))
+    {
+      if(arg.length > 0 && arg[0] !== '-')
+        allScripts.push(scriptName(arg));
+    }
+  }
+  return allScripts
 }


### PR DESCRIPTION
## Description

Details.tsx has some code that checks whether Slurm Accounting is active on a cluster. I moved this to utils so that it can be reused to check for other custom bootstrap actions (specifically Slurm REST API).

## How Has This Been Tested?

- Checked that the accounting tab was visible only when an accounting cluster was selected.
- Created tests for `getScripts()`