### PR TITLE
Add Slurm ScaledownIdleTime support

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -167,7 +167,8 @@
         "validation": {
           "databaseCannotBeEmpty": "Database cannot be empty",
           "usernameCannotBeEmpty": "Username cannot be empty",
-          "passwordCannotBeEmpty": "Password cannot be empty"
+          "passwordCannotBeEmpty": "Password cannot be empty",
+          "scaledownIdleTimeLessThanOne": "Scaledown idle time should be at least 1 minute"
         },
         "container": {
           "title": "Slurm Settings",
@@ -182,6 +183,10 @@
         },
         "password": {
           "label": "Password"
+        },
+        "scaledownIdleTime": {
+          "label": "Scaledown Idle Time (minutes)",
+          "placeholder": "10"
         }
       }
     },

--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -52,8 +52,8 @@ import {
 import HelpTooltip from '../../components/HelpTooltip'
 import {useFeatureFlag} from '../../feature-flags/useFeatureFlag'
 import {
-  slurmAccountingValidateAndSetErrors,
   SlurmSettings,
+  validateSlurmSettings,
 } from './SlurmSettings/SlurmSettings'
 
 // Constants
@@ -152,7 +152,7 @@ function headNodeValidate() {
     clearState([...errorsPath, 'onConfigured'])
   }
 
-  valid = slurmAccountingValidateAndSetErrors()
+  valid = validateSlurmSettings()
 
   setState([...errorsPath, 'validated'], true)
 
@@ -516,7 +516,7 @@ function HeadNode() {
           </ExpandableSection>
         </SpaceBetween>
       </Container>
-      {true && <SlurmSettings />}
+      <SlurmSettings />
     </ColumnLayout>
   )
 }

--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -54,7 +54,7 @@ import {useFeatureFlag} from '../../feature-flags/useFeatureFlag'
 import {
   slurmAccountingValidateAndSetErrors,
   SlurmSettings,
-} from './SlurmSettings'
+} from './SlurmSettings/SlurmSettings'
 
 // Constants
 const headNodePath = ['app', 'wizard', 'config', 'HeadNode']
@@ -516,7 +516,7 @@ function HeadNode() {
           </ExpandableSection>
         </SpaceBetween>
       </Container>
-      {isSlurmAccountingActive && <SlurmSettings />}
+      {true && <SlurmSettings />}
     </ColumnLayout>
   )
 }

--- a/frontend/src/old-pages/Configure/SlurmSettings/ScaledownIdleTimeForm.tsx
+++ b/frontend/src/old-pages/Configure/SlurmSettings/ScaledownIdleTimeForm.tsx
@@ -1,0 +1,81 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {FormField, Input} from '@awsui/components-react'
+import {BaseChangeDetail} from '@awsui/components-react/input/interfaces'
+import {NonCancelableEventHandler} from '@awsui/components-react/internal/events'
+import {useCallback, useState} from 'react'
+import {useTranslation} from 'react-i18next'
+
+export function validateScaledownIdleTime(value: string) {
+  if (!value) {
+    return true
+  }
+
+  return parseInt(value, 10) > 0
+}
+
+type ViewStatus = 'error' | 'valid'
+
+interface Props {
+  value: number | undefined
+  onChange: (value: number | null) => void
+}
+
+export const ScaledownIdleTimeForm: React.FC<Props> = ({value, onChange}) => {
+  const {t} = useTranslation()
+  const [status, setStatus] = useState<ViewStatus>('valid')
+
+  const displayValue = String(value)
+  const errorText =
+    status === 'error'
+      ? t(
+          'wizard.headNode.slurmSettings.validation.scaledownIdleTimeLessThanOne',
+        )
+      : null
+
+  const onChangeCallback: NonCancelableEventHandler<BaseChangeDetail> =
+    useCallback(
+      ({detail: {value}}) => {
+        if (!value) {
+          setStatus('valid')
+          onChange(null)
+          return
+        }
+
+        if (validateScaledownIdleTime(value)) {
+          setStatus('valid')
+          onChange(parseInt(value, 10))
+        } else {
+          setStatus('error')
+          onChange(parseInt(value, 10))
+        }
+      },
+      [onChange],
+    )
+
+  return (
+    <FormField
+      label={t('wizard.headNode.slurmSettings.scaledownIdleTime.label')}
+      errorText={errorText}
+    >
+      <Input
+        onChange={onChangeCallback}
+        value={displayValue}
+        placeholder={t(
+          'wizard.headNode.slurmSettings.scaledownIdleTime.placeholder',
+        )}
+        type="number"
+        inputMode="numeric"
+      />
+    </FormField>
+  )
+}

