### PR TITLE
Cluster in CREATE_FAILED state cannot be selected/deleted

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -354,7 +354,7 @@
   },
   "components": {
     "ClusterFailedHelp": {
-      "errorMessage": "Stack failed to create, see <0>CloudFormation Stack Events</0> &nbsp; or &nbsp;<1>Cluster Logs</1>&nbsp; to see why."
+      "errorMessage": "Stack failed to create, see <0>CloudFormation Stack Events</0> or <1>Cluster Logs</1> to see why."
     },
     "ValidationErrors": {
       "update": "Update",

--- a/frontend/src/__tests__/DescribeCluster.test.ts
+++ b/frontend/src/__tests__/DescribeCluster.test.ts
@@ -1,0 +1,68 @@
+import {DescribeCluster} from '../model'
+
+const mockGet = jest.fn()
+
+jest.mock('axios', () => ({
+  create: () => ({
+    get: (...args: unknown[]) => mockGet(...args),
+  }),
+}))
+
+describe('given a DescribeCluster command and a cluster name', () => {
+  const clusterName = 'any-name'
+
+  describe('when the cluster can be described successfully', () => {
+    beforeEach(() => {
+      const mockResponse = {
+        some: 'data',
+      }
+      mockGet.mockResolvedValueOnce({data: mockResponse})
+    })
+
+    it('should return the cluster description', async () => {
+      const data = await DescribeCluster(clusterName)
+      expect(data).toEqual({
+        some: 'data',
+      })
+    })
+  })
+
+  describe('when the describe cluster fails', () => {
+    let mockErrorCallback: jest.Mock
+    let mockError: any
+
+    beforeEach(() => {
+      mockErrorCallback = jest.fn()
+      mockError = {
+        response: {
+          data: {
+            message: 'some-error-messasge',
+          },
+        },
+      }
+      mockGet.mockRejectedValueOnce(mockError)
+    })
+
+    it('should call the error callback', async () => {
+      try {
+        await DescribeCluster(clusterName, mockErrorCallback)
+      } catch (e) {
+        expect(mockErrorCallback).toHaveBeenCalledTimes(1)
+      }
+    })
+
+    it('should re-throw the error', async () => {
+      try {
+        await DescribeCluster(clusterName, mockErrorCallback)
+      } catch (e) {
+        expect(e).toEqual({
+          response: {
+            data: {
+              message: 'some-error-messasge',
+            },
+          },
+        })
+      }
+    })
+  })
+})

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -171,34 +171,24 @@ function UpdateCluster(
     })
 }
 
