### PR TITLE
Only enable CORS in development

### DIFF
--- a/api/tests/test_build_flask_app.py
+++ b/api/tests/test_build_flask_app.py
@@ -1,0 +1,36 @@
+from api.utils import build_flask_app
+from flask_restful import Api
+
+def test_build_flask_app_dev(monkeypatch):
+    """
+    Given the package name
+      When a Flask app is initialized
+      When in the development environment
+        Then it should enable CORS
+    """
+    monkeypatch.setenv("ENV", "dev")
+    app = build_flask_app('any-name')
+
+    with app.app_context():
+        with app.test_client() as client:
+            response = client.get('/')
+            cors_header = response.headers.get('Access-Control-Allow-Origin')
+            assert cors_header == '*'
+
+
+def test_build_flask_app_prod(monkeypatch):
+    """
+    Given the package name
+      When a Flask app is initialized
+      When in the production environment
+        Then it should not enable CORS
+    """
+    monkeypatch.setenv("ENV", "")
+    app = build_flask_app('any-name')
+
+    with app.app_context():
+        with app.test_client() as client:
+            response = client.get('/')
+            cors_header = response.headers.get('Access-Control-Allow-Origin')
+            assert cors_header == None
+

--- a/api/utils.py
+++ b/api/utils.py
@@ -13,6 +13,7 @@ import os
 
 import dateutil
 from flask import Flask, Response, request, send_from_directory
+from flask_cors import CORS
 import requests
 
 
@@ -80,7 +81,9 @@ def proxy_to(to_url):
 
 def build_flask_app(name):
   if running_local():
-    return Flask(name)
+    app = Flask(name)
+    CORS(app)
+    return app
 
   return Flask(name, static_url_path="", static_folder="frontend/public")
 

--- a/app.py
+++ b/app.py
@@ -12,7 +12,6 @@ import datetime
 
 from flask import Flask, Response, request, send_from_directory
 from flask.json import JSONEncoder
-from flask_cors import CORS  # comment this on deployment
 from flask_restful import Api
 from werkzeug.routing import BaseConverter
 
@@ -67,7 +66,6 @@ def run():
     app = utils.build_flask_app(__name__)
     app.json_encoder = PClusterJSONEncoder
     app.url_map.converters["regex"] = RegexConverter
-    CORS(app)  # comment this on deployment
     api = Api(app)
 
     @app.errorhandler(401)


### PR DESCRIPTION
## Description

This PR makes it so CORS is enabled only in `dev` environment. We don't need it in production

## Changes

- enable CORS only when `running_local()` is `True`

## Changelog entry

- Disable CORS headers in production

## How Has This Been Tested?

- unit tests
- ran locally in both scenarios and looked at the network panel to see whether the headers were being added or not

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
