### PR TITLE
Add git-secrets automation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,9 +23,10 @@ reported the issue. Please try to include as much information as you can. Detail
 ## Contributing via Pull Requests
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the *main* branch.
-2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
-3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
+1. You installed git-secrets using the instructions in the [repository](https://github.com/awslabs/git-secrets#installing-git-secrets)
+2. You are working against the latest source on the *main* branch.
+3. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
+4. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 
 To send us a pull request, please:
 

--- a/frontend/git-secrets-conf.sh
+++ b/frontend/git-secrets-conf.sh
@@ -1,0 +1,2 @@
+git secrets --install -f
+git secrets --register-aws

--- a/frontend/git-secrets-conf.sh
+++ b/frontend/git-secrets-conf.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
-git secrets --install -f
-git secrets --register-aws
+if [[ -z "$CI" || "$CI" != true ]]; then
+  git secrets --install -f
+  git secrets --register-aws
+fi

--- a/frontend/git-secrets-conf.sh
+++ b/frontend/git-secrets-conf.sh
@@ -1,2 +1,3 @@
+#!/usr/bin/env bash
 git secrets --install -f
 git secrets --register-aws

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,8 @@
     "dev": "next dev",
     "export": "next build && next export -o build",
     "ts-reignore": "ts-migrate reignore . --sources='src/**/*'",
-    "ts-validate": "tsc -p tsconfig.json"
+    "ts-validate": "tsc -p tsconfig.json",
+    "prepare": "bash ./git-secrets-conf.sh"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Description

This PR introduces an automation for the setup of git-secrets forcing the installation of the relevant git hooks during the npm "prepare" phase, this works only if git-secrets is installed, so I added installation instructions in the CONTRIBUTING.md file

We may need to add more patterns in the future, but this can be done iteratively

## Changes

*    security - Force the installation of git hooks related to git-secrets at npm "prepare" phase
*    documentation (contributing) Adding instructions to install git-secrets
*    refactor - Adding shebang to bash script
*    refactor (ci) - Execute the git-secrets installation only if we are not on CI

## Changelog entry

N/A

## How Has This Been Tested?

- Run `npm install` without git-secrets installed -> fails
- Run `npm install` with git-secrets installed -> succeeds
  - Hooks installed
  - Tried to commit a secret -> committing fails with `[ERROR] Matched one or more prohibited patterns`
  - Commits without secrets -> succeeds

## References

[git-secrets-repo
](https://github.com/awslabs/git-secrets)

[npm scripts doc](https://docs.npmjs.com/cli/v8/using-npm/scripts)
## PR Quality Checklist
- [X] I checked that `npm run build` builds without any error

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
