### PR TITLE
Force region to be specified in update.sh

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -e
 
-REGION=$(aws configure get region)
-REGION_SET=false
 LOCAL=false
 TAG=latest
 
@@ -23,7 +21,6 @@ case $key in
     ;;
     --region)
     REGION=$2
-    REGION_SET=true
     shift # past argument
     shift # past value
     ;;
@@ -43,8 +40,9 @@ case $key in
 esac
 done
 
-if [ "$REGION_SET" == "false" ]; then
-    echo "Warning: Using default region $REGION from your environment. Please ensure this is where pcluster manager is deployed.";
+if [ -z $REGION ]; then
+    echo "Error: no region was specified, please provide one using --region REGION, exiting."
+    exit 1
 fi
 
 if [ -z $STACKNAME ]; then


### PR DESCRIPTION
## Description

[The last run of Actions](https://github.com/aws-samples/pcluster-manager/actions/runs/3182434830) was failing after fixing the script invocation (using the `-e` flag).
The command failing the build is the one to retrieve the region: this is not really needed as it's better to specify the region manually, thus has been removed.

## How Has This Been Tested?

Run the `update.sh` script locally and verified the region is taken correctly.

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
