### PR TITLE
refactor: move Actions buttons from split panel header to table header

### DIFF
--- a/frontend/src/old-pages/Clusters/Clusters.tsx
+++ b/frontend/src/old-pages/Clusters/Clusters.tsx
@@ -121,6 +121,7 @@ function ClusterList({ clusters }: ClusterListProps) {
   );
 
   return (<Table {...collectionProps} header={<Header variant="h2" description="" counter={clusters && `(${clusters.length})`} actions={<SpaceBetween direction="horizontal" size="xs">
+              {selectedClusterName && <Actions/>}
               {clusters && <Button onClick={configure} variant="primary" iconName={"add-plus"} disabled={!isAdmin()}>Create Cluster</Button>}
             </SpaceBetween>}>
           Clusters
@@ -189,15 +190,7 @@ export default function Clusters () {
             openButtonAriaLabel: t("cluster.list.splitPanel.openButtonAriaLabel"),
             resizeHandleAriaLabel: t("cluster.list.splitPanel.resizeHandleAriaLabel"),
           }}
-          // FIXME move Actions from SplitPanel to Table header
-          // @ts-expect-error TS(2322) FIXME: Type 'Element' is not assignable to type 'string'.
-          header={
-            <Header
-              variant="h2"
-              actions={cluster && <Actions/>}>
-              {clusterName ? `Cluster: ${clusterName}` : t("cluster.list.splitPanel.noClusterSelectedText") }
-            </Header>
-          }>
+          header={clusterName ? `Cluster: ${clusterName}` : t("cluster.list.splitPanel.noClusterSelectedText") }>
           {clusterName ? <Details /> : <div>{t("cluster.list.splitPanel.selectClusterText")}</div>}
         </SplitPanel>
       }


### PR DESCRIPTION
## Description

Currently in PCM we have a TypeScript error due to the fact that the header property of the `SplitPanel` component takes a string while we are passing a `<Header>` component instead.

This is not compliant with Polaris design system, thus we should move actions buttons from `SplitPanel` header to `Table` header.

## Changes
* Moved `Actions` component from `SplitPanel` to `Table` header

<!-- List of relevant changes introduced -->

## How Has This Been Tested?
* Manually tested all action buttons with success
   * Cluster stopped / started
   * Shell
   * Filesystem
   * Edited / deleted


<!-- The tests you ran to verify your changes -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.