### PR TITLE
Remove superfluous SNS topic from PCM Cfn template

### DIFF
--- a/infrastructure/pcluster-manager.yaml
+++ b/infrastructure/pcluster-manager.yaml
@@ -229,7 +229,6 @@ Resources:
         - { Version: !Join ['_', !Split ['.', !FindInMap [PclusterManager, Constants, Version]]], StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
       InstanceProfileName: !Ref ImageBuilderInstanceProfile
       TerminateInstanceOnFailure: true
-      SnsTopicArn: !Ref EcrImageBuilderSNSTopic
       SubnetId:
         Fn::If:
           - NonDefaultVpc
@@ -279,11 +278,6 @@ Resources:
       InfrastructureConfigurationArn: !Ref InfrastructureConfiguration
       ImageTestsConfiguration:
         ImageTestsEnabled: false
-
-  EcrImageBuilderSNSTopic:
-    Type: AWS::SNS::Topic
-    Properties:
-      DisplayName: "PclusterManager ECR Image Builder SNS topic"
 
   EcrImageDeletionLambda:
     Type: AWS::Lambda::Function


### PR DESCRIPTION
## Description
This patch removes the unused `EcrImageBuilderSNSTopic` from the PCM CloudFormation template. The topic was initially added to the PC API CloudFromation template in [#3054](https://github.com/aws/aws-parallelcluster/pull/3054) and was used when updating the Docker image to switch the image, backing the PC API Lambda function. This SNS topic is not used in the PCM template and can therefore be removed.

### Tests
Deployed a new PCM Cfn stack and performed the relevant tests in the checklist below.

## PR Quality Checkilst
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
