### PR TITLE
Add Slurm Accounting configuration in wizard

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -158,11 +158,32 @@
       "memoryBasedSchedulingEnabled": {
         "label": "Slurm Memory Based Scheduling Enabled",
         "help": "If enabled, users may use <i>--mem</i> to specify the amount of memory per node required by a job. For more information, see the <0>Slurm documentation for ConstrainRAMSpace</0>"
-     },
-     "securityGroups": {
+      },
+      "securityGroups": {
        "label": "Additional Security Groups",
        "help": "Provides additional security groups for the HeadNode."
-     }
+      },
+      "slurmSettings": {
+        "validation": {
+          "databaseCannotBeEmpty": "Database cannot be empty",
+          "usernameCannotBeEmpty": "Username cannot be empty",
+          "passwordCannotBeEmpty": "Password cannot be empty"
+        },
+        "container": {
+          "title": "Slurm Settings",
+          "optional": "optional"
+        },
+        "database": {
+          "label": "Database",
+          "placeholder": "DNSName/ip:port"
+        },
+        "username": {
+          "label": "Username"
+        },
+        "password": {
+          "label": "Password"
+        }
+      }
     },
     "storage": {
       "validation": {

--- a/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
+++ b/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
@@ -27,7 +27,7 @@ describe('given a feature flags provider and a list of rules', () => {
     })
   })
 
