### PR TITLE
Fix authentication of admin not belonging to the user group

### DIFF
--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -137,11 +137,11 @@ def authenticate(groups):
     if ("guest" not in groups) and len(groups_granted) == 0:
         return abort(403)
 
-def authenticated(group="user"):
+def authenticated(groups={"user"}):
     def _authenticated(func):
         @functools.wraps(func)
         def _wrapper_authenticated(*args, **kwargs):
-            authenticate(group)
+            authenticate(groups)
             return func(*args, **kwargs)
 
         return _wrapper_authenticated
@@ -711,7 +711,7 @@ def _get_params(_request):
 
 
 class PclusterApiHandler(Resource):
-    method_decorators = [authenticated("user")]
+    method_decorators = [authenticated({"user", "admin"})]
 
     def get(self):
         # if re.match(r".*images.*logstreams/+", args["path"]):
@@ -721,21 +721,21 @@ class PclusterApiHandler(Resource):
         return response.json(), response.status_code
 
     def post(self):
-        auth_response = authenticate("admin")
+        auth_response = authenticate({"admin"})
         if auth_response:
             abort(401)
         resp = sigv4_request("POST", API_BASE_URL, request.args.get("path"), _get_params(request), body=request.json)
         return resp.json(), resp.status_code
 
     def put(self):
-        auth_response = authenticate("admin")
+        auth_response = authenticate({"admin"})
         if auth_response:
             abort(401)
         resp = sigv4_request("PUT", API_BASE_URL, request.args.get("path"), _get_params(request), body=request.json)
         return resp.json(), resp.status_code
 
     def delete(self):
-        auth_response = authenticate("admin")
+        auth_response = authenticate({"admin"})
         if auth_response:
             abort(401)
 
@@ -751,7 +751,7 @@ class PclusterApiHandler(Resource):
         return resp.json(), resp.status_code
 
     def patch(self):
-        auth_response = authenticate("admin")
+        auth_response = authenticate({"admin"})
         if auth_response:
             abort(401)
         resp = sigv4_request("PATCH", API_BASE_URL, request.args.get("path"), _get_params(request), body=request.json)

--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -117,7 +117,7 @@ def sigv4_request(method, host, path, params={}, headers={}, body=None):
 
 # Wrappers
 
-def authenticate(group):
+def authenticate(groups):
     if disable_auth():
         return
 
@@ -132,9 +132,10 @@ def authenticate(group):
     except Exception as e:
         return abort(401)
 
-    if (group != "guest") and (group not in set(decoded.get(USER_ROLES_CLAIM, []))):
+    jwt_roles = set(decoded.get(USER_ROLES_CLAIM, []))
+    groups_granted = groups.intersection(jwt_roles)
+    if ("guest" not in groups) and len(groups_granted) == 0:
         return abort(403)
-
 
 def authenticated(group="user"):
     def _authenticated(func):

--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -653,7 +653,7 @@ def set_user_role():
         cognito.admin_add_user_to_group(UserPoolId=USER_POOL_ID, Username=username, GroupName="user")
         cognito.admin_remove_user_from_group(UserPoolId=USER_POOL_ID, Username=username, GroupName="admin")
     elif role == "admin":
-        cognito.admin_add_user_to_group(UserPoolId=USER_POOL_ID, Username=username, GroupName="user")
+        cognito.admin_remove_user_from_group(UserPoolId=USER_POOL_ID, Username=username, GroupName="user")
         cognito.admin_add_user_to_group(UserPoolId=USER_POOL_ID, Username=username, GroupName="admin")
 
     users = cognito.list_users(UserPoolId=USER_POOL_ID, Filter=f'username = "{username}"')["Users"]

