### PR TITLE
CI(templates) - Set Cognito deletion policy to Retain

### DIFF
--- a/infrastructure/pcluster-manager.yaml
+++ b/infrastructure/pcluster-manager.yaml
@@ -83,6 +83,7 @@ Resources:
 
   PclusterManagerCognito:
     Type: AWS::CloudFormation::Stack
+    DeletionPolicy: Retain
     Properties:
       Parameters:
         AdminUserEmail: !Ref AdminUserEmail


### PR DESCRIPTION
## Description

Set Cognito nested stack deletion policy to Retain to avoid cancellation of the nested stack when the main stack is deleted

## Changes

CI(templates) - Set Cognito deletion policy to retain

## Changelog entry

- Cognito nested stack has now deletion policy set to Retain

## How Has This Been Tested?

Created a new PCM test, deleted main stack, Cognito stack deletion was skipped

## References

N/A

## PR Quality Checklist

Not relevant

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
