### PR TITLE
Enforce IMDSv2 for ImageBuilder instances

### DIFF
--- a/infrastructure/pcluster-manager.yaml
+++ b/infrastructure/pcluster-manager.yaml
@@ -257,6 +257,8 @@ Resources:
           - NonDefaultVpc
           - [!Ref InfrastructureConfigurationSecurityGroup]
           - !Ref AWS::NoValue
+      InstanceMetadataOptions:
+        HttpTokens: required
 
   EcrImageRecipe:
     Type: AWS::ImageBuilder::ContainerRecipe


### PR DESCRIPTION
#### Notes
We use IMDSv2 to copy the pubilc Docker image into the customer's private ECR repository. This patch makes usage of IMDSv2 required in ImageBuilder's build instance (i.e. it disabled IMDSv1). This is okay since we don't allow the customer to specify custom components where they could make `curl` calls to IMDSv1, etc. (see the `EcrImageRecipe`).

#### Tests
Stack deployed in personal account.

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
