### PR TITLE
Removed OIDC provider option and related "UsesCognito" condition

### DIFF
--- a/infrastructure/pcluster-manager.yaml
+++ b/infrastructure/pcluster-manager.yaml
@@ -37,11 +37,6 @@ Parameters:
     Description: S3 bucket where CloudFormation files are stored. Change this parameter only when testing changes made to the infrastructure itself.
     Type: String
     Default: ''
-  OIDCProvider:
-    Description: OICD provider to use (defaults to Amazon Cognito).
-    Type: String
-    AllowedValues: [Cognito]
-    Default: Cognito
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -77,7 +72,6 @@ Conditions:
       - !Not [!Equals [!Ref ImageBuilderVpcId, ""]]
       - !Not [!Equals [!Ref ImageBuilderSubnetId, ""]]
   HasDefaultInfrastructure: !Equals [!Ref InfrastructureBucket, '']
-  UsesCognito: !Equals [!Ref OIDCProvider, 'Cognito']
 
 Mappings:
   PclusterManager:
@@ -88,7 +82,6 @@ Mappings:
 Resources:
 
   PclusterManagerCognito:
-    Condition: UsesCognito
     Type: AWS::CloudFormation::Stack
     DeletionPolicy: Retain
     Properties:
@@ -158,10 +151,10 @@ Resources:
           SITE_URL: !Sub
            - https://${Api}.execute-api.${AWS::Region}.${AWS::URLSuffix}
            - Api: !Ref ApiGateway
-          AUTH_PATH: !If [ UsesCognito, !GetAtt [ PclusterManagerCognito, Outputs.UserPoolAuthDomain ], !Ref AWS::NoValue ]
-          SECRET_ID: !If [ UsesCognito, !GetAtt [ PclusterManagerCognito, Outputs.UserPoolClientSecretName ], !Ref AWS::NoValue ]
-          AUDIENCE: !If [ UsesCognito, !GetAtt [ PclusterManagerCognito, Outputs.AppClientId ], !Ref AWS::NoValue ]
-          OIDC_PROVIDER: !Ref OIDCProvider
+          AUTH_PATH: !GetAtt [ PclusterManagerCognito, Outputs.UserPoolAuthDomain ]
+          SECRET_ID: !GetAtt [ PclusterManagerCognito, Outputs.UserPoolClientSecretName ]
+          AUDIENCE: !GetAtt [ PclusterManagerCognito, Outputs.AppClientId ]
+          OIDC_PROVIDER: 'Cognito'
           ENABLE_AUTH: !Ref EnableAuth
           ENABLE_MFA: !Ref EnableMFA
       FunctionName: !Sub
@@ -444,7 +437,6 @@ Resources:
       RetentionInDays: 90
 
   CognitoPostActions:
-    Condition: UsesCognito
     Type: Custom::CognitoPostActions
     Properties:
       ServiceToken: !GetAtt CognitoPostActionsFunction.Arn
@@ -454,7 +446,6 @@ Resources:
       UserPoolId: !GetAtt [ PclusterManagerCognito, Outputs.UserPoolId ]
 
   CognitoPostActionsFunction:
-    Condition: UsesCognito
     Type: AWS::Lambda::Function
     Properties:
       Handler: index.handler
@@ -523,7 +514,6 @@ Resources:
 
   # Add the Admin User after updating the validation message(s)
   CognitoAdminUser:
-    Condition: UsesCognito
     Type: AWS::Cognito::UserPoolUser
     DependsOn: [CognitoPostActions, PclusterManagerFunction]
     Properties:
@@ -538,7 +528,6 @@ Resources:
       UserPoolId: !GetAtt [ PclusterManagerCognito, Outputs.UserPoolId ]
 
   CognitoUserToAdminGroup:
-    Condition: UsesCognito
     Type: AWS::Cognito::UserPoolUserToGroupAttachment
     Properties:
       GroupName: !GetAtt [ PclusterManagerCognito, Outputs.CognitoAdminGroup ]
@@ -546,7 +535,6 @@ Resources:
       UserPoolId: !GetAtt [ PclusterManagerCognito, Outputs.UserPoolId ]
 
   CognitoUserToUserGroup:
-    Condition: UsesCognito
     Type: AWS::Cognito::UserPoolUserToGroupAttachment
     Properties:
       GroupName: !GetAtt [ PclusterManagerCognito, Outputs.CognitoUserGroup ]
@@ -571,7 +559,7 @@ Resources:
         # Access to the ParllelCluster API
         - !Ref ParallelClusterApiGatewayInvoke
         # Required to run PclusterManager functionalities
-        - !If [ UsesCognito, !Ref PclusterManagerCognitoPolicy, !Ref AWS::NoValue ]
+        - !Ref PclusterManagerCognitoPolicy
         - !Ref PclusterManagerEC2Policy
         - !Ref PclusterManagerDescribeFsxPolicy
         - !Ref PclusterManagerDescribeEfsPolicy
@@ -580,7 +568,6 @@ Resources:
         - !Ref PclusterManagerSsmGetCommandInvocationPolicy
 
   CognitoPostActionsRole:
-    Condition: UsesCognito
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -644,7 +631,6 @@ Resources:
               - { PCApiGateway: !Select [2, !Split ['/', !Select [0, !Split ['.', !GetAtt [ ParallelClusterApi, Outputs.ParallelClusterApiInvokeUrl ]]]]] }
 
   PclusterManagerCognitoPolicy:
-    Condition: UsesCognito
     Type: AWS::IAM::ManagedPolicy
     Properties:
       PolicyDocument:


### PR DESCRIPTION
## Description
Removed unnecessary OIDC provider option from the input parameters and the related `UsesCognito` condition from the CloudFormation template.
<!-- Summary of what this PR introduces and possibly why -->

<!-- List of relevant changes introduced -->

## Changelog entry
- `infrastructure/pcluster-manager.yaml`
<!-- A sentence to be added to the next release's changelog that captures the changes in this PR -->

## How Has This Been Tested?
This has been tested by deploying a new stack and making sure
- the provider option doesn't appear
- the stack gets deployed correctly
- the login works
<!-- The tests you ran to verify your changes -->

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
