### PR TITLE
Bump version of PC and PCM to 3.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ infrastructure/cognitolambda/node_modules
 .hugo_build.lock
 public/*
 /frontend/tsconfig.tsbuildinfo
+.idea/

--- a/infrastructure/pcluster-manager.yaml
+++ b/infrastructure/pcluster-manager.yaml
@@ -24,7 +24,7 @@ Parameters:
   Version:
     Description: Version of AWS ParallelCluster to deploy
     Type: String
-    Default: 3.1.4
+    Default: 3.2.0
   ImageBuilderVpcId:
     Description: (Optional) Select the VPC to use for building the container images. If not selected, default VPC will be used.
     Type: String
@@ -71,8 +71,8 @@ Conditions:
 Mappings:
   PclusterManager:
     Constants:
-      Version: 3.1.4
-      ShortVersion: 3.1.4
+      Version: 3.2.0
+      ShortVersion: 3.2.0
 
 Resources:
 


### PR DESCRIPTION
### Notes
Bump version of PC and PCM to `3.2.0`.

### Test
- Deployed new PCM stack in personal account.
- Tested creation of a cluster.
- Updated to image to latest version (`update.sh --local`).
- Tested creation of a cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.