--- a/frontend/src/old-pages/Configure/SlurmSettings/SlurmAccountingForm.tsx
+++ b/frontend/src/old-pages/Configure/SlurmSettings/SlurmAccountingForm.tsx
@@ -1,0 +1,133 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ColumnLayout, FormField, Input} from '@awsui/components-react'
+import {useTranslation} from 'react-i18next'
+import {useFeatureFlag} from '../../../feature-flags/useFeatureFlag'
+import {setState, useState} from '../../../store'
+
+interface DatabaseFieldProps {
+  uriPath: string[]
+  uriErrorPath: string[]
+}
+
+function DatabaseField({uriPath, uriErrorPath}: DatabaseFieldProps) {
+  const {t} = useTranslation()
+  let uri = useState(uriPath) || ''
+  let uriError = useState(uriErrorPath) || ''
+
+  return (
+    <FormField
+      label={t('wizard.headNode.slurmSettings.database.label')}
+      errorText={uriError}
+    >
+      <Input
+        onChange={({detail}) => {
+          setState(uriPath, detail.value)
+        }}
+        value={uri}
+        placeholder={t('wizard.headNode.slurmSettings.database.placeholder')}
+      />
+    </FormField>
+  )
+}
+
+interface UsernameFieldProps {
+  usernamePath: string[]
+  usernameErrorPath: string[]
+}
+
+function UsernameField({usernamePath, usernameErrorPath}: UsernameFieldProps) {
+  const {t} = useTranslation()
+  let username = useState(usernamePath) || ''
+  let usernameError = useState(usernameErrorPath) || ''
+
+  return (
+    <FormField
+      label={t('wizard.headNode.slurmSettings.username.label')}
+      errorText={usernameError}
+    >
+      <Input
+        onChange={({detail}) => {
+          setState(usernamePath, detail.value)
+        }}
+        value={username}
+        type="text"
+      />
+    </FormField>
+  )
+}
+
+interface PasswordFieldProps {
+  passwordPath: string[]
+  passwordErrorPath: string[]
+}
+
+function PasswordField({passwordPath, passwordErrorPath}: PasswordFieldProps) {
+  const {t} = useTranslation()
+  let password = useState(passwordPath) || ''
+  let passwordError = useState(passwordErrorPath) || ''
+
+  return (
+    <FormField
+      label={t('wizard.headNode.slurmSettings.password.label')}
+      errorText={passwordError}
+    >
+      <Input
+        onChange={({detail}) => {
+          setState(passwordPath, detail.value)
+        }}
+        value={password}
+        type="text"
+      />
+    </FormField>
+  )
+}
+
+interface Props {
+  uriPath: string[]
+  uriErrorPath: string[]
+  usernamePath: string[]
+  usernameErrorPath: string[]
+  passwordPath: string[]
+  passwordErrorPath: string[]
+}
+
+export const SlurmAccountingForm: React.FC<Props> = ({
+  uriPath,
+  uriErrorPath,
+  usernamePath,
+  usernameErrorPath,
+  passwordPath,
+  passwordErrorPath,
+}) => {
+  const isSlurmAccountingEnabled = useFeatureFlag('slurm_accounting')
+
+  if (!isSlurmAccountingEnabled) return null
+
+  return (
+    <>
+      <ColumnLayout columns={2}>
+        <DatabaseField uriPath={uriPath} uriErrorPath={uriErrorPath} />
+      </ColumnLayout>
+      <ColumnLayout columns={2}>
+        <UsernameField
+          usernamePath={usernamePath}
+          usernameErrorPath={usernameErrorPath}
+        />
+        <PasswordField
+          passwordPath={passwordPath}
+          passwordErrorPath={passwordErrorPath}
+        />
+      </ColumnLayout>
+    </>
+  )
+}

