### PR TITLE
Freeze requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-flask_restful
-flask_cors
-boto3
-requests
-python-jose
-pyyaml
-pytest
-pytest-mock
+Flask-RESTful==0.3.9
+Flask-Cors==3.0.10
+boto3==1.24.30
+requests==2.28.1
+python-jose==3.3.0
+PyYAML==6.0
+pytest==7.1.2
+pytest-mock==3.8.2


### PR DESCRIPTION
## Description

This PR locks dependencies to the specific version we are currently using.

**Please note:**
The requirements.txt file is currently missing `flask` (and may be missing something else). Also we currently list `pyyaml` which I don't think is used anywhere. We should address this issues

## Changes

- change `requirements.txt` via `pip freeze`

## How Has This Been Tested?

- running `pip install -r requirements.txt` yields `Requirement already satisfied` for every dependency listed in the requirements file
- cleaned up the virtualenv using `pip uninstall -y -r <(pip freeze -r requirements.txt)` and reinstalled dependencies via `pip install -r requirements.txt`. Installed versions match the content of the frozen requirements.txt

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.