### PR TITLE
Add parameters to support Okta

### DIFF
--- a/infrastructure/pcluster-manager.yaml
+++ b/infrastructure/pcluster-manager.yaml
@@ -38,10 +38,32 @@ Parameters:
     Type: String
     Default: ''
   OIDCProvider:
-    Description: OICD provider to use (defaults to Amazon Cognito).
+    Description: OIDC provider to use (defaults to Amazon Cognito).
     Type: String
-    AllowedValues: [Cognito]
+    AllowedValues: [Cognito, Okta]
     Default: Cognito
+  OktaDomain:
+    Description: The Okta domain.
+    Type: String
+    Default: ''
+  OktaResourceServerId:
+    Description: The Okta resource server ID.
+    Type: String
+    Default: ''
+  OktaClientId:
+    Description: The client ID.
+    Type: String
+    Default: ''
+  OktaClientSecret:
+    Description: The client secret.
+    Type: String
+    NoEcho: true
+    Default: ''
+  OktaScopesList:
+    Description: The Okta scopes list.
+    Type: String
+    Default: 'openid profile email groups'
+
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -61,6 +83,18 @@ Metadata:
         Parameters:
           - Version
           - PublicEcrImageUri
+      - Label:
+          default: OIDC provider
+        Parameters:
+          - OIDCProvider
+      - Label:
+          default: Okta - Compile only if Okta is selected as OIDC provider
+        Parameters:
+          - OktaDomain
+          - OktaResourceServerId
+          - OktaClientId
+          - OktaClientSecret
+          - OktaScopesList
     ParameterLabels:
       EnableMFA:
         default: Require Multi-Factor Authentication for all Users
@@ -70,6 +104,18 @@ Metadata:
         default: Initial Admin's Email 
       AdminUserPhone:
         default: Initial Admin's Phone Number
+      OIDCProvider:
+        default: OIDC provider
+      OktaDomain:
+        default: Domain
+      OktaResourceServerId:
+        default: Resource Server ID
+      OktaClientId:
+        default: Client ID
+      OktaClientSecret:
+        default: Client Secret
+      OktaScopesList:
+        default: Scopes List
 
 Conditions:
   NonDefaultVpc:
@@ -78,6 +124,7 @@ Conditions:
       - !Not [!Equals [!Ref ImageBuilderSubnetId, ""]]
   HasDefaultInfrastructure: !Equals [!Ref InfrastructureBucket, '']
   UsesCognito: !Equals [!Ref OIDCProvider, 'Cognito']
+  UsesOkta: !Equals [!Ref OIDCProvider, 'Okta']
 
 Mappings:
   PclusterManager:
@@ -164,6 +211,11 @@ Resources:
           OIDC_PROVIDER: !Ref OIDCProvider
           ENABLE_AUTH: !Ref EnableAuth
           ENABLE_MFA: !Ref EnableMFA
+          OKTA_DOMAIN: !If [ UsesOkta, !Ref OktaDomain, !Ref AWS::NoValue ]
+          OKTA_RESOURCE_SERVER_ID: !If [ UsesOkta, !Ref OktaResourceServerId, !Ref AWS::NoValue ]
+          CLIENT_ID: !If [ UsesOkta, !Ref OktaClientId, !Ref AWS::NoValue ]
+          CLIENT_SECRET: !If [ UsesOkta, !Ref OktaClientSecret, !Ref AWS::NoValue ]
+          SCOPES_LIST: !If [ UsesOkta, !Ref OktaScopesList, !Ref AWS::NoValue ]
       FunctionName: !Sub
         - PclusterManagerFunction-${StackIdSuffix}
         - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }


### PR DESCRIPTION
### Notes
This patch adds parameters to support Okta. Note that it is not possible to dynamically hide or disable a configuration section based on the choosen OIDC provider in CloudFormation, however it is possible to separate the parameters in different sections using the `AWS::CloudFormation::Interface` metadata, which is the approach adopted in this PR.

<img width="1285" alt="image" src="https://user-images.githubusercontent.com/1719421/191536428-6a540952-a7f3-48e7-9910-5cb3c7833639.png">

### Tests
Verified that by choosing Cognito everything continues to work correctly.

### PR Quality Checklist

- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
