### PR TITLE
Create Cognito resources only when it is chosen as OICD provider

### DIFF
--- a/infrastructure/pcluster-manager.yaml
+++ b/infrastructure/pcluster-manager.yaml
@@ -37,6 +37,11 @@ Parameters:
     Description: S3 bucket where CloudFormation files are stored. Change this parameter only when testing changes made to the infrastructure itself.
     Type: String
     Default: ''
+  OICDProvider:
+    Description: OICD provider to use (defaults to Amazon Cognito).
+    Type: String
+    AllowedValues: [Cognito]
+    Default: Cognito
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -71,7 +76,8 @@ Conditions:
     Fn::And:
       - !Not [!Equals [!Ref ImageBuilderVpcId, ""]]
       - !Not [!Equals [!Ref ImageBuilderSubnetId, ""]]
-  HasDefaultInfrastructure: !Equals [!Ref InfrastructureBucket, ''] 
+  HasDefaultInfrastructure: !Equals [!Ref InfrastructureBucket, '']
+  UsesCognito: !Equals [!Ref OICDProvider, 'Cognito']
 
 Mappings:
   PclusterManager:
@@ -82,6 +88,7 @@ Mappings:
 Resources:
 
   PclusterManagerCognito:
+    Condition: UsesCognito
     Type: AWS::CloudFormation::Stack
     DeletionPolicy: Retain
     Properties:
@@ -151,9 +158,9 @@ Resources:
           SITE_URL: !Sub
            - https://${Api}.execute-api.${AWS::Region}.${AWS::URLSuffix}
            - Api: !Ref ApiGateway
-          AUTH_PATH: !GetAtt [ PclusterManagerCognito, Outputs.UserPoolAuthDomain ]
-          SECRET_ID: !GetAtt [ PclusterManagerCognito, Outputs.UserPoolClientSecretName ]
-          AUDIENCE: !GetAtt [ PclusterManagerCognito, Outputs.AppClientId ]
+          AUTH_PATH: !If [ UsesCognito, !GetAtt [ PclusterManagerCognito, Outputs.UserPoolAuthDomain ], !Ref AWS::NoValue ]
+          SECRET_ID: !If [ UsesCognito, !GetAtt [ PclusterManagerCognito, Outputs.UserPoolClientSecretName ], !Ref AWS::NoValue ]
+          AUDIENCE: !If [ UsesCognito, !GetAtt [ PclusterManagerCognito, Outputs.AppClientId ], !Ref AWS::NoValue ]
           ENABLE_AUTH: !Ref EnableAuth
           ENABLE_MFA: !Ref EnableMFA
       FunctionName: !Sub
@@ -436,6 +443,7 @@ Resources:
       RetentionInDays: 90
 
   CognitoPostActions:
+    Condition: UsesCognito
     Type: Custom::CognitoPostActions
     Properties:
       ServiceToken: !GetAtt CognitoPostActionsFunction.Arn
@@ -445,6 +453,7 @@ Resources:
       UserPoolId: !GetAtt [ PclusterManagerCognito, Outputs.UserPoolId ]
 
   CognitoPostActionsFunction:
+    Condition: UsesCognito
     Type: AWS::Lambda::Function
     Properties:
       Handler: index.handler
@@ -513,6 +522,7 @@ Resources:
 
   # Add the Admin User after updating the validation message(s)
   CognitoAdminUser:
+    Condition: UsesCognito
     Type: AWS::Cognito::UserPoolUser
     DependsOn: [CognitoPostActions, PclusterManagerFunction]
     Properties:
@@ -527,6 +537,7 @@ Resources:
       UserPoolId: !GetAtt [ PclusterManagerCognito, Outputs.UserPoolId ]
 
   CognitoUserToAdminGroup:
+    Condition: UsesCognito
     Type: AWS::Cognito::UserPoolUserToGroupAttachment
     Properties:
       GroupName: !GetAtt [ PclusterManagerCognito, Outputs.CognitoAdminGroup ]
@@ -534,6 +545,7 @@ Resources:
       UserPoolId: !GetAtt [ PclusterManagerCognito, Outputs.UserPoolId ]
 
   CognitoUserToUserGroup:
+    Condition: UsesCognito
     Type: AWS::Cognito::UserPoolUserToGroupAttachment
     Properties:
       GroupName: !GetAtt [ PclusterManagerCognito, Outputs.CognitoUserGroup ]
@@ -558,13 +570,14 @@ Resources:
         # Access to the ParllelCluster API
         - !Ref ParallelClusterApiGatewayInvoke
         # Required to run PclusterManager functionalities
-        - !Ref PclusterManagerCognitoPolicy
+        - !If [ UsesCognito, !Ref PclusterManagerCognitoPolicy, !Ref AWS::NoValue ]
         - !Ref PclusterManagerEC2Policy
         - !Ref PclusterManagerExtraPolicies
         - !Ref PclusterManagerSsmSendPolicy
         - !Ref PclusterManagerSsmGetCommandInvocationPolicy
 
   CognitoPostActionsRole:
+    Condition: UsesCognito
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -628,6 +641,7 @@ Resources:
               - { PCApiGateway: !Select [2, !Split ['/', !Select [0, !Split ['.', !GetAtt [ ParallelClusterApi, Outputs.ParallelClusterApiInvokeUrl ]]]]] }
 
   PclusterManagerCognitoPolicy:
+    Condition: UsesCognito
     Type: AWS::IAM::ManagedPolicy
     Properties:
       PolicyDocument:


### PR DESCRIPTION
### Notes
This patch makes creation of Cognito resources in our `pcluster-manager.yaml` Cfn template conditional on selecting *Cognito* as the OICD provider (it is the default option).

_**Update**: removed Okta as an option as we still don't support it, we will reintroduce it once we have a working implementation._

### Tests
- Deployed a PCM stack with *Cognito* as OICD provider, verified it by running the relevant PR quality checklist tests.
- Deployed a PCM stack with *Okta* as OICD provider, verified that Cognito resources were not created (this includes environment variables in the PCM Lambda, etc.).

### PR Quality Checklist
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
