### PR TITLE
Add role to update infrastructure via GitHub actions

### DIFF
--- a/infrastructure/github-env-setup.yml
+++ b/infrastructure/github-env-setup.yml
@@ -82,6 +82,60 @@ Resources:
       ThumbprintList:
         - 6938fd4d98bab03faadb97b34396831e3780aea1
 
+  PrivateInfrastructureUpdateRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Description: "Role used to update the infrastructure of a private environment (for example, demo)"
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRoleWithWebIdentity
+            Principal:
+              Federated: !If 
+                - CreateOIDCProvider
+                - !Ref GithubOidc
+                - !Ref OIDCProviderArn
+            Condition:
+              StringEquals:
+                token.actions.githubusercontent.com:aud: sts.amazonaws.com
+                token.actions.githubusercontent.com:sub: !Sub repo:${GitHubOrg}/${RepositoryName}:ref:refs/heads/main
+      Policies:
+        - PolicyName: UpdateInfrastructurePolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - cloudformation:DescribeStacks
+                  - cloudformation:UpdateStack
+                  - cloudformation:CreateChangeSet
+                Resource:
+                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/pcluster-manager-demo*
+                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:aws:transform/*
+              - Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                  - s3:ListBucket
+                  - s3:DeleteObject
+                  - s3:GetBucketLocation
+                  - s3:GetObjectTagging
+                  - s3:GetObjectAcl
+                  - s3:PutObjectAcl
+                Resource:
+                  - !Sub arn:${AWS::Partition}:s3:::pcluster-manager-github-infrastructurebucket-7y5h202iem8l
+                  - !Sub arn:${AWS::Partition}:s3:::pcluster-manager-github-infrastructurebucket-7y5h202iem8l/*
+                  - !Sub arn:${AWS::Partition}:s3:::${AWS::Region}-aws-parallelcluster
+                  - !Sub arn:${AWS::Partition}:s3:::${AWS::Region}-aws-parallelcluster/*
+              - Effect: Allow
+                Action:
+                  - iam:GetRole
+                Resource:
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/pcluster-manager-demo*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/pcluster-manager-demo*
+
 Outputs:
   PrivateDeployRole:
     Value: !GetAtt PrivateDeployRole.Arn
+  PrivateInfrastructureUpdateRole:
+    Value: !GetAtt PrivateInfrastructureUpdateRole.Arn

--- a/infrastructure/readme.md
+++ b/infrastructure/readme.md
@@ -7,8 +7,11 @@ To create the resources needed by the workflow action you can deploy the `./gith
 - Give the stack a name (it doesn't matter which one)
 - Create the stack
 - Go to the IAM console, find the role name `*PrivateDeploy*`, copy the ARN and use it with the [AWS credentials action](https://github.com/marketplace/actions/configure-aws-credentials-action-for-github-actions) to authenticate
+- Same needs to be done for the `*PrivateInfrastructureUpdateRole*` role
 
-The stack will create a new role with the minimum set of policies needed to build and deploy an instance of PCluster Manager.
+The stack will create two new roles:
+- the `PrivateDeployRole` with the minimum set of policies needed to build and deploy an instance of PCluster Manager
+- the `PrivateInfrastructureUpdateRole` with the minimum set of policies needed to update the infrastructure of an environment running PCluster Manager
 
 **This procedure must be done only once per AWS account since IAM it's a global service.**
 
@@ -23,3 +26,10 @@ To update the infrastructure just run the `infrastructure/update-environment-inf
 If you have to update the `demo` environment do the following:
 - gain `Admin` access to the AWS account in which the environment is hosted
 - run `./infrastructure/update-environment-infra.sh demo`
+
+### Update the infrastructure via the GitHub workflow
+In order to have the minimum set of allowed actions, the `*UpdateInfrastructurePolicy*` may need to be expanded with time.
+
+If you changed the infrastructure YAMLs, and the workflow is failing due to missing permissions, you should go to `infrastructure/github-env-setup.yml` and update the policy with the new actions you need.
+
+You can then re-run your failing workflow


### PR DESCRIPTION
## Description

This PR adds a new `PrivateInfrastructureUpdateRole` IAM role to the `github-env-setup.yml` template that is to be assumed when running the `update-environment-infra.sh`

Another PR will follow with the workflow running the script and assuming this role

## Changes

- add `PrivateInfrastructureUpdateRole` to the `github-env-setup.yml`

## Changelog entry

- add role to the CFN template that is to be assumed when updating the infrastructure via CI

## How Has This Been Tested?

- created the Role and Policy and ran the update script manually
- tested the created Policy with https://policysim.aws.amazon.com/home/index.jsp and made sure only intended actions are allowed

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
