### PR TITLE
Fix react query updates

### DIFF
--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -17,6 +17,7 @@ import { LoadInitialState} from '../model'
 // UI Elements
 import { SideBarIcons } from './SideBar';
 import TopNavigation from "@awsui/components-react/top-navigation";
+import { useQueryClient } from 'react-query';
 
 function regions(selected: any) {
   let supportedRegions = [
@@ -90,6 +91,7 @@ function regions(selected: any) {
 
 export default function Topbar(props: any) {
   let username = useState(['identity', 'attributes', 'email']);
+  const queryClient = useQueryClient();
 
   const defaultRegion = useState(['aws', 'region']) || "DEFAULT";
   const region = useState(['app', 'selectedRegion']) || defaultRegion;
@@ -102,6 +104,7 @@ export default function Topbar(props: any) {
     let newRegion = region.detail.id;
     setState(['app', 'selectedRegion'], newRegion);
     LoadInitialState();
+    queryClient.invalidateQueries();
   }
 
   const profileActions = [

--- a/frontend/src/old-pages/Clusters/Clusters.tsx
+++ b/frontend/src/old-pages/Clusters/Clusters.tsx
@@ -7,10 +7,10 @@
 // or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 // OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
-import React from 'react';
-import { NavigateFunction, useNavigate, useParams } from "react-router-dom"
+import React, { useEffect } from 'react';
+import { useNavigate, useParams } from "react-router-dom"
 import { ListClusters } from '../../model'
-import { useState, getState, clearState, setState, isAdmin } from '../../store'
+import { useState, clearState, setState, isAdmin } from '../../store'
 import { selectCluster } from './util'
 import { findFirst } from '../../util'
 import { useTranslation } from 'react-i18next';
@@ -34,7 +34,6 @@ import Details from "./Details";
 import { wizardShow } from '../Configure/Configure';
 import AddIcon from '@mui/icons-material/Add';
 
-
 export interface Cluster {
   cloudformationStackArn: string,
   cloudformationStackStatus: string,
@@ -42,29 +41,6 @@ export interface Cluster {
   clusterStatus: string,
   region: string,
   version: string
-}
-
-async function updateClusterList(navigate: NavigateFunction) {
-  const selectedClusterName = getState(['app', 'clusters', 'selected']);
-  const oldStatus = getState(['app', 'clusters', 'selectedStatus']);
-
-  try {
-    const clusterList = await ListClusters();
-    if(selectedClusterName) {
-      const selectedCluster = findFirst(clusterList, (c: Cluster) => c.clusterName === selectedClusterName);
-      if(selectedCluster) {
-        if(oldStatus !== selectedCluster.clusterStatus) {
-          setState(['app', 'clusters', 'selectedStatus'], selectedCluster.clusterStatus);
-        }
-        if((oldStatus === 'CREATE_IN_PROGRESS' && selectedCluster.clusterStatus === 'CREATE_COMPLETE') || (oldStatus === 'UPDATE_IN_PROGRESS' && selectedCluster.clusterStatus === 'UPDATE_COMPLETE')) {
-            selectCluster(selectedClusterName, null);
-        } else if (oldStatus === 'DELETE_IN_PROGRESS') {
-          clearState(['app', 'clusters', 'selected']);
-          navigate('/clusters');
-        }
-      }
-    }
-  } catch (error) {}
 }
 
 type ClusterListProps = {
@@ -76,11 +52,6 @@ function ClusterList({ clusters }: ClusterListProps) {
   let navigate = useNavigate();
   let params = useParams();
   const { t } = useTranslation();
-
-  React.useEffect(() => {
-    const timerId = (setInterval(() => updateClusterList(navigate), 5000));
-    return () => { clearInterval(timerId); }
-  }, [])
 
   React.useEffect(() => {
     if(params.clusterName && selectedClusterName !== params.clusterName)
@@ -165,10 +136,31 @@ function ClusterList({ clusters }: ClusterListProps) {
 
 export default function Clusters () {
   const clusterName = useState(['app', 'clusters', 'selected']);
-  const cluster = useState(['clusters', 'index', clusterName]);
   const [ splitOpen, setSplitOpen ] = React.useState(true);
   const { t } = useTranslation();
-  const { data } = useQuery('LIST_CLUSTERS', () => ListClusters());
+  const { data } = useQuery('LIST_CLUSTERS', () => ListClusters(),  {
+    refetchInterval: 5000,
+  });
+  const selectedClusterName = useState(['app', 'clusters', 'selected']);
+  const oldStatus = useState(['app', 'clusters', 'selectedStatus']);
+  let navigate = useNavigate();
+
+  useEffect(() => {
+    if(selectedClusterName) {
+      const selectedCluster = findFirst(data, (c: Cluster) => c.clusterName === selectedClusterName);
+      if(selectedCluster) {
+        if(oldStatus !== selectedCluster.clusterStatus) {
+          setState(['app', 'clusters', 'selectedStatus'], selectedCluster.clusterStatus);
+        }
+        if((oldStatus === 'CREATE_IN_PROGRESS' && selectedCluster.clusterStatus === 'CREATE_COMPLETE') || (oldStatus === 'UPDATE_IN_PROGRESS' && selectedCluster.clusterStatus === 'UPDATE_COMPLETE')) {
+            selectCluster(selectedClusterName, null);
+        } else if (oldStatus === 'DELETE_IN_PROGRESS') {
+          clearState(['app', 'clusters', 'selected']);
+          navigate('/clusters');
+        }
+      }
+    }
+  }, [selectedClusterName, oldStatus, data, navigate])
 
   return (
     <AppLayout

--- a/frontend/src/old-pages/Clusters/__tests__/Clusters.test.tsx
+++ b/frontend/src/old-pages/Clusters/__tests__/Clusters.test.tsx
@@ -1,15 +1,15 @@
 import { ThemeProvider } from '@emotion/react'
 import { createTheme } from '@mui/material'
-import { render, waitFor, screen, prettyDOM } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { I18nextProvider } from 'react-i18next'
 import { QueryClient, QueryClientProvider } from 'react-query'
 import { Provider } from 'react-redux'
-import { BrowserRouter, useNavigate } from 'react-router-dom'
+import { BrowserRouter } from 'react-router-dom'
 import i18n from '../../../i18n'
 import { ListClusters } from '../../../model'
-import { store, isAdmin } from '../../../store'
-import Clusters from '../Clusters'
+import { store, clearState, setState } from '../../../store'
+import Clusters, { onClustersUpdate } from '../Clusters'
 
 
 const queryClient = new QueryClient();
@@ -43,13 +43,15 @@ jest.mock('../../../model', () => ({
 jest.mock('../../../store', () => ({
   ...jest.requireActual('../../../store') as any,
   isAdmin: () => true,
+  setState: jest.fn(),
+  clearState: jest.fn(),
 }));
 
-const mockedUseNavigate = jest.fn();
+const mockNavigate = jest.fn();
 
 jest.mock('react-router-dom', () => ({
    ...jest.requireActual('react-router-dom') as any,
-  useNavigate: () => mockedUseNavigate,
+  useNavigate: () => mockNavigate,
 }));
 
 describe('given a component to show the clusters list', () => {
@@ -57,7 +59,7 @@ describe('given a component to show the clusters list', () => {
   describe('when the clusters list is available', () => {
     beforeEach(() => {
       (ListClusters as jest.Mock).mockResolvedValue(mockClusters);
-      mockedUseNavigate.mockReset();
+      mockNavigate.mockReset();
     });
 
     it('should render the clusters', async () => {
@@ -81,7 +83,7 @@ describe('given a component to show the clusters list', () => {
         ))       
         
         await userEvent.click(output.getByRole('radio'))
-        expect(mockedUseNavigate).toHaveBeenCalledWith('/clusters/test-cluster')
+        expect(mockNavigate).toHaveBeenCalledWith('/clusters/test-cluster')
       })
     })
 
@@ -94,7 +96,7 @@ describe('given a component to show the clusters list', () => {
         ))       
         
         await userEvent.click(output.getByText('Create Cluster'))
-        expect(mockedUseNavigate).toHaveBeenCalledWith('/configure')
+        expect(mockNavigate).toHaveBeenCalledWith('/configure')
       })
     })
   })
@@ -115,3 +117,36 @@ describe('given a component to show the clusters list', () => {
     }) 
   }) 
 })
+
+describe("Given a list of clusters", () => {
+  beforeEach(() => jest.resetAllMocks()); 
+  describe("when a cluster is selected and the list is updated", () => {
+    describe("when the cluster has a new status", () => {
+      it("should be saved", () => {
+        onClustersUpdate("test-cluster", mockClusters, "CREATE_IN_PROGRESS", mockNavigate);
+
+        expect(setState).toHaveBeenCalledWith(['app', 'clusters', 'selectedStatus'], "CREATE_COMPLETE");
+      });
+    });
+
+    describe("when the cluster has the same status", () => {
+      it("should not be updated", () => {
+        onClustersUpdate("test-cluster", mockClusters, "CREATE_COMPLETE", mockNavigate);
+
+        expect(setState).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when a cluster is deleted", () => {
+      beforeEach(() => {
+        onClustersUpdate("test-cluster", mockClusters, "DELETE_IN_PROGRESS", mockNavigate);
+      });
+      it("should become unselected", () => {
+        expect(clearState).toHaveBeenCalledWith(['app', 'clusters', 'selected']);
+      });
+      it("should navigate to the clusters list", () => {
+        expect(mockNavigate).toHaveBeenCalledWith('/clusters');
+      });
+    });
+  })
+});


### PR DESCRIPTION
## Description

This PR resolves an issue emerged from https://github.com/aws-samples/pcluster-manager/pull/219 where a user might not get a clusters list update when a region is changed. This happens because when you switch the region, `react-query` is not informed that the change happened, and the user still sees the old data.

## Changes

- invalidate all queries state when a region is changed
- refactored part of the clusters list to poll the list status by leveraging react-query
- removed a side effect from the clusters list update function that might cause unwanted navigation on a cluster update

## How Has This Been Tested?

- created a new cluster and verified that is selected
- deleted the cluster and verified that becomes unselected

## PR Quality Checkilst

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
