### PR TITLE
fix: add missing policies for EcrImageDeletionLambdaRole

### DIFF
--- a/infrastructure/pcluster-manager.yaml
+++ b/infrastructure/pcluster-manager.yaml
@@ -400,7 +400,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - imagebuilder:ListImagePipelineImages
-                Resource: !Ref EcrImagePipeline
+                Resource: !Sub
+                  - arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image-pipeline/ecrimagepipeline-*${StackIdSuffix}*
+                  - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
               - Effect: Allow
                 Action:
                   - imagebuilder:DeleteImage


### PR DESCRIPTION
## Description
Currently `pcluster-manager` stack cannot be updated in case of a bumped version due to insufficient policies in EcrImageDeletionLambdaRole.

## Changes

* Added missing policies for **EcrImageDeletionLambdaRole** in `pcluster-manager.yaml` file

## How Has This Been Tested?

* Manual tests
   * Created the stack (3.1.3) and attempted to upgrade to 3.1.3 --> Stack Update Failed EcrImageRemover Error in CloudFormation
   * Created the stack (3.1.3) with an API template with the changes in this commit
Attempted to upgrade to 3.1.4 --> Stack updated Succeeded

## References
* https://github.com/aws/aws-parallelcluster/pull/4194
* https://github.com/aws/aws-parallelcluster/pull/4206

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.