### PR TITLE
Fix Slurm Accounting visualization and validation

### DIFF
--- a/frontend/src/old-pages/Clusters/Details.tsx
+++ b/frontend/src/old-pages/Clusters/Details.tsx
@@ -11,7 +11,7 @@
 import React from 'react'
 import {useNavigate, useParams} from 'react-router-dom'
 
-import {useState} from '../../store'
+import {getState, useState} from '../../store'
 import {getScripts} from './util'
 
 // UI Elements
@@ -39,7 +39,23 @@ export default function ClusterTabs() {
   ])
   const selectedClusterName = useState(['app', 'clusters', 'selected'])
 
-  let accountingEnabled = getScripts(customActions).includes('slurm-accounting')
+  function isMultiScriptAccountingEnabled() {
+    return getScripts(customActions).includes('slurm-accounting')
+  }
+
+  function isNativeAccountingEnabled() {
+    const accountingPath = [
+      ...clusterPath,
+      'config',
+      'Scheduling',
+      'SlurmSettings',
+      'Database',
+    ]
+    return getState(accountingPath) ? true : false
+  }
+
+  let accountingEnabled =
+    isMultiScriptAccountingEnabled() || isNativeAccountingEnabled()
   let navigate = useNavigate()
   let params = useParams()
 

--- a/frontend/src/old-pages/Configure/SlurmSettings.tsx
+++ b/frontend/src/old-pages/Configure/SlurmSettings.tsx
@@ -52,7 +52,10 @@ function slurmAccountingValidateAndSetErrors(): boolean {
     i18next.t('wizard.headNode.slurmSettings.validation.passwordCannotBeEmpty'),
   ]
 
-  if (errorMask.every(e => e) || errorMask.every(e => !e)) {
+  if (errorMask.every(e => e)) {
+    return true
+  } else if (errorMask.every(e => !e)) {
+    clearState([...slurmSettingsPath, 'Database'])
     return true
   } else {
     slurmAccountingSetErrors(errorMask, errorPaths, errorValues)


### PR DESCRIPTION
## Description

Following Slurm Accounting integration in: https://github.com/aws-samples/pcluster-manager/pull/320, this PR aims to fix two issues:

1. Slurm Accounting tab did not show up in case Slurm Accounting was enabled through Slurm Settings section
2. If Slurm Accounting fields were filled and then deleted, the validation process did not take care of clearing the state of the fields, resulting in a YAML configuration file with empty parameters

## How Has This Been Tested?

* Created a cluster with `slurm_accounting` feature flag disabled
   * Verified that if accounting fields are filled and then deleted, the resulting YAML configuration does not have `Database` section included
* Created a cluster with `slurm_accounting` feature enabled
   * Submitted successfully 3 sample jobs
   * Retrieved accounting info through `sacct` command and showed in `Accounting` tab in cluster details page

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
