### PR TITLE
Add PROJECT_GUIDELINES to Contributing section

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,6 +27,6 @@
 - [ ] I checked that a new cluster can be created (config is produced and dry run passes)
 - [ ] I checked that login and logout work as expected
 
-In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](CONTRIBUTING.md) and the [Project Guidelines](PROJECT_GUIDELINES.md)
+In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)
 
 By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@
 
 <!-- Any link to resources, issues, other PRs that are relevant to this PR -->
 
-## PR Quality Checkilst
+## PR Quality Checklist
 
 - [ ] I added tests to new or existing code
 - [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
@@ -26,5 +26,7 @@
 - [ ] I checked that clusters are listed correctly
 - [ ] I checked that a new cluster can be created (config is produced and dry run passes)
 - [ ] I checked that login and logout work as expected
+
+In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](CONTRIBUTING.md) and the [Project Guidelines](PROJECT_GUIDELINES.md)
 
 By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

--- a/PROJECT_GUIDELINES.md
+++ b/PROJECT_GUIDELINES.md
@@ -4,5 +4,5 @@ Contributions via pull requests are much appreciated. Before sending us a pull r
 
 - You have added tests, even if just the happy path, when adding or refactoring code
 - You used types in your TypeScript code so that we can leverage static analysis to maintain quality
-- You have interationalized any user-facing text or copy, by using our `i18n` solution ([as shown here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601)) so that we can translate in other languages in the future
+- You have interationalized any user-facing text or copy, by using our `i18n` solution ([as shown here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601)) so that we can translate to other languages in the future
 - You have followed the PR Quality Checklist available in our [Pull Request Template](.github/pull_request_template.md)

--- a/PROJECT_GUIDELINES.md
+++ b/PROJECT_GUIDELINES.md
@@ -1,0 +1,8 @@
+# Project Guidelines
+
+Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
+
+- You have added tests, even if just the happy path, when adding or refactoring code
+- You used types in your TypeScript code so that we can leverage static analysis to maintain quality
+- You have interationalized any user-facing text or copy, by using our `i18n` solution ([as shown here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601)) so that we can translate in other languages in the future
+- You have followed the PR Quality Checklist available in our [Pull Request Template](.github/pull_request_template.md)

--- a/README.md
+++ b/README.md
@@ -170,7 +170,12 @@ For detailed information on how to invoke `pytest`, see this [resource](https://
 
 ## Security
 
-See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
+See [Security Issue Notifications](CONTRIBUTING.md#security-issue-notifications) for more information.
+
+## Contributing
+
+Please refer to our [Contributing Guidelines](CONTRIBUTING.md) before reporting bugs or feature requests
+Please refer to our [Project Guidelines](PROJECT_GUIDELINES.md) before diving into the code
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ See [Security Issue Notifications](CONTRIBUTING.md#security-issue-notifications)
 ## Contributing
 
 Please refer to our [Contributing Guidelines](CONTRIBUTING.md) before reporting bugs or feature requests
+
 Please refer to our [Project Guidelines](PROJECT_GUIDELINES.md) before diving into the code
 
 ## License


### PR DESCRIPTION
## Description

This PR adds a Contributing section to our README, with Project Guidelines to be respected to maintain high quality code

## Changes

- add PROJECT_GUIDELINES.md
- add Contributing section to README.md
- link to Contributing Guidelines and Project Guidelines from our PR template

## How Has This Been Tested?

- browsed [the branch](https://github.com/aws-samples/pcluster-manager/tree/project-guidelines) to check that links work

## PR Quality Checkilst

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
