### PR TITLE
Type translations

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -333,7 +333,8 @@
     "components": {
       "customAmi": {
         "label": "Use Custom AMI?",
-        "help": "Custom AMI's provide a way to customize the cluster. See the <0>Image section</0> of the documentation for more information."
+        "help": "Custom AMI's provide a way to customize the cluster. See the <0>Image section</0> of the documentation for more information.",
+        "suggestLabel": "Custom AMI ID"
       },
       "rootVolume": {
         "size": {

--- a/frontend/src/i18n-resources.d.ts
+++ b/frontend/src/i18n-resources.d.ts
@@ -1,0 +1,9 @@
+// src/i18n-resources.d.ts
+
+import 'react-i18next'
+
+declare module 'react-i18next' {
+  export interface Resources {
+    translation: typeof import('../locales/en/strings.json')
+  }
+}

--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -253,7 +253,7 @@ function CustomAMISettings({
         </HelpTooltip>
       </div>
       {customAmiEnabled &&
-        <FormField label={t('wizard.components.customAmi.AmiId')} errorText={error}>
+        <FormField label={t('wizard.components.customAmi.suggestLabel')} errorText={error}>
           <Autosuggest
             onChange={({ detail }) => {if(detail.value !== customAmi){setState(customAmiPath, detail.value);}}}
             value={customAmi || ""}


### PR DESCRIPTION
## Description

This PR uses Typescript to check if a key supplied to the translation function exists, and if it does not exist, trigger an error during the build.

## Changes

- all keys of `string.json` are now suggested when using the translation function
- fix an existing key which didn't exist

## How Has This Been Tested?

- run `npm run ts-validate` and verified that the project builds correctly

## PR Quality Checkilst

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
