### PR TITLE
Fix CloudFormation invocation in update.sh script + "bash not found" error

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
     "lint": "next lint",
     "dev": "next dev",
     "export": "next build && next export -o build",
-    "prepare": "bash ./scripts/git-secrets-command.sh '--register-aws > /dev/null' && cd .. && husky install frontend/.husky",
+    "prepare": "/bin/bash ./scripts/git-secrets-command.sh '--register-aws > /dev/null' && cd .. && husky install frontend/.husky",
     "ts-reignore": "ts-migrate reignore . --sources='src/**/*'",
     "ts-validate": "tsc -p tsconfig.json"
   },

--- a/infrastructure/github-env-setup.yml
+++ b/infrastructure/github-env-setup.yml
@@ -52,9 +52,11 @@ Resources:
                 Action:
                   - lambda:UpdateFunctionCode
                   - ecr:DescribeRepositories
+                  - cloudformation:DescribeStackResources
                 Resource:
                   - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:PclusterManagerFunction*
                   - !Sub arn:${AWS::Partition}:ecr:${AWS::Region}:${AWS::AccountId}:repository/*
+                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*/*
               - Effect: Allow
                 Action:
                   - lambda:ListFunctions

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -58,7 +58,7 @@ function resource_id_from_cf_output {
 }
 
 CF_QUERY="StackResources[?LogicalResourceId == 'PrivateEcrRepository' || LogicalResourceId == 'PclusterManagerFunction'].{ LogicalResourceId: LogicalResourceId, PhysicalResourceId: PhysicalResourceId }"
-CF_OUTPUT=`aws cloudformation describe-stack-resources --stack-name pcluster-manager --query "$CF_QUERY" --output text | tr '\t' ' '`
+CF_OUTPUT=`aws cloudformation describe-stack-resources --stack-name "$STACKNAME" --region "$REGION" --query "$CF_QUERY" --output text | tr '\t' ' '`
 
 LAMBDA_NAME="$(resource_id_from_cf_output "$CF_OUTPUT" "PclusterManagerFunction")"
 LAMBDA_ARN=$(aws lambda --region ${REGION} list-functions --query "Functions[?contains(FunctionName, '$LAMBDA_NAME')] | [0].FunctionArn" | xargs echo)


### PR DESCRIPTION
## Description
In the previous PR #291 there was an hardcoded string used, instead of the correct parameter introduced in that PR, plus the GH action presents a new error `bash not found` that we're trying to solve.
<!-- Summary of what this PR introduces and possibly why -->

## Changes
- github-env-setup.yml has been edited to introduce the newly necessary policy the the role used, in order to perform the DescribeStackResources action
- the package.json `prepare` script now uses `/bin/bash` instead of `bash` only to perform its operations
- the update.sh script correctly uses the `--stack-name` parameter and the `region` value to perform its operation against AWS APIs.

<!-- A sentence to be added to the next release's changelog that captures the changes in this PR -->

## How Has This Been Tested?
This was tested both locally and on GitHub actions deploying the code and temporarily changing the GH actions to perform scripts only on the wip branch. 
<!-- The tests you ran to verify your changes -->

## References
#291 
#292 
<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [x] I removed hardcoded strings

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