--- a/api/tests/test_authenticate.py
+++ b/api/tests/test_authenticate.py
@@ -11,14 +11,14 @@ def test_authenticate():
       When authentication is disabled
         Then it should do nothing
     """
-    assert authenticate('any-group') is None
+    assert authenticate({'any-group'}) is None
 
 
 def test_authenticate_with_no_access_token_returns_401(mocker, app):
     with app.test_request_context():
         mock_abort = mocker.patch('api.PclusterApiHandler.abort')
 
-        authenticate('any-group')
+        authenticate({'any-group'})
 
         mock_abort.assert_called_once_with(401)
 
@@ -26,7 +26,7 @@ def test_authenticate_with_access_token_no_id_token_returns_401(mocker, app):
     with app.test_request_context(headers={'Cookie': 'accessToken=access-token'}):
         mock_abort = mocker.patch('api.PclusterApiHandler.abort')
 
-        authenticate('any-group')
+        authenticate({'any-group'})
 
         mock_abort.assert_called_once_with(401)
 
@@ -34,7 +34,7 @@ def test_authenticate_with_id_token_no_access_token_returns_401(mocker, app):
     with app.test_request_context(headers={'Cookie': 'idToken=access-token'}):
         mock_abort = mocker.patch('api.PclusterApiHandler.abort')
 
-        authenticate('any-group')
+        authenticate({'any-group'})
 
         mock_abort.assert_called_once_with(401)
 
@@ -44,7 +44,7 @@ def test_authenticate_with_expired_signature_returns_401(mocker, app):
         mocker.patch('api.PclusterApiHandler.jwt_decode',
                      side_effect=jwt.ExpiredSignatureError())
 
-        authenticate('any-group')
+        authenticate({'any-group'})
 
         mock_abort.assert_called_once_with(401)
 
@@ -55,7 +55,7 @@ def test_authenticate_with_signature_exception_returns_401(mocker, app):
         mocker.patch('api.PclusterApiHandler.jwt_decode',
                      side_effect=Exception())
 
-        authenticate('any-group')
+        authenticate({'any-group'})
 
         mock_abort.assert_called_once_with(401)
 
@@ -66,7 +66,7 @@ def test_authenticate_with_non_guest_group_not_in_user_roles_claim_returns_403(m
         mocker.patch('api.PclusterApiHandler.jwt_decode',
                      return_value={'cognito:groups': ['other-group']})
 
-        authenticate('any-group')
+        authenticate({'any-group'})
 
         mock_abort.assert_called_once_with(403)
 
@@ -77,7 +77,7 @@ def test_authenticate_with_guest_group_succeeds(mocker, app):
         mocker.patch('api.PclusterApiHandler.jwt_decode',
                      return_value={'cognito:groups': ['other-group']})
 
-        authenticate('guest')
+        authenticate({'guest'})
 
         mock_abort.assert_not_called()
 
@@ -88,6 +88,16 @@ def test_authenticate_with_group_in_user_role_claim_succeeds(mocker, app):
         mocker.patch('api.PclusterApiHandler.jwt_decode',
                      return_value={'cognito:groups': ['my-group']})
 
-        authenticate('my-group')
+        authenticate({'my-group'})
+
+        mock_abort.assert_not_called()
+
+def test_authenticate_with_admin_not_in_the_user_group_succeds(mocker, app):
+    with app.test_request_context(headers={'Cookie': 'accessToken=access-token'}):
+        mock_abort = mocker.patch('api.PclusterApiHandler.abort')
+        mocker.patch('api.PclusterApiHandler.jwt_decode',
+                     return_value={'cognito:groups': ['admin']})
+
+        authenticate({'user', 'admin'})
 
         mock_abort.assert_not_called()

--- a/app.py
+++ b/app.py
@@ -19,7 +19,6 @@ from werkzeug.routing import BaseConverter
 import api.utils as utils
 from api.PclusterApiHandler import (
     PclusterApiHandler,
-    authenticate,
     authenticated,
     cancel_job,
     create_user,
@@ -44,6 +43,7 @@ from api.PclusterApiHandler import (
     submit_job,
 )
 
+ADMINS_USERS_GROUP = { "user", "admin" }
 
 class RegexConverter(BaseConverter):
     def __init__(self, url_map, *items):
@@ -81,32 +81,32 @@ def run():
         return utils.serve_frontend(app, path)
 
     @app.route("/manager/ec2_action", methods=["POST"])
-    @authenticated()
+    @authenticated(ADMINS_USERS_GROUP)
     def ec2_action_():
         return ec2_action()
 
     @app.route("/manager/get_cluster_configuration")
-    @authenticated()
+    @authenticated(ADMINS_USERS_GROUP)
     def get_cluster_config_():
         return get_cluster_config()
 
     @app.route("/manager/get_custom_image_configuration")
-    @authenticated()
+    @authenticated(ADMINS_USERS_GROUP)
     def get_custom_image_config_():
         return get_custom_image_config()
 
     @app.route("/manager/get_aws_configuration")
-    @authenticated()
+    @authenticated(ADMINS_USERS_GROUP)
     def get_aws_config_():
         return get_aws_config()
 
     @app.route("/manager/get_instance_types")
-    @authenticated()
+    @authenticated(ADMINS_USERS_GROUP)
     def get_instance_types_():
         return get_instance_types()
 
     @app.route("/manager/get_dcv_session")
-    @authenticated()
+    @authenticated(ADMINS_USERS_GROUP)
     def get_dcv_session_():
         return get_dcv_session()
 
@@ -144,32 +144,32 @@ def run():
         return set_user_role()
 
     @app.route("/manager/queue_status")
-    @authenticated()
+    @authenticated(ADMINS_USERS_GROUP)
     def queue_status_():
         return queue_status()
 
     @app.route("/manager/cancel_job")
-    @authenticated()
+    @authenticated(ADMINS_USERS_GROUP)
     def cancel_job_():
         return cancel_job()
 
     @app.route("/manager/price_estimate")
-    @authenticated()
+    @authenticated(ADMINS_USERS_GROUP)
     def price_estimate_():
         return price_estimate()
 
     @app.route("/manager/submit_job", methods=["POST"])
-    @authenticated()
+    @authenticated(ADMINS_USERS_GROUP)
     def submit_job_():
         return submit_job()
 
     @app.route("/manager/sacct", methods=["POST"])
-    @authenticated()
+    @authenticated(ADMINS_USERS_GROUP)
     def sacct_():
         return sacct()
 
     @app.route("/manager/scontrol_job")
-    @authenticated()
+    @authenticated(ADMINS_USERS_GROUP)
     def scontrol_job_():
         return scontrol_job()
 

--- a/app.py
+++ b/app.py
@@ -44,6 +44,7 @@ from api.PclusterApiHandler import (
 )
 
 ADMINS_USERS_GROUP = { "user", "admin" }
+ADMINS_GROUP = { "admin" }
 
 class RegexConverter(BaseConverter):
     def __init__(self, url_map, *items):
@@ -111,7 +112,7 @@ def run():
         return get_dcv_session()
 
     @app.route("/manager/get_identity")
-    @authenticated("guest")
+    @authenticated({"guest"})
     def get_identity_():
         return get_identity()
 
@@ -124,22 +125,22 @@ def run():
         return get_app_config()
 
     @app.route("/manager/list_users")
-    @authenticated("admin")
+    @authenticated(ADMINS_GROUP)
     def list_users_():
         return list_users()
 
     @app.route("/manager/create_user", methods=["POST"])
-    @authenticated("admin")
+    @authenticated(ADMINS_GROUP)
     def create_user_():
         return create_user()
 
     @app.route("/manager/delete_user", methods=["DELETE"])
-    @authenticated("admin")
+    @authenticated(ADMINS_GROUP)
     def delete_user_():
         return delete_user()
 
     @app.route("/manager/set_user_role", methods=["PUT"])
-    @authenticated("admin")
+    @authenticated(ADMINS_GROUP)
     def set_user_role_():
         return set_user_role()
 


### PR DESCRIPTION
## Description

Gives the ability for an admin which is not in the `users` group (Cognito) to use the application.
Previously, an administrator not belonging to the `users` group could not access PCM.
This is a requirement to integrate with a third-party provider, as we must not assume how users are created on that platform.

## Changes
- authenticate agains a set of groups rather than a single one
- include both the `admin` and `user` group for endpoints accessible by both

## Changelog entry

Fix permissions check against `admin` not belonging to the Cognito `user` group

## How Has This Been Tested?

Tested locally with Cognito:
- removed the `user` group from an admin account and verified it broke the application
- applied the changes to the backend
- verified the user can to browse PCM
- 
## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
