### PR TITLE
Fix logout running into a 400

### DIFF
--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -675,7 +675,7 @@ def login():
 
 
 def logout():
-    resp = redirect("/login", code=302)
+    resp = redirect("/index.html", code=302)
     resp.set_cookie("accessToken", "", expires=0)
     resp.set_cookie("idToken", "", expires=0)
     resp.set_cookie("refreshToken", "", expires=0)

--- a/api/tests/test_logout.py
+++ b/api/tests/test_logout.py
@@ -1,0 +1,28 @@
+import os
+from unittest import mock
+from api.PclusterApiHandler import logout
+
+
+def test_logout_redirect():
+    """
+    Given an handler for the /logout endpoint
+      When user logs out
+        Then it should redirect to index.html
+    """
+    res = logout()
+
+    assert res.status_code == 302
+    assert res.location == '/index.html'
+
+def test_logout_clear_cookies(mocker, app):
+    """
+    Given an handler for the /logout endpoint
+      When user logs out
+        Then it should clear the authentication cookies
+    """
+    res = logout()
+    
+    cookie_list = res.headers.getlist('Set-Cookie')
+    assert "accessToken=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/" in cookie_list
+    assert "idToken=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/" in cookie_list
+    assert "refreshToken=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/" in cookie_list


### PR DESCRIPTION
## Description

This PR fixes the logout button resulting into a 400 for the user

**Please note**: This PR does not introduce actual logout to the auth provider (Cognito). It simply fixes the user facing issue of having a broken experience when logging out

## Changes

- redirect to `/index.html` upon logout
- add tests to `logout()` function

## Changelog entry

Fix logout button sending users to a broken URL

## How Has This Been Tested?

- Manually, logged out and checked redirection worked out fine
- pytest

## PR Quality Checkilst

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
