### PR TITLE
Handle id token and access token attributes in get_identity

### DIFF
--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -557,9 +557,9 @@ def _populate_identity(identity, decoded, claims):
     if "username" in decoded:
         identity["username"] = decoded["username"]
 
-    for key, value in decoded.items():
-        if key in claims:
-            identity["attributes"][key] = value
+    for claim in claims:
+      if claim in decoded:
+        identity["attributes"][claim] = decoded[claim]
     
 
 def get_identity():

--- a/api/tests/test_get_identity.py
+++ b/api/tests/test_get_identity.py
@@ -1,20 +1,17 @@
-import os
-from unittest import mock
 from api.PclusterApiHandler import get_identity
 
 
 MOCK_IDENTITY_OBJECT = {"user_roles": ["user", "admin"], "username": "username", "attributes": {"email": "user@domain.com"}}
 
-@mock.patch.dict(os.environ,{"ENABLE_AUTH": "false"})
-def test_get_identity_auth_disabled():
+def test_get_identity_auth_disabled(monkeypatch):
     """
     Given an handler for the /get-identity endpoint
       When authentication is disabled
         Then it should return a static identity object
     """
+    monkeypatch.setenv("ENABLE_AUTH", "false")
     assert get_identity() == MOCK_IDENTITY_OBJECT
 
-@mock.patch.dict(os.environ,{"ENABLE_AUTH": "true"})
 def test_get_identity_auth_enabled_both_tokens_provide_attributes(monkeypatch, mocker, app):
     """
     Given an handler for the /get-identity endpoint
@@ -22,6 +19,7 @@ def test_get_identity_auth_enabled_both_tokens_provide_attributes(monkeypatch, m
       When both access token and identity token contain the same user attributes
         Then it should return the attributes contained in the identity token
     """
