### PR TITLE
fix: on missing idtoken or accesstoken return 401

### DIFF
--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -561,7 +561,7 @@ def get_identity():
 
     access_token = request.cookies.get("accessToken")
     id_token = request.cookies.get("idToken")
-    if not access_token:
+    if not (access_token and id_token):
         return {"message": "No access token."}, 401
     try:
         decoded = jwt_decode(access_token)


### PR DESCRIPTION
## Description
Fixed a small bug on missing id_token in requests
It caused a 500 in the get_identity_() controller function

## How Has This Been Tested?
This has been tested in a deployed environment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.