### PR TITLE
Fix update.sh script usage after PR 291

### DIFF
--- a/.github/workflows/demo_deploy.yml
+++ b/.github/workflows/demo_deploy.yml
@@ -75,6 +75,6 @@ jobs:
           role-to-assume: arn:aws:iam::063695377715:role/pcluster-manager-github-PrivateDeployRole-8D5K5C4RM02U
       
       - name: Update staging environment
-        run: /bin/bash scripts/update.sh --region eu-west-1 --local
+        run: /bin/bash scripts/update.sh --stack-name "pcluster-manager-demo" --region eu-west-1 --local
 
 


### PR DESCRIPTION
## Description
After #291 , the deploy demo action needs to be adjusted since it doesn't pass the additional parameter `--stack-name` now required.
<!-- Summary of what this PR introduces and possibly why -->

## Changes
- correct usage of update.sh

## References
#291 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