+    monkeypatch.setenv("ENABLE_AUTH", "true")
     monkeypatch.setattr('api.PclusterApiHandler.USER_ROLES_CLAIM', 'user_roles_claim')
     accessTokenDecoded = {
       'user_roles_claim': ['access-token-group'],
@@ -42,7 +40,6 @@ def test_get_identity_auth_enabled_both_tokens_provide_attributes(monkeypatch, m
           'username': 'id-token-username'
       }
 
-@mock.patch.dict(os.environ,{"ENABLE_AUTH": "true"})
 def test_get_identity_auth_enabled_access_tokens_used_as_fallback(monkeypatch, mocker, app):
     """
     Given an handler for the /get-identity endpoint
@@ -50,6 +47,7 @@ def test_get_identity_auth_enabled_access_tokens_used_as_fallback(monkeypatch, m
       When identity token is missing some user attributes
         Then it should fallback to the attributes contained in the access token
     """
+    monkeypatch.setenv("ENABLE_AUTH", "true")
     monkeypatch.setattr('api.PclusterApiHandler.USER_ROLES_CLAIM', 'user_roles_claim')
     accessTokenDecoded = {
       'user_roles_claim': ['access-token-group'],
@@ -68,7 +66,6 @@ def test_get_identity_auth_enabled_access_tokens_used_as_fallback(monkeypatch, m
           'username': 'access-token-username'
       }
 
-@mock.patch.dict(os.environ,{"ENABLE_AUTH": "true"})
 def test_get_identity_auth_enabled_no_username_provided(monkeypatch, mocker, app):
     """
     Given an handler for the /get-identity endpoint
@@ -76,6 +73,7 @@ def test_get_identity_auth_enabled_no_username_provided(monkeypatch, mocker, app
       When username could not be retrieved
         Then it should return a 400
     """
+    monkeypatch.setenv("ENABLE_AUTH", "true")
     monkeypatch.setattr('api.PclusterApiHandler.USER_ROLES_CLAIM', 'user_roles_claim')
     accessTokenDecoded = {}
     identityTokenDecoded = {
@@ -87,7 +85,6 @@ def test_get_identity_auth_enabled_no_username_provided(monkeypatch, mocker, app
 
       assert get_identity() == ({"message": "No username present in access or id token."}, 400)
 
-@mock.patch.dict(os.environ,{"ENABLE_AUTH": "true"})
 def test_get_identity_auth_enabled_no_user_roles_provided(monkeypatch, mocker, app):
     """
     Given an handler for the /get-identity endpoint
@@ -95,6 +92,7 @@ def test_get_identity_auth_enabled_no_user_roles_provided(monkeypatch, mocker, a
       When user roles could not be retrieved
         Then it should fallback to "user" as user role
     """
+    monkeypatch.setenv("ENABLE_AUTH", "true")
     monkeypatch.setattr('api.PclusterApiHandler.USER_ROLES_CLAIM', 'user_roles_claim')
     accessTokenDecoded = {}
     identityTokenDecoded = {

--- a/api/tests/test_get_identity.py
+++ b/api/tests/test_get_identity.py
@@ -6,10 +6,107 @@ from api.PclusterApiHandler import get_identity
 MOCK_IDENTITY_OBJECT = {"user_roles": ["user", "admin"], "username": "username", "attributes": {"email": "user@domain.com"}}
 
 @mock.patch.dict(os.environ,{"ENABLE_AUTH": "false"})
-def test_get_identity():
+def test_get_identity_auth_disabled():
     """
     Given an handler for the /get-identity endpoint
       When authentication is disabled
         Then it should return a static identity object
     """
     assert get_identity() == MOCK_IDENTITY_OBJECT
+
+@mock.patch.dict(os.environ,{"ENABLE_AUTH": "true"})
+def test_get_identity_auth_enabled_both_tokens_provide_attributes(monkeypatch, mocker, app):
+    """
+    Given an handler for the /get-identity endpoint
+      When authentication is enabled
+      When both access token and identity token contain the same user attributes
+        Then it should return the attributes contained in the identity token
+    """
+    monkeypatch.setattr('api.PclusterApiHandler.USER_ROLES_CLAIM', 'user_roles_claim')
+    accessTokenDecoded = {
+      'user_roles_claim': ['access-token-group'],
+      'username': 'access-token-username',
+      'email': 'access-token-email'
+    }
+    identityTokenDecoded = {
+      'user_roles_claim': ['id-token-group'],
+      'username': 'id-token-username',
+      'email': 'id-token-email'
+    }
+    with app.test_request_context(headers={'Cookie': 'accessToken=access-token; idToken=identity-token'}):
+      mocker.patch('api.PclusterApiHandler.jwt_decode', side_effect=[accessTokenDecoded, identityTokenDecoded])
+
+      assert get_identity() == {
+          'attributes': {'email': 'id-token-email'},
+          'user_roles': ['id-token-group'],
+          'username': 'id-token-username'
+      }
+
+@mock.patch.dict(os.environ,{"ENABLE_AUTH": "true"})
+def test_get_identity_auth_enabled_access_tokens_used_as_fallback(monkeypatch, mocker, app):
+    """
+    Given an handler for the /get-identity endpoint
+      When authentication is enabled
+      When identity token is missing some user attributes
+        Then it should fallback to the attributes contained in the access token
+    """
+    monkeypatch.setattr('api.PclusterApiHandler.USER_ROLES_CLAIM', 'user_roles_claim')
+    accessTokenDecoded = {
+      'user_roles_claim': ['access-token-group'],
+      'username': 'access-token-username',
+      'email': 'access-token-email'
+    }
+    identityTokenDecoded = {
+      'email': 'id-token-email'
+    }
+    with app.test_request_context(headers={'Cookie': 'accessToken=access-token; idToken=identity-token'}):
+      mocker.patch('api.PclusterApiHandler.jwt_decode', side_effect=[accessTokenDecoded, identityTokenDecoded])
+
+      assert get_identity() == {
+          'attributes': {'email': 'id-token-email'},
+          'user_roles': ['access-token-group'],
+          'username': 'access-token-username'
+      }
+
+@mock.patch.dict(os.environ,{"ENABLE_AUTH": "true"})
+def test_get_identity_auth_enabled_no_username_provided(monkeypatch, mocker, app):
+    """
+    Given an handler for the /get-identity endpoint
+      When authentication is enabled
+      When username could not be retrieved
+        Then it should return a 400
+    """
+    monkeypatch.setattr('api.PclusterApiHandler.USER_ROLES_CLAIM', 'user_roles_claim')
+    accessTokenDecoded = {}
+    identityTokenDecoded = {
+      'user_roles': ['id-token-group'],
+      'email': 'id-token-email'
+    }
+    with app.test_request_context(headers={'Cookie': 'accessToken=access-token; idToken=identity-token'}):
+      mocker.patch('api.PclusterApiHandler.jwt_decode', side_effect=[accessTokenDecoded, identityTokenDecoded])
+
+      assert get_identity() == ({"message": "No username present in access or id token."}, 400)
+
+@mock.patch.dict(os.environ,{"ENABLE_AUTH": "true"})
+def test_get_identity_auth_enabled_no_user_roles_provided(monkeypatch, mocker, app):
+    """
+    Given an handler for the /get-identity endpoint
+      When authentication is enabled
+      When user roles could not be retrieved
+        Then it should fallback to "user" as user role
+    """
+    monkeypatch.setattr('api.PclusterApiHandler.USER_ROLES_CLAIM', 'user_roles_claim')
+    accessTokenDecoded = {}
+    identityTokenDecoded = {
+      'username': 'id-token-username',
+      'email': 'id-token-email'
+    }
+    with app.test_request_context(headers={'Cookie': 'accessToken=access-token; idToken=identity-token'}):
+      mocker.patch('api.PclusterApiHandler.jwt_decode', side_effect=[accessTokenDecoded, identityTokenDecoded])
+
+      assert get_identity() == {
+        'attributes': {'email': 'id-token-email'},
+        'user_roles': ['user'],
+        'username': 'id-token-username'
+      }
+      

--- a/api/tests/test_pcluster_api_handler.py
+++ b/api/tests/test_pcluster_api_handler.py
@@ -1,21 +1,5 @@
 from unittest import mock
-from api.PclusterApiHandler import _get_user_roles, login
-
-
-@mock.patch("api.PclusterApiHandler.USER_ROLES_CLAIM", "user_roles")
-def test_user_roles():
-    user_roles = ["user", "admin"]
-
-    _test_decoded_with_user_roles_claim(decoded={"user_roles": user_roles}, user_roles=user_roles)
-    _test_decoded_without_user_roles_claim(decoded={})
-
-
-def _test_decoded_with_user_roles_claim(decoded, user_roles):
-    assert _get_user_roles(decoded) == user_roles
-
-
-def _test_decoded_without_user_roles_claim(decoded):
-    assert _get_user_roles(decoded) == ["user"]
+from api.PclusterApiHandler import login
 
 
 @mock.patch("api.PclusterApiHandler.requests.post")


### PR DESCRIPTION
## Description

Currently PCM retrieves `user_groups` and `username` claims from the access token, and store all the claims of the id token in the `attributes` field of the object returned by the `get_identity` function.

In order to avoid forcing the customer to specify which attributes will end up in the access token and which ones in the ID token, we have to refactor our current logic.

The idea is to get user attributes from the access token first and then from the id token, resolving all conflicts in favor of the id token.

## Changes

* `user_groups`, `username` and `email` claims are now retrieved from both access token and id token, giving higher priority to the latter (i.e. if a claim is available in both tokens, the id token claim will be returned in the identity object)
* dropped unused parameters in the returned identity object

## Changelog entry

* Handle both id token and access token claims in get_identity endpoint, giving higher priority to id token ones

## How Has This Been Tested?

* Run PCM locally pointing to Cognito user pool in my personal account setting the following environment variables:
```
export SECRET_ID
export AUTH_PATH
export USER_POOL_ID
export AUDIENCE
export CLIENT_ID
export CLIENT_SECRET
```
* Manually inspected `get_identity` output and verified that id token claims overrode access token claims

## PR Quality Checkilst

- [x] I added tests to new or existing code
- [n/a] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
