### PR TITLE
Mutable email field in pcluster-manager-cognito CloudFormation template

### DIFF
--- a/infrastructure/pcluster-manager-cognito.yaml
+++ b/infrastructure/pcluster-manager-cognito.yaml
@@ -194,8 +194,8 @@ Resources:
           - !Ref AWS::NoValue
       Schema: !If
         - MFA
-        - [{Name: email, AttributeDataType: String, Mutable: false, Required: true}, {Name: phone_number, AttributeDataType: String, Mutable: false, Required: true}]
-        - [{Name: email, AttributeDataType: String, Mutable: false, Required: true}]
+        - [{Name: email, AttributeDataType: String, Mutable: true, Required: true}, {Name: phone_number, AttributeDataType: String, Mutable: false, Required: true}]
+        - [{Name: email, AttributeDataType: String, Mutable: true, Required: true}]
       UserPoolName: !Sub ${AWS::StackName}-userpool
       UsernameConfiguration:
         CaseSensitive: false


### PR DESCRIPTION

## Description
Changing email as a mutable field to avoid breaking second login in Cognito setup with AD SAML federation.

<!-- Summary of what this PR introduces and possibly why -->

## Changes
- Email field `mutable` attribute to `true` from `false`
<!-- List of relevant changes introduced -->

## Changelog entry
- Fix: Email field `mutable` attribute set to `true` to fix an issue where second login would break authentication process in Cognito
<!-- A sentence to be added to the next release's changelog that captures the changes in this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
