### PR TITLE
release - Add scripts to rollback and rollforward the latest aws lambda image

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,23 @@
+# How to use rollback/rollforward scripts
+
+The rollback and rollforward scripts in this folder should be used when there are problems on a published release. In particular in the frontend or backend code.
+
+To work properly, the scripts need Admin credentials of the account in which the public ECR is.
+
+As the code is shipped as a Docker-based Lambda in a public ECR, to rollback the code we need to remove the "latest" tag from the broken released image and assign it to the image that was pushed before (latest-1 release).
+So the customers won't pull the broken release again.
+
+This is done by simply launching 
+
+```
+bash ./rollback_awslambda_image.sh
+```
+
+If the rollback script is launched by mistake, the rollforward script helps to restore the situation, putting the "latest" tag on the lastly pushed release, the script can be launched as
+
+```
+bash ./rollforward_awslambda_image.sh
+```
+
+**NOTE:** The rollforward script should be used only if the rollback script is launched by mistake, the normal procedure to publish a new release after a rollback is by launching the `build_awslambda.sh` after fixing the code
+

--- a/scripts/rollback_awslambda_image.sh
+++ b/scripts/rollback_awslambda_image.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+REPO="pcluster-manager-awslambda"
+DIGEST=$(aws ecr describe-images --repository-name "${REPO}" \
+--query 'sort_by(imageDetails,& imagePushedAt)[-2].[imageDigest][0]')
+MANIFEST=$(aws ecr batch-get-image --repository-name "${REPO}" --image-ids imageDigest="${DIGEST}" | jq --raw-output --join-output '.images[0].imageManifest')
+aws ecr put-image --repository-name "${REPO}" --image-tag latest --image-manifest "${MANIFEST}"

--- a/scripts/rollforward_awslambda_image.sh
+++ b/scripts/rollforward_awslambda_image.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+REPO="pcluster-manager-awslambda"
+DIGEST=$(aws ecr describe-images --repository-name "${REPO}" \
+--query 'sort_by(imageDetails,& imagePushedAt)[-1].[imageDigest][0]')
+MANIFEST=$(aws ecr batch-get-image --repository-name "${REPO}" --image-ids imageDigest="${DIGEST}" | jq --raw-output --join-output '.images[0].imageManifest')
+aws ecr put-image --repository-name "${REPO}" --image-tag latest --image-manifest "${MANIFEST}"


### PR DESCRIPTION
## Description

Add scripts to rollback and rollforward the latest aws lambda image.

The scripts could have been merged into just one, but I thought it would been easier for an operator launch to different scripts instead of messing with arguments of a single script.

There are no README instruction for the script at the moment, the usage will be explained in the rollback runbook we will have soon.

## Changes

Just added two scripts.

## Changelog entry

N/A

## How Has This Been Tested?

Tested in a personal private ECR repo, see video below

https://user-images.githubusercontent.com/83351137/186454157-cf36f401-dbd1-468b-a128-2a1f3a5f446d.mp4

## References

N/A

## PR Quality Checklist

-Not relevant

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
