### PR TITLE
Add encryption to S3 bucket for infrastructure

### DIFF
--- a/infrastructure/github-env-setup.yml
+++ b/infrastructure/github-env-setup.yml
@@ -21,6 +21,10 @@ Resources:
     Properties:
       VersioningConfiguration:
         Status: Enabled
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
 
   PrivateDeployRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
## Description

For our security standards, every S3 bucket must have encryption enabled. This PR introduces encryption to the already created S3 bucket, the one holding the infrastructure files.

## Changes

- add default encryption (S3 keys) to the S3 bucket holding the infrastructure files

## How Has This Been Tested?

Updated the CFN stack and verified the default encryption.

![Screenshot 2022-08-25 at 09 32 04](https://user-images.githubusercontent.com/3091286/186603794-5018e459-a2ff-4f2c-a818-8b0342a14cb9.png)

## PR Quality Checklist
- N/A

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
