### PR TITLE
Add manual script entry as a new job submission option

### DIFF
--- a/api/tests/test_submit_job_script.py
+++ b/api/tests/test_submit_job_script.py
@@ -1,0 +1,85 @@
+import json
+from unittest import mock
+from requests import Response
+from api.PclusterApiHandler import post_job_slurm_api, translate_job
+
+
+@mock.patch("api.PclusterApiHandler.requests.post")
+def test_post_to_slurm_api_with_correct_request(mock_post):
+    """
+    Given a function that posts jobs to the Slurm API
+      When a job body, user, token, and ip are inputted
+        It should call request.post with the correct url, data, and headers
+    """
+    post_job_slurm_api(
+        {'job-name': 'test'},
+        'test-user', 'slurm-token123', '123.456.7.8'
+    )
+
+    mock_post.assert_called_once_with(
+        url='https://123.456.7.8/slurm/v0.0.36/job/submit', 
+        data=json.dumps({
+            "job": {
+                "environment": {
+                    "PATH": "/bin:/usr/bin/:/usr/local/bin/:/opt/slurm/bin/"
+                },
+                "name": "test", 
+                "current_working_directory": "/home/test-user"
+            }
+         }),
+        headers={
+            'Content-Type': 'application/json', 
+            'X-SLURM-USER-NAME': 'test-user', 
+            'X-SLURM-USER-TOKEN': 'slurm-token123'
+        }, 
+        verify=False
+    )
+
+
+@mock.patch("api.PclusterApiHandler.requests.post")
+def test_post_to_slurm_api_returns_errors(mock_post):
+    """
+    Given a function that posts jobs to the Slurm API
+      When the response contains errors
+        It should return the error messages separated by new lines
+    """
+    resp = Response()
+    resp.status_code = 400
+    resp.reason = 'BAD REQUEST'
+    resp._content = b'{"errors": [ \
+        {"error": "test", "error_code": -1}, \
+        {"error": "testing", "error_code": 9001}]}'
+
+    mock_post.return_value = resp
+
+    ret = post_job_slurm_api(
+        {'job-name': 'test'}, 
+        'test-user', 'slurm-token123', '123.456.7.8'
+    )
+
+    assert ret.get('errors') == 'test\ntesting'
+    assert ret.get('status_code') == 400
+    assert ret.get('reason') == 'BAD REQUEST'
+
+
+def test_translate_job():
+    """
+    Given a function that translates a job
+      When a dict of job data is inputted
+        It should format the job to be accepted by the Slurm API
+    """
+    request_body = {'job-name': 'test', 'nodes': 1, 'command': 'test command'}
+
+    translation = translate_job(request_body, 'test-user')
+
+    assert translation == {
+        "job": {
+            "name": "test", 
+            "current_working_directory": "/home/test-user",
+            "nodes": 1,
+            "environment": {
+                    "PATH": "/bin:/usr/bin/:/usr/local/bin/:/opt/slurm/bin/"
+                }
+            },
+        "script": 'test command'
+     } 

--- a/app.py
+++ b/app.py
@@ -42,6 +42,7 @@ from api.PclusterApiHandler import (
     scontrol_job,
     set_user_role,
     submit_job,
+    submit_job_script
 )
 
 
@@ -167,6 +168,11 @@ def run():
     @authenticated()
     def sacct_():
         return sacct()