--- a/frontend/src/old-pages/Configure/SlurmSettings/SlurmSettings.tsx
+++ b/frontend/src/old-pages/Configure/SlurmSettings/SlurmSettings.tsx
@@ -19,6 +19,8 @@ import {
   Header,
   ColumnLayout,
 } from '@awsui/components-react'
+import {setState, getState, clearState} from '../../../store'
+import {SlurmAccountingForm} from './SlurmAccountingForm'
 import {setState, getState, useState, clearState} from '../../../store'
 
 const slurmSettingsPath = [
@@ -79,69 +81,6 @@ function slurmAccountingSetErrors(
   )
 }
 
-function DatabaseField() {
-  const {t} = useTranslation()
-  let uri = useState(uriPath) || ''
-  let uriError = useState(uriErrorPath) || ''
-
-  return (
-    <FormField
-      label={t('wizard.headNode.slurmSettings.database.label')}
-      errorText={uriError}
-    >
-      <Input
-        onChange={({detail}) => {
-          setState(uriPath, detail.value)
-        }}
-        value={uri}
-        placeholder={t('wizard.headNode.slurmSettings.database.placeholder')}
-      />
-    </FormField>
-  )
-}
-
-function UsernameField() {
-  const {t} = useTranslation()
-  let username = useState(usernamePath) || ''
-  let usernameError = useState(usernameErrorPath) || ''
-
-  return (
-    <FormField
-      label={t('wizard.headNode.slurmSettings.username.label')}
-      errorText={usernameError}
-    >
-      <Input
-        onChange={({detail}) => {
-          setState(usernamePath, detail.value)
-        }}
-        value={username}
-        type="text"
-      />
-    </FormField>
-  )
-}
-
-function PasswordField() {
-  const {t} = useTranslation()
-  let password = useState(passwordPath) || ''
-  let passwordError = useState(passwordErrorPath) || ''
-
-  return (
-    <FormField
-      label={t('wizard.headNode.slurmSettings.password.label')}
-      errorText={passwordError}
-    >
-      <Input
-        onChange={({detail}) => {
-          setState(passwordPath, detail.value)
-        }}
-        value={password}
-        type="text"
-      />
-    </FormField>
-  )
-}
-
 function SlurmSettings() {
   const {t} = useTranslation()
 
@@ -158,13 +97,14 @@ function SlurmSettings() {
         </Header>
       }
     >
-      <ColumnLayout columns={2}>
-        <DatabaseField />
-      </ColumnLayout>
-      <ColumnLayout columns={2}>
-        <UsernameField />
-        <PasswordField />
-      </ColumnLayout>
+      <SlurmAccountingForm
+        uriPath={uriPath}
+        uriErrorPath={uriErrorPath}
+        usernamePath={usernamePath}
+        usernameErrorPath={usernameErrorPath}
+        passwordPath={passwordPath}
+        passwordErrorPath={passwordErrorPath}
+      />
     </Container>
   )
 }

--- a/frontend/src/old-pages/Configure/SlurmSettings/SlurmSettings.tsx
+++ b/frontend/src/old-pages/Configure/SlurmSettings/SlurmSettings.tsx
@@ -19,7 +19,7 @@ import {
   Header,
   ColumnLayout,
 } from '@awsui/components-react'
