### PR TITLE
Miscellaneous chores

### DIFF
--- a/docs/content/02-tutorials/02-slurm-accounting.md
+++ b/docs/content/02-tutorials/02-slurm-accounting.md
@@ -145,7 +145,7 @@ Choose a name for your job, a number of nodes to run under, choose to `Run a com
 
 ![Cluster Properties](accounting/submit-job-dialog.png)
 
-## Step 5 - View the Accounting Tab
+## Step 6 - View the Accounting Tab
 
 Once you've submitted a job, you can see the job information under the `Accounting tab`
 

--- a/docs/content/02-tutorials/05-cloud9.md
+++ b/docs/content/02-tutorials/05-cloud9.md
@@ -1,5 +1,5 @@
 +++
-title = "d. Cloud9 ☁️"
+title = "e. Cloud9 ☁️"
 weight = 25
 +++
 

--- a/docs/content/02-tutorials/06-downloading.md
+++ b/docs/content/02-tutorials/06-downloading.md
@@ -1,7 +1,7 @@
 
 +++
-title = "d. Downloading ⇓"
-weight = 25
+title = "f. Downloading ⇓"
+weight = 26
 +++
 
 This tutorial shows you how you can download a file from an external source at cluster start.

--- a/frontend/src/components/FileChooser.tsx
+++ b/frontend/src/components/FileChooser.tsx
@@ -69,8 +69,7 @@ function FileUploadButton(props: any) {
   };
   return (
     <div>
-      {/* @ts-expect-error TS(2322) FIXME: Type '"contained"' is not assignable to type 'Vari... Remove this comment to see the full error message */}
-      <Button onClick={handleClick} variant="contained">
+      <Button onClick={handleClick}>
         Choose file...
       </Button>
       <input

--- a/frontend/src/old-pages/Configure/Source.tsx
+++ b/frontend/src/old-pages/Configure/Source.tsx
@@ -37,6 +37,9 @@ import {
 import { HiddenUploader } from '../../components/FileChooser'
 import Loading from '../../components/Loading'
 
+// Types
+import { ClusterInfoSummary, ClusterStatus } from '../../types/clusters';
+
 // Constants
 const sourcePath = ['app', 'wizard', 'source'];
 const sourceErrorsPath = ['app', 'wizard', 'errors', 'source'];
@@ -111,8 +114,8 @@ function ClusterSelect() {
   let source = useState([...sourcePath, 'type']);
   let validated = useState([...sourceErrorsPath, 'validated']);
 
-  const itemToOption = (item: any) => {
-    if(item)
+  const itemToOption = (item: ClusterInfoSummary) => {
+    if(item && item.clusterStatus != ClusterStatus.DeleteInProgress)
       return {label: item.clusterName, value: item.clusterName}
     else
       return {label: i18next.t('wizard.source.clusterSelect.placeholder')}

--- a/frontend/src/old-pages/CustomImages/ImageBuildDialog.tsx
+++ b/frontend/src/old-pages/CustomImages/ImageBuildDialog.tsx
@@ -25,6 +25,7 @@ import {
 
 // Components
 import ValidationErrors from '../../components/ValidationErrors'
+import FileUploadButton from '../../components/FileChooser'
 
 // State
 import { setState, useState, getState, clearState } from '../../store'
@@ -50,36 +51,6 @@ function buildImageValidate(suppressUpload = false) {
   }
 
   return valid;
-}
-
-const FileUploadButton = (props: any) => {
-  const hiddenFileInput = React.useRef(null);
-  const handleClick = (event: any) => {
-    // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
-    hiddenFileInput.current.click();
-  };
-  const handleChange = (event: any) => {
-    var file = event.target.files[0]
-    var reader = new FileReader();
-    reader.onload = function(e) {
-      // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
-      props.handleData(e.target.result)
-    }
-    reader.readAsText(file);
-  };
-  return (
-    <>
-      <Button onClick={handleClick}>
-        Choose file...
-      </Button>
-      <input
-        type="file"
-        ref={hiddenFileInput}
-        onChange={handleChange}
-        style={{display: 'none'}}
-      />
-    </>
-  );
 }
 
 export default function ImageBuildDialog(props: any) {


### PR DESCRIPTION
## Description

<!-- Summary of what this PR introduces and possibly why -->

- Removed a duplicate component
- During cluster configuration, using a cluster that is undergoing deletion as a template leads to creation failure. I removed the possibility of selecting these clusters.
- Fixed typos in tutorials

<!-- List of relevant changes introduced -->

## How Has This Been Tested?

Manually - deleted a cluster and checked to make sure that it didn't show up in cluster configuration