+
+    @app.route("/manager/submit_job_script", methods=["POST"])
+    @authenticated()
+    def submit_job_script_():
+        return submit_job_script()
 
     @app.route("/manager/scontrol_job")
     @authenticated()

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -365,9 +365,62 @@
     }
   },
   "JobSubmitDialog": {
-    "requiredMemory": {
+    "header": "Submit Job",
+    "cancel": "Cancel",
+    "submit": "Submit",
+    "job-name": {
+      "header": "Job Name",
+      "description": "Please choose an identifier for this job.",
+      "placeholder": "job-name"
+    },
+    "chdir": {
+      "header": "Working Directory",
+      "description": "Please choose a working directory for the job [optional]"
+    },
+    "nodes": {
+      "header": "Nodes",
+      "description": "Number of nodes for job [optional]"
+    },
+    "ntasks": {
+      "header": "Number of tasks",
+      "description": "Number of tasks for a job [optional]"
+    },
+    "mem": {
       "header": "Required memory",
       "description": "Real memory required per node, in MB. A memory size specification of zero is treated as a special case and grants the job access to all of the memory on each node. [optional]"
+    },
+    "jobTypeCommand": {
+      "header": "Command",
+      "description": "The command to run as a part of this job.",
+      "radioGroup": "Run a command"
+    },
+    "jobTypeFile": {
+      "header": "Script Path",
+      "description": "Path to the script to run",
+      "radioGroup": "Run a script on the head node"
+    },
+    "jobTypeScript": {
+      "radioGroup": "Enter sbatch script manually",
+      "radioGroupDisabledDescription": "Requires Slurm REST API"
+    },
+    "queue": {
+      "header": "Queue",
+      "description": "Queue where the job will run."
+    },
+    "costEstimate": {
+      "header": "Cost estimate",
+      "alertHeader": "Experimental!",
+      "alertContent": "This provides a basic cost estimate based on the expected job run-time, the number of nodes and their instance type. Actual costs will vary based on node uptime, storage, and other factors. Please refer to Cost Explorer for actual cluster costs.",
+      "timeEstimateHeader": "Your estimate of the total runtime of the job (in Hours).",
+      "button": "Estimate",
+      "estimatedCost": "Estimated job cost:",
+      "formula": "Price ($/h) * Time (h) * NodeCount"
+    },
+    "errors": {
+      "mustSelectQueue": "Error: You must select a queue.",
+      "mustSelectNodes": "Error: You must select a node count.",
+      "mustSelectRuntime": "Error: You must select a job runtime.",
+      "emptyJob": "Error: Job is empty"
     }
   }
 }

