### PR TITLE
Add missing permissions to describe FSx volumes

### DIFF
--- a/infrastructure/pcluster-manager.yaml
+++ b/infrastructure/pcluster-manager.yaml
@@ -686,7 +686,8 @@ Resources:
         Version: '2012-10-17'
         Statement:
           - Action:
-            - fsx:DescribeFileSystems
+              - fsx:DescribeFileSystems
+              - fsx:DescribeVolumes
             Resource:
             - '*'
             Effect: Allow


### PR DESCRIPTION
## Description

ONTAP/ZFS volumes are not visible inside the wizard because the corresponding IAM permission has not been added.
Fixes #276.

## Changes

- add the `fsx:DescribeVolumes` to the Lambda role

## Changelog entry

Fix display of ONTAP/ZFS volumes in the wizard

## How Has This Been Tested?

- edited the template of a test stack with the new permission and verified that the Ontap volume is shown

## PR Quality Checklist

- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