-  describe('when the version is above 3.2.0', () => {
+  describe('when the version is between 3.2.0 and 3.3.0', () => {
     it('should return the list of available features', async () => {
       const features = await subject('3.2.5')
       expect(features).toEqual([
@@ -36,6 +36,20 @@ describe('given a feature flags provider and a list of rules', () => {
         'fsx_openzsf',
         'lustre_persistent2',
         'memory_based_scheduling',
+      ])
+    })
+  })
+
+  describe('when the version is above 3.3.0', () => {
+    it('should return the list of available features', async () => {
+      const features = await subject('3.3.2')
+      expect(features).toEqual([
+        'multiuser_cluster',
+        'fsx_ontap',
+        'fsx_openzsf',
+        'lustre_persistent2',
+        'memory_based_scheduling',
+        'slurm_accounting',
       ])
     })
   })

--- a/frontend/src/feature-flags/featureFlagsProvider.ts
+++ b/frontend/src/feature-flags/featureFlagsProvider.ts
@@ -19,6 +19,7 @@ const versionToFeaturesMap: Record<string, AvailableFeature[]> = {
     'memory_based_scheduling',
     'multiuser_cluster',
   ],
+  '3.3.0': ['slurm_accounting'],
 }
 
 function composeFlagsListByVersion(currentVersion: string): AvailableFeature[] {

--- a/frontend/src/feature-flags/types.ts
+++ b/frontend/src/feature-flags/types.ts
@@ -14,3 +14,4 @@ export type AvailableFeature =
   | 'lustre_persistent2'
   | 'multiuser_cluster'
   | 'memory_based_scheduling'
+  | 'slurm_accounting'

--- a/frontend/src/old-pages/Configure/SlurmSettings.tsx
+++ b/frontend/src/old-pages/Configure/SlurmSettings.tsx
@@ -1,0 +1,174 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react'
+import i18next from 'i18next'
+import {useTranslation} from 'react-i18next'
+import {
+  Container,
+  Input,
+  FormField,
+  Header,
+  ColumnLayout,
+} from '@awsui/components-react'
+import {setState, getState, useState, clearState} from '../../store'
+
+const slurmSettingsPath = [
+  'app',
+  'wizard',
+  'config',
+  'Scheduling',
+  'SlurmSettings',
+]
+const errorsPath = ['app', 'wizard', 'errors', 'headNode', 'slurmSettings']
+
+const uriPath = [...slurmSettingsPath, 'Database', 'Uri']
+const usernamePath = [...slurmSettingsPath, 'Database', 'UserName']
+const passwordPath = [...slurmSettingsPath, 'Database', 'PasswordSecretArn']
+const uriErrorPath = [...errorsPath, 'database', 'uri']
+const usernameErrorPath = [...errorsPath, 'database', 'username']
+const passwordErrorPath = [...errorsPath, 'database', 'password']
+
+function slurmAccountingValidateAndSetErrors(): boolean {
+  const errorMask: Array<boolean> = [uriPath, usernamePath, passwordPath].map(
+    path => slurmAccountingValidateField(getState(path)),
+  )
+  const errorPaths: Array<Array<string>> = [
+    uriErrorPath,
+    usernameErrorPath,
+    passwordErrorPath,
+  ]
+  const errorValues: Array<string> = [
+    i18next.t('wizard.headNode.slurmSettings.validation.databaseCannotBeEmpty'),
+    i18next.t('wizard.headNode.slurmSettings.validation.usernameCannotBeEmpty'),
+    i18next.t('wizard.headNode.slurmSettings.validation.passwordCannotBeEmpty'),
+  ]
+
+  if (errorMask.every(e => e) || errorMask.every(e => !e)) {
+    return true
+  } else {
+    slurmAccountingSetErrors(errorMask, errorPaths, errorValues)
+    return false
+  }
+}
+
+function slurmAccountingValidateField(field: string | undefined): boolean {
+  return field ? true : false
+}
+
+function slurmAccountingSetErrors(
+  errorMask: Array<boolean>,
+  errorPaths: Array<Array<string>>,
+  errorValues: Array<string>,
+) {
+  errorMask.forEach((err, idx) =>
+    err
+      ? clearState(errorPaths[idx])
+      : setState(errorPaths[idx], errorValues[idx]),
+  )
+}
+
+function DatabaseField() {
+  const {t} = useTranslation()
+  let uri = useState(uriPath) || ''
+  let uriError = useState(uriErrorPath) || ''
+
+  return (
+    <FormField
+      label={t('wizard.headNode.slurmSettings.database.label')}
+      errorText={uriError}
+    >
+      <Input
+        onChange={({detail}) => {
+          setState(uriPath, detail.value)
+        }}
+        value={uri}
+        placeholder={t('wizard.headNode.slurmSettings.database.placeholder')}
+      />
+    </FormField>
+  )
+}
+
+function UsernameField() {
+  const {t} = useTranslation()
+  let username = useState(usernamePath) || ''
+  let usernameError = useState(usernameErrorPath) || ''
+
+  return (
+    <FormField
+      label={t('wizard.headNode.slurmSettings.username.label')}
+      errorText={usernameError}
+    >
+      <Input
+        onChange={({detail}) => {
+          setState(usernamePath, detail.value)
+        }}
+        value={username}
+        type="text"
+      />
+    </FormField>
+  )
+}
+
+function PasswordField() {
+  const {t} = useTranslation()
+  let password = useState(passwordPath) || ''
+  let passwordError = useState(passwordErrorPath) || ''
+
+  return (
+    <FormField
+      label={t('wizard.headNode.slurmSettings.password.label')}
+      errorText={passwordError}
+    >
+      <Input
+        onChange={({detail}) => {
+          setState(passwordPath, detail.value)
+        }}
+        value={password}
+        type="text"
+      />
+    </FormField>
+  )
+}
+
+function SlurmSettings() {
+  const {t} = useTranslation()
+
+  return (
+    <Container
+      header={
+        <Header variant="h2">
+          {t('wizard.headNode.slurmSettings.container.title')}{' '}
+          <span
+            style={{fontWeight: '400', fontStyle: 'italic', fontSize: '14px'}}
+          >
+            - {t('wizard.headNode.slurmSettings.container.optional')}
+          </span>
+        </Header>
+      }
+    >
+      <ColumnLayout columns={2}>
+        <DatabaseField />
+      </ColumnLayout>
+      <ColumnLayout columns={2}>
+        <UsernameField />
+        <PasswordField />
+      </ColumnLayout>
+    </Container>
+  )
+}
+
+export {
+  SlurmSettings,
+  slurmAccountingValidateAndSetErrors,
+  slurmAccountingValidateField,
+  slurmAccountingSetErrors,
+}

--- a/frontend/src/old-pages/Configure/__tests__/slurmAccountingValidation.test.ts
+++ b/frontend/src/old-pages/Configure/__tests__/slurmAccountingValidation.test.ts
@@ -1,0 +1,102 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  slurmAccountingValidateField,
+  slurmAccountingSetErrors,
+} from '../SlurmSettings'
+
+const mockSetState = jest.fn()
+const mockClearState = jest.fn()
+
+jest.mock('../../../store', () => ({
+  ...(jest.requireActual('../../../store') as any),
+  setState: (...args: unknown[]) => mockSetState(...args),
+  clearState: (...args: unknown[]) => mockClearState(...args),
+}))
+
+describe('Given a function to validate a Slurm Accounting field', () => {
+  describe('if a field is not empty or undefined', () => {
+    it('should return true', () => {
+      expect(slurmAccountingValidateField('some-uri')).toBeTruthy()
+    })
+  })
+  describe('if a field is empty', () => {
+    it('should return false', () => {
+      expect(slurmAccountingValidateField('')).toBeFalsy()
+    })
+  })
+  describe('if a field is undefined', () => {
+    it('should return false', () => {
+      expect(slurmAccountingValidateField(undefined)).toBeFalsy()
+    })
+  })
+})
+
+describe('Given a function to set errors on Slurm Accouting fields', () => {
+  const errorPaths = [
+    ['uriErrorPath'],
+    ['usernameErrorPath'],
+    ['passwordErrorPath'],
+  ]
+  const errorValues = [
+    'uriErrorValue',
+    'usernameErrorValue',
+    'passwordErrorValue',
+  ]
+
+  beforeEach(() => {
+    mockClearState.mockReset()
+    mockSetState.mockReset()
+  })
+
+  describe('if uri field is valid, and username and password are not valid', () => {
+    it('should clean uri error and set username and password errors', () => {
+      slurmAccountingSetErrors([true, false, false], errorPaths, errorValues)
+      expect(mockClearState).toHaveBeenCalledTimes(1)
+      expect(mockClearState).toHaveBeenCalledWith(['uriErrorPath'])
+      expect(mockSetState).toHaveBeenCalledTimes(2)
+      expect(mockSetState).toHaveBeenCalledWith(
+        ['usernameErrorPath'],
+        'usernameErrorValue',
+      )
+      expect(mockSetState).toHaveBeenCalledWith(
+        ['passwordErrorPath'],
+        'passwordErrorValue',
+      )
+    })
+  })
+
+  describe('if uri and password fields are valid, and username is not valid', () => {
+    it('should clean uri password errors and set username error', () => {
+      slurmAccountingSetErrors([true, false, true], errorPaths, errorValues)
+      expect(mockClearState).toHaveBeenCalledTimes(2)
+      expect(mockClearState).toHaveBeenCalledWith(['uriErrorPath'])
+      expect(mockClearState).toHaveBeenCalledWith(['passwordErrorPath'])
+      expect(mockSetState).toHaveBeenCalledTimes(1)
+      expect(mockSetState).toHaveBeenCalledWith(
+        ['usernameErrorPath'],
+        'usernameErrorValue',
+      )
+    })
+  })
+
+  describe('if all fields are valid', () => {
+    it('should clean errors on every field', () => {
+      slurmAccountingSetErrors([true, true, true], errorPaths, errorValues)
+      expect(mockClearState).toHaveBeenCalledTimes(3)
+      expect(mockClearState).toHaveBeenCalledWith(['uriErrorPath'])
+      expect(mockClearState).toHaveBeenCalledWith(['usernameErrorPath'])
+      expect(mockClearState).toHaveBeenCalledWith(['passwordErrorPath'])
+    })
+  })
+})


### PR DESCRIPTION
## Description

Currently in pcluster-manager users can leverage Slurm Accouting feature by following [this procedure](https://pcluster.cloud/02-tutorials/02-slurm-accounting.html), which is based on the Multi-Runner script feature.

From ParallelCluster 3.3.0, users are able to provide their own database that Slurm will use to store accounting data. ParallelCluster will take care of configuring the scheduler db daemon and its communication with the database server.

This PR aims at providing a new `Slurm Settings` section in the `HeadNode` wizard configuration section to specify the following paramters:
* `Database`: the uri of the database
* `Username`: username of the admin user of the database
* `Password`: Secrets Manager arn of the plain text password of the database admin
## Changelog entry

* Added Slurm Accounting configuration in create cluster wizard

## How Has This Been Tested?
* Verified that if no field is set, user can navigate to next page (Slurm Settings box is entirely marked as optional)
* Verified that if all fields are set, user can navigate to the next page
* Verified that if some fields are sets and some don't, user is prompted with an error message in the offending field(s)
* Manually inspected generated YAML configuration file
* Dry-run executed successfully

<!-- The tests you ran to verify your changes -->

## PR Quality Checklist

- [x] I added tests to new or existing code
- [x] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