-import {setState, getState, useState, clearState} from '../../store'
+import {setState, getState, useState, clearState} from '../../../store'
 
 const slurmSettingsPath = [
   'app',

--- a/frontend/src/old-pages/Configure/SlurmSettings/SlurmSettings.tsx
+++ b/frontend/src/old-pages/Configure/SlurmSettings/SlurmSettings.tsx
@@ -12,16 +12,13 @@
 import * as React from 'react'
 import i18next from 'i18next'
 import {useTranslation} from 'react-i18next'
-import {
-  Container,
-  Input,
-  FormField,
-  Header,
-  ColumnLayout,
-} from '@awsui/components-react'
-import {setState, getState, clearState} from '../../../store'
+import {Container, Header, ColumnLayout} from '@awsui/components-react'
+import {setState, getState, clearState, useState} from '../../../store'
 import {SlurmAccountingForm} from './SlurmAccountingForm'
-import {setState, getState, useState, clearState} from '../../../store'
+import {
+  ScaledownIdleTimeForm,
+  validateScaledownIdleTime,
+} from './ScaledownIdleTimeForm'
 
 const slurmSettingsPath = [
   'app',
@@ -38,6 +35,8 @@ const passwordPath = [...slurmSettingsPath, 'Database', 'PasswordSecretArn']
 const uriErrorPath = [...errorsPath, 'database', 'uri']
 const usernameErrorPath = [...errorsPath, 'database', 'username']
 const passwordErrorPath = [...errorsPath, 'database', 'password']
+
+const scaledownIdleTimePath = [...slurmSettingsPath, 'ScaledownIdletime']
 
 function slurmAccountingValidateAndSetErrors(): boolean {
   const errorMask: Array<boolean> = [uriPath, usernamePath, passwordPath].map(
@@ -81,8 +80,31 @@ function slurmAccountingSetErrors(
   )
 }
 
+function validateSlurmSettings() {
+  const scaledownIdleTime = getState(scaledownIdleTimePath)
+
+  const validSettings = [
+    slurmAccountingValidateAndSetErrors(),
+    validateScaledownIdleTime(scaledownIdleTime),
+  ]
+
+  return validSettings.filter(Boolean).length === validSettings.length
+}
+
 function SlurmSettings() {
   const {t} = useTranslation()
+  const scaledownIdleTime = useState(scaledownIdleTimePath)
+
+  const onScaledownIdleTimeChange = React.useCallback(
+    (value: number | null) => {
+      if (!value) {
+        clearState(scaledownIdleTimePath)
+      } else {
+        setState(scaledownIdleTimePath, value)
+      }
+    },
+    [],
+  )
 
   return (
     <Container
@@ -105,12 +127,19 @@ function SlurmSettings() {
         passwordPath={passwordPath}
         passwordErrorPath={passwordErrorPath}
       />
+      <ColumnLayout columns={2}>
+        <ScaledownIdleTimeForm
+          value={scaledownIdleTime}
+          onChange={onScaledownIdleTimeChange}
+        />
+      </ColumnLayout>
     </Container>
   )
 }
 
 export {
   SlurmSettings,
+  validateSlurmSettings,
   slurmAccountingValidateAndSetErrors,
   slurmAccountingValidateField,
   slurmAccountingSetErrors,

--- a/frontend/src/old-pages/Configure/SlurmSettings/__tests__/ScaledownIdleTimeForm.test.tsx
+++ b/frontend/src/old-pages/Configure/SlurmSettings/__tests__/ScaledownIdleTimeForm.test.tsx
@@ -1,0 +1,96 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {fireEvent, render, RenderResult, waitFor} from '@testing-library/react'
+import {I18nextProvider} from 'react-i18next'
+import i18n from 'i18next'
+import {initReactI18next} from 'react-i18next'
+import {ScaledownIdleTimeForm} from '../ScaledownIdleTimeForm'
+
+i18n.use(initReactI18next).init({
+  resources: {},
+  lng: 'en',
+})
+
+const MockProviders = (props: any) => (
+  <I18nextProvider i18n={i18n}>{props.children}</I18nextProvider>
+)
+
+describe("given a component to set the Slurm's scaledown idle time", () => {
+  let screen: RenderResult
+  let mockOnChange: jest.Mock
+
+  beforeEach(() => {
+    mockOnChange = jest.fn()
+
+    screen = render(
+      <MockProviders>
+        <ScaledownIdleTimeForm value={undefined} onChange={mockOnChange} />
+      </MockProviders>,
+    )
+  })
+
+  describe('when the user selects a valid value', () => {
+    const mockValidValue = 5
+
+    beforeEach(async () => {
+      const field = screen.getByRole('spinbutton')
+      await waitFor(() =>
+        fireEvent.change(field, {target: {value: mockValidValue}}),
+      )
+    })
+
+    it('should call the onChange handler with the value ', () => {
+      expect(mockOnChange).toHaveBeenCalledTimes(1)
+      expect(mockOnChange).toHaveBeenCalledWith(mockValidValue)
+    })
+  })
+
+  describe('when the user selects an invalid value', () => {
+    const mockInvalidValue = -1
+
+    beforeEach(async () => {
+      const field = screen.getByRole('spinbutton')
+      await waitFor(() =>
+        fireEvent.change(field, {target: {value: mockInvalidValue}}),
+      )
+    })
+
+    it('should display the error message', () => {
+      expect(
+        screen.getByText(
+          'wizard.headNode.slurmSettings.validation.scaledownIdleTimeLessThanOne',
+        ),
+      ).toBeTruthy()
+    })
+
+    it('should call the onChange handler with the invalid value ', () => {
+      expect(mockOnChange).toHaveBeenCalledTimes(1)
+      expect(mockOnChange).toHaveBeenCalledWith(mockInvalidValue)
+    })
+  })
+
+  describe('when the user leaves the field empty', () => {
+    const mockEmptyValue = ''
+
+    beforeEach(async () => {
+      const field = screen.getByRole('spinbutton')
+      await waitFor(() =>
+        fireEvent.change(field, {target: {value: mockEmptyValue}}),
+      )
+    })
+
+    it('should call the onChange handler with null ', () => {
+      expect(mockOnChange).toHaveBeenCalledTimes(1)
+      expect(mockOnChange).toHaveBeenCalledWith(null)
+    })
+  })
+})

--- a/frontend/src/old-pages/Configure/SlurmSettings/__tests__/slurmAccountingValidation.test.ts
+++ b/frontend/src/old-pages/Configure/SlurmSettings/__tests__/slurmAccountingValidation.test.ts
@@ -18,8 +18,8 @@ import {
 const mockSetState = jest.fn()
 const mockClearState = jest.fn()
 
-jest.mock('../../../store', () => ({
-  ...(jest.requireActual('../../../store') as any),
+jest.mock('../../../../store', () => ({
+  ...(jest.requireActual('../../../../store') as any),
   setState: (...args: unknown[]) => mockSetState(...args),
   clearState: (...args: unknown[]) => mockClearState(...args),
 }))


### PR DESCRIPTION
## Description

This PR adds support for the `ScaledownIdletime` Slurm setting

## Changes

- refactor `SlurmAccountingForm` into its own component
- add `ScaledownIdleTimeForm` component

## Changelog entry

Add support for the the [`ScaledownIdletime` Slurm setting](https://docs.aws.amazon.com/parallelcluster/latest/ug/Scheduling-v3.html#yaml-Scheduling-SlurmSettings-ScaledownIdletime)

## How Has This Been Tested?

- unit tests
- manually tested both setting and unsetting the property
- manually tested the error case

## References

- [ScaledownIdletime documentation](https://docs.aws.amazon.com/parallelcluster/latest/ug/Scheduling-v3.html#yaml-Scheduling-SlurmSettings-ScaledownIdletime)

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
