### PR TITLE
Restore docker build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,15 +1,9 @@
-# Install dependencies
-FROM node:16-alpine as deps
+FROM node:16-alpine
 WORKDIR /app
-COPY package.json ./
-COPY package-lock.json ./
-RUN npm ci
-
-# Build source code
-FROM node:16-alpine AS builder
-WORKDIR /app
-COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+# The env var is used to skip git-secrets checks, not needed for the build
+ENV CI true
+RUN npm ci
 # Disable telemetry
 #   Next.js collects completely anonymous telemetry data about general usage.
 #   Learn more here: https://nextjs.org/telemetry

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -11,6 +11,12 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  experimental: {
+    images: {
+      unoptimized: true, // disables next/image for static exports, otherwise the export is going to fail
+                         // it can be enabled when the Next server is used
+    },
+  },
   async rewrites() {
     return [
       /**

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
     "lint": "next lint",
     "dev": "next dev",
     "export": "next build && next export -o build",
-    "prepare": "/bin/bash ./scripts/git-secrets-command.sh '--register-aws > /dev/null' && cd .. && husky install frontend/.husky",
+    "prepare": "./scripts/git-secrets-command.sh '--register-aws > /dev/null' && cd .. && husky install frontend/.husky",
     "ts-reignore": "ts-migrate reignore . --sources='src/**/*'",
     "ts-validate": "tsc -p tsconfig.json"
   },

--- a/frontend/scripts/git-secrets-command.sh
+++ b/frontend/scripts/git-secrets-command.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # The following script checks if git-secrets is installed on a local machine.
 # If not, it prints an error message pointing to the official awslabs git-secrets repository.

--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -45,7 +45,6 @@ import {
 // Components
 import HelpTooltip from '../../components/HelpTooltip'
 import {NonCancelableEventHandler} from '@awsui/components-react/internal/events'
-import Image from 'next/image'
 
 // Helper Functions
 function strToOption(str: any) {


### PR DESCRIPTION
## Description

Some of the recent activities, like `git-secrets` and `linting` setup, broke the build of the Docker image.
This PR fixes those issues.

## Changes

- disabled Next image component, not available for static exports
- replaced Bash with sh as it's not available in the docker image
- skip `git-secrets` when building the Docker image

## How Has This Been Tested?

Built the Docker image successfully

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
