### PR TITLE
Script to update a CFN stack

### DIFF
--- a/infrastructure/environments/demo-cfn.yaml
+++ b/infrastructure/environments/demo-cfn.yaml
@@ -1,0 +1,12 @@
+TemplateURL: https://pcluster-manager-github-infrastructurebucket-7y5h202iem8l.s3.eu-west-1.amazonaws.com/pcluster-manager.yaml
+Parameters:
+  - ParameterKey: Version
+    ParameterValue: 3.2.0
+  - ParameterKey: InfrastructureBucket
+    ParameterValue: https://pcluster-manager-github-infrastructurebucket-7y5h202iem8l.s3.eu-west-1.amazonaws.com
+  - ParameterKey: AdminUserEmail
+    UsePreviousValue: true
+Capabilities:
+  - CAPABILITY_AUTO_EXPAND
+  - CAPABILITY_NAMED_IAM
+DisableRollback: false

--- a/infrastructure/environments/demo-variables.sh
+++ b/infrastructure/environments/demo-variables.sh
@@ -1,0 +1,3 @@
+REGION=eu-west-1
+BUCKET=pcluster-manager-github-infrastructurebucket-7y5h202iem8l
+STACK_NAME=pcluster-manager-demo

--- a/infrastructure/github-env-setup.yml
+++ b/infrastructure/github-env-setup.yml
@@ -16,10 +16,16 @@ Conditions:
     - ""
 
 Resources:
+  InfrastructureBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      VersioningConfiguration:
+        Status: Enabled
+
   PrivateDeployRole:
     Type: AWS::IAM::Role
-    Description: "Role used to deploy PCM to a private environment (for example, demo)"
     Properties:
+      Description: "Role used to deploy PCM to a private environment (for example, demo)"
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow

--- a/infrastructure/pcluster-manager.yaml
+++ b/infrastructure/pcluster-manager.yaml
@@ -33,6 +33,10 @@ Parameters:
     Description: (Optional) Select the subnet to use for building the container images. If not selected, Subnet in the default VPC will be used.
     Type: String
     Default: ''
+  InfrastructureBucket:
+    Description: S3 bucket where CloudFormation files are stored. Change this parameter only when testing changes made to the infrastructure itself.
+    Type: String
+    Default: ''
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -63,10 +67,11 @@ Metadata:
         default: Initial Admin's Phone Number
 
 Conditions:
-   NonDefaultVpc:
+  NonDefaultVpc:
     Fn::And:
       - !Not [!Equals [!Ref ImageBuilderVpcId, ""]]
       - !Not [!Equals [!Ref ImageBuilderSubnetId, ""]]
+  HasDefaultInfrastructure: !Equals [!Ref InfrastructureBucket, ''] 
 
 Mappings:
   PclusterManager:
@@ -88,7 +93,13 @@ Resources:
         CallbackURL: !Sub
          - https://${Api}.execute-api.${AWS::Region}.${AWS::URLSuffix}/login
          - Api: !Ref ApiGateway
-      TemplateURL: !Sub https://pcluster-manager-${AWS::Region}.s3.${AWS::Region}.amazonaws.com/pcluster-manager-cognito.yaml
+      TemplateURL: !Sub 
+        - '${Bucket}/pcluster-manager-cognito.yaml'
+        - Bucket: !If 
+          - HasDefaultInfrastructure
+          - !Sub https://pcluster-manager-${AWS::Region}.s3.${AWS::Region}.amazonaws.com
+          - !Sub ${InfrastructureBucket}
+
       TimeoutInMinutes: 10
 
   ParallelClusterApi:
@@ -115,7 +126,12 @@ Resources:
   SSMDefaultUser:
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: !Sub https://pcluster-manager-${AWS::Region}.s3.${AWS::Region}.amazonaws.com/SSMSessionProfile-cfn.yaml
+      TemplateURL: !Sub 
+        - '${Bucket}/SSMSessionProfile-cfn.yaml'
+        - Bucket: !If 
+          - HasDefaultInfrastructure
+          - !Sub https://pcluster-manager-${AWS::Region}.s3.${AWS::Region}.amazonaws.com
+          - !Sub ${InfrastructureBucket}
       TimeoutInMinutes: 30
 
   PclusterManagerFunction:

--- a/infrastructure/readme.md
+++ b/infrastructure/readme.md
@@ -11,3 +11,15 @@ To create the resources needed by the workflow action you can deploy the `./gith
 The stack will create a new role with the minimum set of policies needed to build and deploy an instance of PCluster Manager.
 
 **This procedure must be done only once per AWS account since IAM it's a global service.**
+
+## Update the infrastructure of an environment
+When a change is made to one of the following files:
+- pcluster-manager.yaml
+- pcluster-manager-cognito.yaml
+- SSMSessionProfile-cfn.yaml
+
+it is not sufficient to run the `update.sh` script to update the PCM instances because it builds and deploys the Lambda image (with only the changes to backend and frontend().
+To update the infrastructure just run the `infrastructure/update-environment-infra.sh` and pass the environment to update.
+If you have to update the `demo` environment do the following:
+- gain `Admin` access to the AWS account in which the environment is hosted
+- run `./infrastructure/update-environment-infra.sh demo`

--- a/infrastructure/update-environment-infra.sh
+++ b/infrastructure/update-environment-infra.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+
+# This script is used to update the infrastructure of a given PCM environment.
+# An environment is composed of a list of variables with the entrypoints of the environment
+# and a CloudFormation request file where the stack update can be customized,
+# for example by changing the parameters provided to the previous version of the stack
+#
+# Usage: ./infrastructure/update-infrastructure.sh [ENVIRONMENT]
+# Example: ./infrastructure/update-infrastructure.sh demo
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+FILES=(SSMSessionProfile-cfn.yaml pcluster-manager-cognito.yaml pcluster-manager.yaml)
+ENVIRONMENT=$1
+. ${SCRIPT_DIR}/environments/${ENVIRONMENT}-variables.sh
+
+# The yaml files describing the infrastructure are uploaded to a private S3 bucket
+# and then used to update the CloudFormation stack, where the same bucket is passed as parameters.
+# This is done to make sure that we deploy all the changes to the infrastructure, and not only the changes
+# made to pcluster-manager.yaml (the parent stack)
+echo Uploading to: ${BUCKET}
+for FILE in "${FILES[@]}"
+do
+  aws s3 cp ${SCRIPT_DIR}/${FILE} s3://${BUCKET}/${FILE}
+done
+
+# Launches a new CFN update: the script hangs until the stack is updated
+AWS_PAGER="cat" aws cloudformation update-stack --cli-input-yaml file://${SCRIPT_DIR}/environments/${ENVIRONMENT}-cfn.yaml --stack-name ${STACK_NAME} --region ${REGION}
+aws cloudformation wait stack-update-complete --stack-name ${STACK_NAME} --region ${REGION}


### PR DESCRIPTION
## Description
Provides an easy way to update the infrastructure of a specific environment on which PCM is running.
The script is run locally because of the complex IAM policy required by the workflow (it may be added later).

See the infrastructure readme or the script itself for more info.

## Changes

- add a new parameter to specify the infrastructure bucket on CFN
  - if left empy it will use the public yaml files
  - if a user provides a custom bucket it will use the files inside it
- add a script to update a CFN stack

## How Has This Been Tested?

Launched `./infrastructure/update-environment-infra.sh demo` on the demo environment and verified the stack is updated correctly

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