-function DescribeCluster(clusterName: any, errorCallback?: Callback) {
+async function DescribeCluster(clusterName: string, errorCallback?: Callback) {
   var url = `api?path=/v3/clusters/${clusterName}`
-  request('get', url)
-    .then((response: any) => {
-      //console.log("Describe Success", response)
-      if (response.status === 200) {
-        updateState(['clusters', 'index', clusterName], (existing: any) => {
-          return {...existing, ...response.data}
-        })
-      }
-    })
-    .catch((error: any) => {
-      if (error.response) {
-        errorCallback && errorCallback()
-        var selected = getState(['app', 'clusters', 'selected'])
-        if (selected === clusterName) {
-          clearState(['app', 'clusters', 'selected'])
-          return
-        } else {
-          console.log(error.response)
-          notify(
-            `Error (${clusterName}): ${error.response.data.message}`,
-            'error',
-          )
-        }
-      }
-      console.log(error)
-    })
+  try {
+    const response = await request('get', url)
+    if (response.status === 200) {
+      updateState(['clusters', 'index', clusterName], (existing: any) => {
+        return {...existing, ...response.data}
+      })
+    }
+    return response.data || {}
+  } catch (error: any) {
+    if (error.response) {
+      errorCallback && errorCallback()
+      notify(`Error (${clusterName}): ${error.response.data.message}`, 'error')
+    }
+    console.log(error)
+    throw error
+  }
 }
 
 function DeleteCluster(clusterName: any, callback?: Callback) {

--- a/frontend/src/old-pages/Clusters/Clusters.tsx
+++ b/frontend/src/old-pages/Clusters/Clusters.tsx
@@ -14,7 +14,7 @@ import {
 } from '../../types/clusters'
 import React, {useEffect} from 'react'
 import {NavigateFunction, useNavigate, useParams} from 'react-router-dom'
-import {ListClusters} from '../../model'
+import {DescribeCluster, GetConfiguration, ListClusters} from '../../model'
 import {useState, clearState, setState, isAdmin} from '../../store'
 import {selectCluster} from './util'
 import {findFirst} from '../../util'
@@ -75,8 +75,8 @@ function ClusterList({clusters}: {clusters: ClusterInfoSummary[]}) {
 
   React.useEffect(() => {
     if (params.clusterName && selectedClusterName !== params.clusterName)
-      selectCluster(params.clusterName, navigate)
-  }, [selectedClusterName, params, navigate])
+      selectCluster(params.clusterName, DescribeCluster, GetConfiguration)
+  }, [navigate, params.clusterName, selectedClusterName])
 
   const onSelectionChangeCallback = React.useCallback(
     ({detail}) => {

--- a/frontend/src/old-pages/Clusters/__tests__/util.test.ts
+++ b/frontend/src/old-pages/Clusters/__tests__/util.test.ts
@@ -1,4 +1,4 @@
-import {getScripts} from '../util'
+import {getScripts, selectCluster} from '../util'
 
 describe('Given a function to get script names of all custom actions', () => {
   describe('when a custom action to be run on node startup is provided', () => {
@@ -71,6 +71,57 @@ describe('Given a function to get script names of all custom actions', () => {
     it('should return an empty array', () => {
       const scriptNames = getScripts(null)
       expect(scriptNames).toEqual([])
+    })
+  })
+})
+
+describe('Given a function to select the current cluster and a cluster name', () => {
+  const clusterName = 'some-cluster-name'
+  let mockDescribeCluster: jest.Mock
+  let mockGetConfiguration: jest.Mock
+
+  beforeEach(() => {
+    mockDescribeCluster = jest.fn()
+    mockGetConfiguration = jest.fn()
+  })
+
+  describe('when user selects a cluster by name', () => {
+    it('should describe the cluster', async () => {
+      await selectCluster(
+        clusterName,
+        mockDescribeCluster,
+        mockGetConfiguration,
+      )
+      expect(mockDescribeCluster).toHaveBeenCalledTimes(1)
+      expect(mockDescribeCluster).toHaveBeenCalledWith(clusterName)
+    })
+
+    it('should get the cluster configuration', async () => {
+      await selectCluster(
+        clusterName,
+        mockDescribeCluster,
+        mockGetConfiguration,
+      )
+      expect(mockGetConfiguration).toHaveBeenCalledTimes(1)
+      expect(mockGetConfiguration).toHaveBeenCalledWith(
+        clusterName,
+        expect.any(Function),
+      )
+    })
+
+    describe('when describing the cluster fails', () => {
+      beforeEach(async () => {
+        mockDescribeCluster = jest.fn(() => Promise.reject('any-error'))
+        await selectCluster(
+          clusterName,
+          mockDescribeCluster,
+          mockGetConfiguration,
+        )
+      })
+
+      it('should not get the cluster configuration', () => {
+        expect(mockGetConfiguration).toHaveBeenCalledTimes(0)
+      })
     })
   })
 })

--- a/frontend/src/old-pages/Clusters/util.tsx
+++ b/frontend/src/old-pages/Clusters/util.tsx
@@ -20,6 +20,10 @@ export async function selectCluster(
 ) {
   const oldClusterName = getState(['app', 'clusters', 'selected'])
   let config_path = ['clusters', 'index', clusterName, 'config']
+  if (oldClusterName !== clusterName) {
+    setState(['app', 'clusters', 'selected'], clusterName)
+  }
+
   try {
     await DescribeCluster(clusterName)
     GetConfiguration(clusterName, (configuration: any) => {
@@ -29,9 +33,6 @@ export async function selectCluster(
   } catch (_) {
     // NOOP
   }
-
-  if (oldClusterName !== clusterName)
-    setState(['app', 'clusters', 'selected'], clusterName)
 }
 
 export function getScripts(customActions: Record<string, any> | null) {


### PR DESCRIPTION
## Description

Fixes #271 

This PR introduces a check to make sure we don't fetch cluster details when the cluster is in an unstable states. ~~States are listed and can be easily changed in the future~~

Whenever the describe cluster fails, the app shows an error message and stops fetching other data (preventing misleading errors from happening)

If we want to prevent the first error message from showing, we should move the error handling outside of the `DescribeCluster` command and handle it on a case-by-case basis (I'd do this in another PR anyway)

## Changes

- avoid describing the cluster if it is is an unstable state
- fix error message showing `&nbsp;` symbols

## Changelog entry

Fix cluster selection not working when cluster is in CREATE_FAILED state

## How Has This Been Tested?

- unit tests
- locally, mocking the state of the cluster
- mocked a `CREATE_FAILED` and deleted the cluster successfully
- mocked a `CREATE_FAILED` and selected the cluster successfully

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
