### PR TITLE
Fix release infra: Added necessary policy to 'PrivateInfrastructureUpdateRole'

### DIFF
--- a/infrastructure/github-env-setup.yml
+++ b/infrastructure/github-env-setup.yml
@@ -146,6 +146,24 @@ Resources:
                   - lambda:UpdateFunctionConfiguration
                 Resource:
                   - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:PclusterManagerFunction-*
+        - PolicyName: ImageBuilderPolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - imagebuilder:UpdateInfrastructureConfiguration
+                Resource:
+                  - !Sub arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:infrastructure-configuration/pclustermanagerimagebuilderinfrastructureconfiguration-*
+        - PolicyName: PassRolePolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - iam:PassRole
+                Resource:
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/executionServiceEC2Role/pcluster-manager-demo-ImageBuilderInstanceRole*
 
 Outputs:
   PrivateDeployRole:


### PR DESCRIPTION
## Description
Added to policies to the PrivateInfrastructureUpdateRole to allow the release infrastructure script to work.

<!-- A sentence to be added to the next release's changelog that captures the changes in this PR -->

## How Has This Been Tested?
This has been tested updating the current github-env stack in ClouFormation with the one in this PR.

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [x] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
