### PR TITLE
`[Storage]` Remove MUI Slider, various chores.

### DIFF
--- a/frontend/src/__tests__/util.test.tsx
+++ b/frontend/src/__tests__/util.test.tsx
@@ -1,0 +1,34 @@
+import { clamp } from "../util";
+
+describe("Given a function to clamp a number using an option step discretization", () => {
+  describe("when the input is below the minimum", () => {
+    it("should be set to the minimum", () => {
+      const result = clamp(1, 20, 200);
+      expect(result).toBe(20);
+    });
+  });
+  describe("when the input is equal to the minimum", () => {
+    it("should be set to the minimum", () => {
+      const result = clamp(20, 20, 200);
+      expect(result).toBe(20);
+    });
+  });
+  describe("when the input is above the maximum", () => {
+    it("should be set to the maximum", () => {
+      const result = clamp(201, 20, 200);
+      expect(result).toBe(200);
+    });
+  });
+  describe("when the input is equal to the maximum", () => {
+    it("should be set to the maximum", () => {
+      const result = clamp(200, 20, 200);
+      expect(result).toBe(200);
+    });
+  });
+  describe("when the input is not at the step size", () => {
+    it("should be set to a multiple of the step size", () => {
+      const result = clamp(21, 20, 200, 20);
+      expect(result).toBe(20);
+    });
+  });
+});

--- a/frontend/src/util.ts
+++ b/frontend/src/util.ts
@@ -70,4 +70,12 @@ function clusterDefaultUser(cluster: any) {
     "centos7": "centos"}[os]
 }
 
-export { getIn, swapIn, setIn, updateIn, findFirst, clusterDefaultUser }
+function clamp(num: number, min: number, max: number, step?: number): number
+{
+  step ||= 1;
+  const clamped = Math.max(min, Math.min(max, num));
+  const remain = clamped % step;
+  return clamped - remain;
+}
+
+export { clamp, getIn, swapIn, setIn, updateIn, findFirst, clusterDefaultUser }


### PR DESCRIPTION
## Description

This PR removes the MUI slider so that we have one less dependency on a second UX framework.

## Changes

- Add a util clamp function
- Remove the MUI Slider, replace with an input that clamps value on blur
- Convert EFS throughput input to use same clamping function
- Add types to options and remove ts-expect-errors

## How Has This Been Tested?

Manually tested the Lustre Storage Capacity input with: letters, negative numbers, positive numbers, numbers out of step
Manually tested the EFS Throughput  input with: letters, negative numbers, positive numbers, numbers out of step

![image](https://user-images.githubusercontent.com/6087509/182279294-5f791fa7-f1cb-4c94-aab9-7aebeca72c5d.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.