### PR TITLE
Added checkbox for infrastructure edits check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,6 +22,7 @@
 
 - [ ] I added tests to new or existing code
 - [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
+- [ ] In case the infrastructure files were edited I tested the infra update to make sure the right policies/permissions were in place or I added/edited the right policies to make the infra update work
 - [ ] I checked that `npm run build` builds without any error
 - [ ] I checked that clusters are listed correctly
 - [ ] I checked that a new cluster can be created (config is produced and dry run passes)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,7 +22,7 @@
 
 - [ ] I added tests to new or existing code
 - [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
-- [ ] In case the infrastructure files were edited I tested the infra update to make sure the right policies/permissions were in place or I added/edited the right policies to make the infra update work
+- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
 - [ ] I checked that `npm run build` builds without any error
 - [ ] I checked that clusters are listed correctly
 - [ ] I checked that a new cluster can be created (config is produced and dry run passes)


### PR DESCRIPTION
## Description
In case the infrastructure CloudFormation templates get edited, it's important to make sure the update infra script from the GH Action still works. This usually involves changes in the role used by the GH Action to perform certain actions. If new actions are needed, new policies need to get added to the role used by the GH Action itself.


## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
