### PR TITLE
Remove push to main from PR workflow triggers

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,9 +4,6 @@ name: Pull Request
 on:
   #By default, a workflow only runs when a pull_request event's activity type is opened, synchronize, or reopened.
   pull_request:
-  push:
-    branches:
-      - main
 
 jobs:
   frontend-tests:


### PR DESCRIPTION
## Description
Running the unit tests is not needed when pushing to `main`: a direct push to `main` is disabled and thus tests are not needed.
Anyway, tests are done for safety before deploying the updated code in the `demo` environment, see #257.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
