### PR TITLE
Remove uuid and adopt simple util to generate a random string

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,7 +32,6 @@
         "react-query": "^3.39.1",
         "react-redux": "^7.2.5",
         "react-router-dom": "^6.2.2",
-        "uuid": "^8.3.2",
         "web-vitals": "^1.1.2"
       },
       "devDependencies": {
@@ -42,7 +41,6 @@
         "@types/jest": "^28.1.4",
         "@types/lodash": "^4.14.182",
         "@types/node": "^18.0.0",
-        "@types/uuid": "^8.3.4",
         "eslint": "^8.19.0",
         "eslint-config-next": "12.2.0",
         "jest": "^28.1.2",
@@ -4263,12 +4261,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
-      "dev": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -14441,14 +14433,6 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -17665,12 +17649,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
-      "dev": true
-    },
-    "@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
     },
     "@types/yargs": {
@@ -25370,11 +25348,6 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz",
       "integrity": "sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==",
       "requires": {}
-    },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,6 @@
     "react-query": "^3.39.1",
     "react-redux": "^7.2.5",
     "react-router-dom": "^6.2.2",
-    "uuid": "^8.3.2",
     "web-vitals": "^1.1.2"
   },
   "scripts": {
@@ -60,7 +59,6 @@
     "@types/jest": "^28.1.4",
     "@types/lodash": "^4.14.182",
     "@types/node": "^18.0.0",
-    "@types/uuid": "^8.3.4",
     "eslint": "^8.19.0",
     "eslint-config-next": "12.2.0",
     "jest": "^28.1.2",

--- a/frontend/src/auth/handleNotAuthorizedErrors.ts
+++ b/frontend/src/auth/handleNotAuthorizedErrors.ts
@@ -10,6 +10,7 @@
 
 import { AxiosError } from 'axios';
 import { AppConfig } from '../app-config/types';
+import { generateRandomId } from '../util';
 
 export const handleNotAuthorizedErrors = ({authUrl, clientId, scopes, redirectUri}: AppConfig) => async (requestPromise: Promise<any>) => {
   return requestPromise.catch(
@@ -26,10 +27,6 @@ export const handleNotAuthorizedErrors = ({authUrl, clientId, scopes, redirectUr
 }
 
 function redirectToAuthServer(authUrl: string, clientId: string, scopes: string, redirectUri: string) {
-  const url = `${authUrl}?response_type=code&client_id=${clientId}&scope=${encodeURIComponent(scopes)}&redirect_uri=${redirectUri}&state=${oauth2StateParameter()}`
+  const url = `${authUrl}?response_type=code&client_id=${clientId}&scope=${encodeURIComponent(scopes)}&redirect_uri=${redirectUri}&state=${generateRandomId()}`
   window.location.replace(url)
-}
-
-function oauth2StateParameter(length = 16): string {
-    return Math.random().toString(20).substring(2, length)
 }

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -11,7 +11,7 @@
 import axios from 'axios'
 import { setState, getState, clearState, updateState, clearAllState } from './store'
 import { USER_ROLES_CLAIM } from './auth/constants';
-import { v4 as uuidv4 } from 'uuid';
+import { generateRandomId } from './util';
 
 // UI Elements
 import { handleNotAuthorizedErrors } from './auth/handleNotAuthorizedErrors';
@@ -28,7 +28,7 @@ const axiosInstance = axios.create({
 
 function notify(text: any, type='info', id?: string, dismissible=true) {
 
-  let messageId = id || uuidv4();
+  let messageId = id || generateRandomId();
   let newMessage = {type: type,
     content: text,
     id: messageId,

--- a/frontend/src/util.ts
+++ b/frontend/src/util.ts
@@ -78,4 +78,8 @@ function clamp(num: number, min: number, max: number, step?: number): number
   return clamped - remain;
 }
 
-export { clamp, getIn, swapIn, setIn, updateIn, findFirst, clusterDefaultUser }
+function generateRandomId(length = 16) {
+  return Math.random().toString(20).substring(2, length)
+}
+
+export { generateRandomId, clamp, getIn, swapIn, setIn, updateIn, findFirst, clusterDefaultUser }


### PR DESCRIPTION
## Description

This PR removes a dependency we don't need at the moment. This is also an easy solution to our [CI failing like this](https://github.com/aws-samples/pcluster-manager/runs/7670526834?check_suite_focus=true)

## Changes

- remove `uuid`
- refactor `oauth2StateParameter` to be a generic util

## How Has This Been Tested?

- manually tested notifications
- jest

## PR Quality Checkilst

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
