### PR TITLE
Refactor PclusterManagerUserRole policies

### DIFF
--- a/infrastructure/pcluster-manager.yaml
+++ b/infrastructure/pcluster-manager.yaml
@@ -572,7 +572,9 @@ Resources:
         # Required to run PclusterManager functionalities
         - !If [ UsesCognito, !Ref PclusterManagerCognitoPolicy, !Ref AWS::NoValue ]
         - !Ref PclusterManagerEC2Policy
-        - !Ref PclusterManagerExtraPolicies
+        - !Ref PclusterManagerDescribeFsxPolicy
+        - !Ref PclusterManagerDescribeEfsPolicy
+        - !Ref PclusterManagerPricingPolicy
         - !Ref PclusterManagerSsmSendPolicy
         - !Ref PclusterManagerSsmGetCommandInvocationPolicy
 
@@ -693,7 +695,7 @@ Resources:
             Effect: Allow
             Sid: EC2ManagePolicy
 
-  PclusterManagerExtraPolicies:
+  PclusterManagerDescribeFsxPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
       PolicyDocument:
@@ -703,21 +705,36 @@ Resources:
               - fsx:DescribeFileSystems
               - fsx:DescribeVolumes
             Resource:
-            - '*'
+              - !Sub arn:${AWS::Partition}:fsx:*:${AWS::AccountId}:volume/*
+              - !Sub arn:${AWS::Partition}:fsx:*:${AWS::AccountId}:file-system/*
             Effect: Allow
-            Sid: FsxLustrePolicy
+            Sid: FsxPolicy
+
+  PclusterManagerDescribeEfsPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
           - Action:
-            - elasticfilesystem:DescribeFileSystems
+              - elasticfilesystem:DescribeFileSystems
             Resource:
               - !Sub arn:${AWS::Partition}:elasticfilesystem:*:${AWS::AccountId}:file-system/*
             Effect: Allow
             Sid: EfsPolicy
+
+  PclusterManagerPricingPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
           - Action:
-            - pricing:GetProducts
+              - pricing:GetProducts
             Resource:
-            - '*'
+              - '*'
             Effect: Allow
-            Sid: PricePolicy
+            Sid: PricingPolicy
 
   PclusterManagerSsmSendPolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -726,7 +743,7 @@ Resources:
         Version: '2012-10-17'
         Statement:
           - Action:
-            - ssm:SendCommand
+              - ssm:SendCommand
             Resource:
               - !Sub arn:${AWS::Partition}:ec2:*:${AWS::AccountId}:instance/*
             Effect: Allow


### PR DESCRIPTION
## Description

* Refactored `PclusterManagerExtraPolicies` separating it in three different policies clarifying the scope
* Removed wildcards in policies where possible

## How Has This Been Tested?

* Deployed stacks on my personal account
* Performed tasks in PR Quality Checklist successfully
* Created cluster with EFS
* Created cluster with FSx
* Submitted a job through SSM

## References

* https://quip-amazon.com/9MgvA9mYGAzt/PCM-IAM-Resources

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