--- a/frontend/src/old-pages/Clusters/JobSubmitDialog.tsx
+++ b/frontend/src/old-pages/Clusters/JobSubmitDialog.tsx
@@ -10,9 +10,13 @@
 // limitations under the License.
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useState, setState, getState, clearState } from '../../store'
-import { findFirst, clusterDefaultUser } from '../../util'
-import { SubmitJob, PriceEstimate } from '../../model'
+import { useState, setState, getState, clearState } from '../../store';
+import { findFirst, clusterDefaultUser } from '../../util';
+import { getScripts } from './util';
+import { SubmitJob, SubmitJobScript, PriceEstimate } from '../../model';
+import ConfigView from '../../components/ConfigView';
+import { Job } from '../../types/jobs';
+import FileUploadButton from '../../components/FileChooser'; 
 
 // UI Elements
 import {
@@ -38,19 +42,18 @@ function itemToOption([value, title]: [string, string]) {
 }
 
 function QueueSelect() {
+  const { t } = useTranslation();
   const clusterName = getState(['app', 'clusters', 'selected']);
   const clusterPath = ['clusters', 'index', clusterName];
   const queues = getState([...clusterPath, 'config', 'Scheduling', 'SlurmQueues']) || []
 
-  const jobPath = [...submitPath, 'job'];
   let partition = useState([...jobPath, 'partition']);
 
   let queuesOptions = [["[ANY]", "[ANY]"], ...queues.map((q: any) => [q.Name, q.Name])]
 
   return <>
-    {/* @ts-expect-error TS(2322) FIXME: Type '"h4"' is not assignable to type 'Variant | u... Remove this comment to see the full error message */}
-    <Header variant="h4"
-      description="Queue where the job will run.">Queue</Header>
+    <Header variant="h2"
+      description={t("JobSubmitDialog.queue.description")}>{t("JobSubmitDialog.queue.header")}</Header>
     <Select
       selectedOption={itemToOption(findFirst(queuesOptions, (x: any) => {return x[0] === partition}) || ["[ANY]", "[ANY]"])}
       onChange={({detail}) => {
@@ -67,6 +70,7 @@ function QueueSelect() {
 }
 
 function JobCostEstimate() {
+  const { t } = useTranslation();
   const jobRuntimePath = [...submitPath, 'jobRuntime'];
   const priceEstimatePath = [...submitPath, 'priceEstimate'];
   const priceEstimate = useState(priceEstimatePath);
@@ -75,7 +79,6 @@ function JobCostEstimate() {
   const costEstimatePending = useState(costEstimatePendingPath);
 
   const jobRuntime = useState(jobRuntimePath);
-  const jobPath = [...submitPath, 'job'];
   const nodes = useState([...jobPath, 'nodes']);
 
   const costEstimatePath = [...submitPath, 'costEstimate'];
@@ -100,15 +103,15 @@ function JobCostEstimate() {
     }
     if(!queueName || queueName === "[ANY]")
     {
-      setState(errorsPath, "Error: You must select a queue.");
+      setState(errorsPath, t("JobSubmitDialog.errors.mustSelectQueue"));
       clearState(costEstimatePendingPath);
     } else if(!nodes || nodes === '')
     {
-      setState(errorsPath, "Error: You must select a node count.");
+      setState(errorsPath, t("JobSubmitDialog.errors.mustSelectNodes"));
       clearState(costEstimatePendingPath);
     } else if(!jobRuntime || jobRuntime === '')
     {
-      setState(errorsPath, "Error: You must select a job runtime.");
+      setState(errorsPath, t("JobSubmitDialog.errors.mustSelectRuntime"));
       clearState(costEstimatePendingPath);
     } else {
       PriceEstimate(clusterName, queueName, callback, failure);
@@ -116,12 +119,12 @@ function JobCostEstimate() {
   }
 
   return <>
-    <Alert visible header="Experimental!">
-      This provides a basic cost estimate based on the expected job run-time, the number of nodes and their instance type. Actual costs will vary based on node uptime, storage, and other factors. Please refer to Cost Explorer for actual cluster costs.
+    <Alert visible header={t("JobSubmitDialog.costEstimate.alertHeader")}>
+      {t("JobSubmitDialog.costEstimate.alertContent")}
     </Alert>
     <div style={{marginTop: "10px"}}>
       <FormField errorText={errors}>
-        Your estimate of the total runtime of the job (in Hours).
+      {t("JobSubmitDialog.costEstimate.timeEstimateHeader")}
         <SpaceBetween direction="horizontal" size="s" key="command">
           <div style={{flexGrow: 1}}>
             <Input
@@ -131,11 +134,11 @@ function JobCostEstimate() {
               placeholder={'2.5'}
             />
           </div>
-          <Button loading={costEstimatePending} onClick={estimateCost}>Estimate</Button>
+          <Button loading={costEstimatePending} onClick={estimateCost}>{t("JobSubmitDialog.costEstimate.button")}</Button>
         </SpaceBetween>
       </FormField>
-      {costEstimate && <FormField>Estimated job cost: ${costEstimate.toFixed(2)}</FormField>}
-      {costEstimate && <pre>Price ($/h) * Time (h) * NodeCount =&gt; {priceEstimate} * {jobRuntime} * {nodes}</pre>}
+      {costEstimate && <FormField>{t("JobSubmitDialog.costEstimate.estimatedCost")} ${costEstimate.toFixed(2)}</FormField>}
+      {costEstimate && <pre>{t("JobSubmitDialog.costEstimate.formula")} =&gt; {priceEstimate} * {jobRuntime} * {nodes}</pre>}
     </div>
   </>
 }
@@ -145,14 +148,21 @@ interface JobFieldProps {
   description: string;
   placeholder: string;
   property: string;
+  disabled?: boolean;
 }
 
 function JobField({
   header,
   description,
   placeholder,
-  property
+  property,
+  disabled=false
 }: JobFieldProps) {
+
+  const setStateIfNotEmpty = React.useCallback((value: string) => {
+    !value || value === '' ? clearState([...jobPath, property]) : setState([...jobPath, property], value);
+  }, [property])
+
   return <>
     <SpaceBetween direction="vertical" size="xxs" key={property}>
       <Header 
@@ -162,9 +172,10 @@ function JobField({
       </Header>
       <FormField>
         <Input 
-          onChange={({ detail }) => {setState([...jobPath, property], detail.value);}}
+          onChange={({ detail }) => setStateIfNotEmpty(detail.value)}
           value={useState([...jobPath, property])}
           placeholder={placeholder}
+          disabled={disabled}
         />
       </FormField>
     </SpaceBetween>
@@ -174,61 +185,88 @@ function JobField({
 export default function JobSubmitDialog({
   submitCallback
 }: any) {
+  
   const { t } = useTranslation();
   const open = useState([...submitPath, 'dialog']);
-  const error = useState([...submitPath, 'error']);
+  const error = useState([...submitPath, 'error']) || "";
   const clusterName = getState(['app', 'clusters', 'selected']);
+  const clusterPath = ['clusters', 'index', clusterName];
+  const cluster = getState(clusterPath);
+  const headNode = getState([...clusterPath, 'headNode']);
 
-  const job = useState(jobPath);
+  const job: Job = useState(jobPath);
   const submitting = useState([...submitPath, 'pending']);
-  const jobType: string = useState([...submitPath, 'job-entry']) || 'command';
-
-  React.useEffect(() => setState([...jobPath, 'wrap'], true), []);
+  const jobType: string = useState([...submitPath, 'job-entry']);
+  const jobCommand: string = useState([...jobPath, 'command']);
 
   let isMemBasedSchedulingEnabled = useState(
-      ['clusters', 'index', clusterName, 'config', 'Scheduling', 'SlurmSettings', 'EnableMemoryBasedScheduling']
+    [...clusterPath, 'config', 'Scheduling', 'SlurmSettings', 'EnableMemoryBasedScheduling']
   ) || false;
 
-  const jobTypeSelect = (detail: string) => {
-    setState([...submitPath, 'job-entry'], detail)
-    detail === 'command' ? setState([...jobPath, 'wrap'], true) : clearState([...jobPath, 'wrap']);
+  let isSlurmApiEnabled = getScripts(
+    useState([...clusterPath, 'config', 'HeadNode', 'CustomActions'])
+  ).includes('slurm-rest-api');
+
+  const isScriptSelected = jobType === 'script';
+
+  const jobTypeSelect = (entryType: string) => {
+    setState([...submitPath, 'job-entry'], entryType);
+    clearState([...jobPath, 'command']);
+    entryType === 'command' ? setState([...jobPath, 'wrap'], true) : clearState([...jobPath, 'wrap']);
+    if(entryType === 'script') clearState([...jobPath, 'chdir']);
   }
 
+  const scriptSelectDescription = isSlurmApiEnabled ? "" : t("JobSubmitDialog.jobTypeScript.radioGroupDisabledDescription");
+
   const jobTypeHeader = {
-    'command': "Command",
-    'file': "Script Path"
+    'command': t("JobSubmitDialog.jobTypeCommand.header"),
+    'file': t("JobSubmitDialog.jobTypeFile.header")
   }[jobType]
 
   const jobTypeDescription = {
-    'command': "The command to run as a part of this job.",
-    'file': "Path to the script to run."
+    'command': t("JobSubmitDialog.jobTypeCommand.description"),
+    'file': t("JobSubmitDialog.jobTypeFile.description")
   }[jobType]
 
   const jobTypePlaceholder = {
     'command': "sleep 30",
-    'file': "/home/ec2-user/myscript.sbatch"
+    'file': "/home/ec2-user/myscript.sbatch",
+    'script': jobCommand || "#!/bin/bash\n"
   }[jobType]
 
-  const submitJob = () => {
-    const clusterPath = ['clusters', 'index', clusterName];
-    const cluster = getState(clusterPath);
+  const submitJob = React.useCallback(async () => {
     let user = clusterDefaultUser(cluster);
-    const headNode = getState([...clusterPath, 'headNode']);
     const success_callback = () => {
+      clearState([...submitPath, 'error']);
       setState([...submitPath, 'dialog'], false);
       setState([...submitPath, 'pending'], false);
       submitCallback && submitCallback();
     }
-    const failure_callback = (message: any) => {
-      setState([...submitPath, 'error'], message)
+    const failure_callback = (message: string) => {
+      setState([...submitPath, 'error'], message); // TODO: doesn't support translation
       setState([...submitPath, 'pending'], false);
     }
     setState([...submitPath, 'pending'], true);
-    SubmitJob(headNode.instanceId, user, job, success_callback, failure_callback)
-  };
+    const errorMessage = isScriptSelected ? 
+      await SubmitJobScript(clusterName, headNode.instanceId, user, job) 
+      : 
+      await SubmitJob(headNode.instanceId, user, job); 
+    errorMessage === "" ? success_callback() : failure_callback(errorMessage);
+    errorMessage === "" ? success_callback() : failure_callback(errorMessage);
+  }, [cluster, clusterName, headNode.instanceId, isScriptSelected, job, submitCallback]);
+
+  const submitJobIfEntered = React.useCallback(() => {
+    const entry = (getState([...jobPath, 'command']) || '').replace(/\n| /gm, '');
+    if(entry === '#!/bin/bash' || entry === '') {
+      setState([...submitPath, 'error'], t("JobSubmitDialog.errors.emptyJob"));
+    } else {
+      submitJob();
+    }
+  }, [submitJob])
 
   const cancel = () => {
-    setState([...submitPath, 'dialog'], false)
+    setState([...submitPath, 'dialog'], false);
+    clearState([...submitPath, 'error']);
   };
 
   return (
@@ -240,47 +278,48 @@ export default function JobSubmitDialog({
       footer={
         <Box float="right">
           <SpaceBetween direction="horizontal" size="xs">
-            <Button onClick={cancel}>Cancel</Button>
-            <Button loading={submitting} onClick={submitJob}>Submit</Button>
+            <Button onClick={cancel}>{t("JobSubmitDialog.cancel")}</Button>
+            <Button loading={submitting} onClick={submitJobIfEntered} variant="primary">{t("JobSubmitDialog.submit")}</Button>
           </SpaceBetween>
         </Box>
       }
-      header="Submit Job">
+      header={t("JobSubmitDialog.header")}>
       <SpaceBetween direction="vertical" size="m">
       <ColumnLayout columns={2} borders="vertical">
       
         <JobField 
-          header="Job Name" 
-          description="Please choose an identifier for this job." 
-          placeholder="job-name" 
+          header={t("JobSubmitDialog.job-name.header")}
+          description={t("JobSubmitDialog.job-name.description")}
+          placeholder={t("JobSubmitDialog.job-name.placeholder")}
           property='job-name'
         />
 
         <JobField
-          header="Working Directory" 
-          description="Please choose a working directory for the job [optional]" 
+          header={t("JobSubmitDialog.chdir.header")}
+          description={t("JobSubmitDialog.chdir.description")}
           placeholder="/home/ec2-user" 
           property='chdir'
+          disabled={isScriptSelected}
         />
 
         <JobField
-          header="Nodes"
-          description="Number of nodes for job [optional]"
+          header={t("JobSubmitDialog.nodes.header")}
+          description={t("JobSubmitDialog.nodes.description")}
           placeholder="0"
           property='nodes'
         />
 
         <JobField
-          header="Number of tasks"
-          description="Number of tasks for job [optional]"
+          header={t("JobSubmitDialog.ntasks.header")}
+          description={t("JobSubmitDialog.ntasks.description")}
           placeholder="0"
           property='ntasks'
         />
 
         { isMemBasedSchedulingEnabled && 
           <JobField
-            header={t("JobSubmitDialog.requiredMemory.header")}
-            description={t("JobSubmitDialog.requiredMemory.description")}
+            header={t("JobSubmitDialog.mem.header")}
+            description={t("JobSubmitDialog.mem.description")}
             placeholder="0"
             property='mem'
           />
@@ -292,24 +331,38 @@ export default function JobSubmitDialog({
           onChange={({detail}) => {jobTypeSelect(detail.value);}}
           value={jobType}
           items={[
-            {value: "command", label: "Run a command"},
-            {value: "file", label: "Run a script on the head node"}
+            {value: "command", label: t("JobSubmitDialog.jobTypeCommand.radioGroup")},
+            {value: "file", label: t("JobSubmitDialog.jobTypeFile.radioGroup")},
+            {value: "script", label: t("JobSubmitDialog.jobTypeScript.radioGroup"), disabled: !isSlurmApiEnabled, description: scriptSelectDescription}
           ]}
         />
-
-        <JobField
-          header={jobTypeHeader!}
-          description={jobTypeDescription!}
-          placeholder={jobTypePlaceholder!}
-          property='command'
-        />
-
       </ColumnLayout>
-      <ExpandableSection header="Cost estimate">
+
+        { isScriptSelected ? 
+          <>
+          <FileUploadButton handleData={(data: string) => setState([...jobPath, 'command'], data)}/>
+          <ConfigView 
+            config={jobTypePlaceholder!}
+            // language="sh"
+            onChange={({ detail }: any) => {
+              setState([...jobPath, 'command'], detail.value);
+            }}>
+          </ConfigView>
+          </>
+          :
+          <JobField
+            header={jobTypeHeader!}
+            description={jobTypeDescription!}
+            placeholder={jobTypePlaceholder!}
+            property='command'
+          />
+        }
+
+      <ExpandableSection header={t("JobSubmitDialog.costEstimate.header")}>
         <JobCostEstimate />
       </ExpandableSection>
       </SpaceBetween>
-      <div style={{color: 'red', marginTop: "20px"}}>{(error || "").split('\n').map((line: any, i: any) => <div key={i}>{line}</div>)}</div>
+      <div style={{color: 'red', marginTop: "20px"}}>{error.split('\n').map((line: any, i: any) => <div key={i}>{line}</div>)}</div>
     </Modal>
   );
 }

--- a/frontend/src/old-pages/Clusters/Scheduling.tsx
+++ b/frontend/src/old-pages/Clusters/Scheduling.tsx
@@ -189,6 +189,8 @@ export default function ClusterScheduling() {
   const jobs: JobSummary[] = useState(['clusters', 'index', clusterName, 'jobs']);
   const defaultRegion = useState(['aws', 'region']);
   const region = useState(['app', 'selectedRegion']) || defaultRegion;
+  const jobInfoPath = ['app', 'clusters', 'jobInfo']
+  const jobSubmitPath = ['app', 'clusters', 'jobSubmit']
 
   function isSsmPolicy(p: any) {
     return p.hasOwnProperty('Policy') && p.Policy === ssmPolicy(region);
@@ -207,7 +209,7 @@ export default function ClusterScheduling() {
   }, [])
 
   const selectJobCallback = (jobInfo: any) => {
-    setState(['app', 'clusters', 'jobInfo', 'data'], jobInfo);
+    setState([...jobInfoPath, 'data'], jobInfo);
   }
 
   const selectJob = (jobId: string) => {
@@ -217,8 +219,8 @@ export default function ClusterScheduling() {
       const cluster = getState(clusterPath);
       let user = clusterDefaultUser(cluster);
       const headNode = getState([...clusterPath, 'headNode']);
-      clearState(['app', 'clusters', 'jobInfo', 'data']);
-      headNode && setState(['app', 'clusters', 'jobInfo', 'dialog'], true);
+      clearState([...jobInfoPath, 'data']);
+      headNode && setState([...jobInfoPath, 'dialog'], true);
       headNode && JobInfo(headNode.instanceId, user, jobId, selectJobCallback);
     }
   }
@@ -247,11 +249,18 @@ export default function ClusterScheduling() {
     }
   );
 
+  const showJobSubmitDialog = () => {
+    setState([...jobSubmitPath, 'dialog'], true);
+    if (!getState([...jobSubmitPath, 'job-entry'])) {
+      setState([...jobSubmitPath, 'job-entry'], 'command');
+      setState([...jobSubmitPath, 'job', 'wrap'], true);
+    }
+  }
 
   return <SpaceBetween direction="vertical" size="s">
     <JobModal />
     <JobSubmitDialog submitCallback={refreshQueues}/>
-    {ssmEnabled && <Button variant="primary" disabled={fleetStatus !== "RUNNING"} onClick={() => setState(['app', 'clusters', 'jobSubmit', 'dialog'], true)}>Submit Job</Button>}
+    {ssmEnabled && <Button variant="primary" disabled={fleetStatus !== "RUNNING"} onClick={showJobSubmitDialog}>Submit Job</Button>}
     {clusterMinor > 0 && ssmEnabled &&
         (jobs ? <Table {...collectionProps} trackBy="job_id" columnDefinitions={[
                 {


### PR DESCRIPTION
## Description

Added an option to submit jobs by file upload or manual entry through a code editor. This is a proof of concept for my Slurm REST API script. Jobs entered through this method are submitted through the Slurm API rather than SSM.

![Screen Shot 2022-08-16 at 6 35 17 PM](https://user-images.githubusercontent.com/47367209/185015293-94907a2d-e7ab-48d8-8d46-17fa3b5daac5.png)

## Changes

- Added a new component JobField to simplify JobSubmitDialog.
- Added a new API endpoint to proxy requests to the Slurm REST API.
- Added new `script` submit option, which is only selectable when a cluster has the Slurm REST API Custom Bootstrap Action enabled. ~~(waiting on #227)~~
- Fixed a couple bugs/issues along the way
  - State did not clear when user inputted and then deleted a job property, which caused the job to fail
  - Error messages were never cleared
  - Refactored SubmitJob endpoint to return a Promise
  - Use translations in JobSubmitDialog.tsx

## How Has This Been Tested?

Manually submitted jobs with different properties and checked the request submitted to the Slurm API.

## References

#197
https://slurm.schedmd.com/rest_api.html#slurmV0038SubmitJob

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.