### PR TITLE
Use feature flags to toggle features instead of using version checks

### DIFF
--- a/frontend/src/old-pages/Clusters/Filesystems.tsx
+++ b/frontend/src/old-pages/Clusters/Filesystems.tsx
@@ -25,6 +25,7 @@ import {
 
 // Components
 import EmptyState from '../../components/EmptyState'
+import {useFeatureFlag} from '../../feature-flags/useFeatureFlag'
 
 function StorageId({storage}: any) {
   const settingsKey = `${storage.StorageType}Settings`
@@ -36,11 +37,13 @@ function StorageId({storage}: any) {
   const id = getIn(storage, [settingsKey, idKey])
   const defaultRegion = useState(['aws', 'region'])
   const region = useState(['app', 'selectedRegion']) || defaultRegion
-  const versionMinor = useState(['app', 'version', 'minor'])
-  const fsxStorageTypes =
-    versionMinor && versionMinor >= 2
-      ? ['FsxLustre', 'FsxOntap', 'FsxOpenZfs']
-      : ['FsxLustre']
+  const isFsxOnTapActive = useFeatureFlag('fsx_ontap')
+  const isFsxOpenZsfActive = useFeatureFlag('fsx_openzsf')
+  const fsxStorageTypes = [
+    'FsxLustre',
+    isFsxOnTapActive ? 'FsxOntap' : false,
+    isFsxOpenZsfActive ? 'FsxOpenZfs' : false,
+  ].filter(Boolean)
 
   if (!id) return 'internal'
 

--- a/frontend/src/old-pages/Configure/Cluster.tsx
+++ b/frontend/src/old-pages/Configure/Cluster.tsx
@@ -33,6 +33,7 @@ import {LoadAwsConfig} from '../../model'
 
 // Components
 import {LabeledIcon, CustomAMISettings} from './Components'
+import {useFeatureFlag} from '../../feature-flags/useFeatureFlag'
 
 // Constants
 const errorsPath = ['app', 'wizard', 'errors', 'cluster']
@@ -340,8 +341,7 @@ function Cluster() {
   let awsConfig = useState(['aws'])
   let defaultRegion = useState(['aws', 'region']) || ''
   const region = useState(['app', 'selectedRegion']) || defaultRegion
-
-  let versionMinor = useState(['app', 'version', 'minor'])
+  const isMultiuserClusterActive = useFeatureFlag('multiuser_cluster')
 
   React.useEffect(() => {
     const configPath = ['app', 'wizard', 'config']
@@ -403,7 +403,7 @@ function Cluster() {
         <RegionSelect />
         <OsSelect />
         <VpcSelect />
-        {versionMinor && versionMinor >= 1 && (
+        {isMultiuserClusterActive && (
           <FormField>
             <Header
               // @ts-expect-error TS(2322) FIXME: Type '"h4"' is not assignable to type 'Variant | u... Remove this comment to see the full error message

--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -109,7 +109,7 @@ function storageValidate() {
 
 function FsxLustreSettings({index}: any) {
   const {t} = useTranslation()
-  const versionMinor = useState(['app', 'version', 'minor'])
+  const isLustrePersistent2Active = useFeatureFlag('lustre_persistent2')
   const useExisting =
     useState(['app', 'wizard', 'storage', 'ui', index, 'useExisting']) || false
 
@@ -117,10 +117,12 @@ function FsxLustreSettings({index}: any) {
   const storageCapacityPath = [...fsxPath, 'StorageCapacity']
   const lustreTypePath = [...fsxPath, 'DeploymentType']
   // support FSx Lustre PERSISTENT_2 only in >= 3.2.0
-  const lustreTypes =
-    versionMinor >= 2
-      ? ['PERSISTENT_2', 'PERSISTENT_1', 'SCRATCH_1', 'SCRATCH_2']
-      : ['PERSISTENT_1', 'SCRATCH_1', 'SCRATCH_2']
+  const lustreTypes = [
+    isLustrePersistent2Active ? 'PERSISTENT_2' : null,
+    'PERSISTENT_1',
+    'SCRATCH_1',
+    'SCRATCH_2',
+  ].filter(Boolean)
   const storageThroughputPath = [...fsxPath, 'PerUnitStorageThroughput']
   const storageThroughputsP1 = [50, 100, 200]
   const storageThroughputsP2 = [125, 250, 500, 1000]
@@ -146,7 +148,7 @@ function FsxLustreSettings({index}: any) {
     if (lustreType === null && !useExisting)
       setState(
         lustreTypePath,
-        versionMinor >= 2 ? 'PERSISTENT_2' : 'PERSISTENT_1',
+        isLustrePersistent2Active ? 'PERSISTENT_2' : 'PERSISTENT_1',
       )
   }, [
     storageCapacity,
@@ -154,7 +156,7 @@ function FsxLustreSettings({index}: any) {
     storageThroughput,
     index,
     useExisting,
-    versionMinor,
+    isLustrePersistent2Active,
   ])
 
   const toggleCompression = () => {

--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -42,6 +42,7 @@ import {
   STORAGE_TYPE_PROPS,
   UIStorageSettings,
 } from './Storage.types'
+import {useFeatureFlag} from '../../feature-flags/useFeatureFlag'
 
 // Constants
 const storagePath = ['app', 'wizard', 'config', 'SharedStorage']
@@ -1043,7 +1044,8 @@ function Storage() {
   const editing = useState(['app', 'wizard', 'editing'])
   const uiStorageSettings = useState(['app', 'wizard', 'storage', 'ui'])
   const storageType = useState(['app', 'wizard', 'storage', 'type'])
-  const versionMinor = useState(['app', 'version', 'minor'])
+  const isFsxOnTapActive = useFeatureFlag('fsx_ontap')
+  const isFsxOpenZsfActive = useFeatureFlag('fsx_openzsf')
 
   const storageMaxes: Record<string, number> = {
     FsxLustre: 21,
@@ -1056,20 +1058,17 @@ function Storage() {
   /*
     Activate ONTAP/OpenZFS only from ParallelCluster 3.2.0
    */
-  const storageTypesSource: StorageTypeOption[] =
-    versionMinor >= 2
-      ? [
-          ['FsxLustre', 'Amazon FSx for Lustre (FSX)', '/img/fsx.svg'],
-          ['FsxOntap', 'Amazon FSx for NetApp ONTAP (FSX)', '/img/fsx.svg'],
-          ['FsxOpenZfs', 'Amazon FSx for OpenZFS (FSX)', '/img/fsx.svg'],
-          ['Efs', 'Amazon Elastic File System (EFS)', '/img/efs.svg'],
-          ['Ebs', 'Amazon Elastic Block Store (EBS)', '/img/ebs.svg'],
-        ]
-      : [
-          ['FsxLustre', 'Amazon FSx for Lustre (FSX)', '/img/fsx.svg'],
-          ['Efs', 'Amazon Elastic File System (EFS)', '/img/efs.svg'],
-          ['Ebs', 'Amazon Elastic Block Store (EBS)', '/img/ebs.svg'],
-        ]
+  const storageTypesSource: StorageTypeOption[] = [
+    ['FsxLustre', 'Amazon FSx for Lustre (FSX)', '/img/fsx.svg'],
+    isFsxOnTapActive
+      ? ['FsxOntap', 'Amazon FSx for NetApp ONTAP (FSX)', '/img/fsx.svg']
+      : false,
+    isFsxOpenZsfActive
+      ? ['FsxOpenZfs', 'Amazon FSx for OpenZFS (FSX)', '/img/fsx.svg']
+      : false,
+    ['Efs', 'Amazon Elastic File System (EFS)', '/img/efs.svg'],
+    ['Ebs', 'Amazon Elastic Block Store (EBS)', '/img/ebs.svg'],
+  ].filter(Boolean) as StorageTypeOption[]
 
   const defaultCounts = {FsxLustre: 0, Efs: 0, Ebs: 0}
 


### PR DESCRIPTION
## Description

This PR adopts the mechanisms introduced with #311 in order to toggle features using flags, instead of version checks

## Changes

- adopt `multiuser_cluster` feature flags
- adopt `fsx_ontap` and `fsx_openzsf` feature flags
- adopt `persistent_2` feature flag

## How Has This Been Tested?

- manually mocked the current version and checked feature gets toggled on and off, for every adopted flag

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
