### PR TITLE
Move Slurm memory based scheduling from 'HeadNode' to 'Queues' wizard section

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -155,10 +155,6 @@
         "label": "Subnet ID",
         "description": "Subnet ID for HeadNode."
       },
-      "memoryBasedSchedulingEnabled": {
-        "label": "Slurm Memory Based Scheduling Enabled",
-        "help": "If enabled, users may use <i>--mem</i> to specify the amount of memory per node required by a job. For more information, see the <0>Slurm documentation for ConstrainRAMSpace</0>"
-      },
       "securityGroups": {
        "label": "Additional Security Groups",
        "help": "Provides additional security groups for the HeadNode."
@@ -276,6 +272,24 @@
         "scriptWithArgs": "You must specify a script path if you specify args.",
         "customAmiSelect": "You must select an AMI ID if you enable Custom AMI."
       },
+      "container": {
+        "title": "Queues"
+      },
+      "slurmMemorySettings": {
+        "container": {
+          "title": "Slurm Memory Settings",
+          "info": "info",
+          "help": "If enabled, users may use <i>--mem</i> to specify the amount of memory per node required by a job. For more information, see the <0>Slurm documentation for ConstrainRAMSpace</0>"
+        },
+        "toggle": {
+          "label": "Slurm Memory Based Scheduling"
+        },
+        "info": {
+          "header": "Slurm Memory Based Scheduling can be enabled if only one instance type is selected",
+          "body": "If more than one instance type is selected in any queue, Slurm Memory Based Scheduling is disabled by default.",
+          "dismissAriaLabel": "Close alert"
+        }
+      },
       "schedulableMemory": {
         "name": "Schedulable Memory (MiB)",
         "description": "Amount of memory in MiB to be made available to jobs on the compute nodes of the compute resource",
@@ -289,6 +303,9 @@
         "disableHT": "Disable Hyperthreading",
         "enableEfa": "Enable EFA",
         "enableGpuDirect": "Enable EFA GPUDirect RDMA"
+      },
+      "addQueueButton": {
+        "label": "Add queue"
       },
       "Gdr": {
         "help": "Only for p4d.24xlarge, See <0>GdrSupport</0>."

--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -369,9 +369,6 @@ function HeadNode() {
   const subnetErrors = useState([...errorsPath, 'subnet'])
   const subnetValue = useState(subnetPath) || ''
   const editing = useState(['app', 'wizard', 'editing'])
-  const isMemoryBasedSchedulingActive = useFeatureFlag(
-    'memory_based_scheduling',
-  )
   let isSlurmAccountingActive = useFeatureFlag('slurm_accounting')
 
   const toggleImdsSecured = () => {
@@ -381,34 +378,6 @@ function HeadNode() {
       clearState(imdsSecuredPath)
       if (Object.keys(getState([...headNodePath, 'Imds'])).length === 0)
         clearState([...headNodePath, 'Imds'])
-    }
-  }
-
-  const slurmSettingsPath = [
-    'app',
-    'wizard',
-    'config',
-    'Scheduling',
-    'SlurmSettings',
-  ]
-  const memoryBasedSchedulingEnabledPath = [
-    ...slurmSettingsPath,
-    'EnableMemoryBasedScheduling',
-  ]
-  const memoryBasedSchedulingEnabled = useState(
-    memoryBasedSchedulingEnabledPath,
-  )
-  const toggleMemoryBasedSchedulingEnabled = () => {
-    const setMemoryBasedSchedulingEnabled = !memoryBasedSchedulingEnabled
-    if (setMemoryBasedSchedulingEnabled)
-      setState(
-        memoryBasedSchedulingEnabledPath,
-        setMemoryBasedSchedulingEnabled,
-      )
-    else {
-      clearState(memoryBasedSchedulingEnabledPath)
-      if (Object.keys(getState([...slurmSettingsPath])).length === 0)
-        clearState([...slurmSettingsPath])
     }
   }
 
@@ -465,33 +434,6 @@ function HeadNode() {
               </Trans>
             </HelpTooltip>
           </div>
-          {isMemoryBasedSchedulingActive && (
-            <div
-              key="memory-based-scheduling-enabled"
-              style={{
-                display: 'flex',
-                flexDirection: 'row',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-              }}
-            >
-              <Toggle
-                checked={memoryBasedSchedulingEnabled || false}
-                onChange={toggleMemoryBasedSchedulingEnabled}
-              >
-                <Trans i18nKey="wizard.headNode.memoryBasedSchedulingEnabled.label" />
-              </Toggle>
-              <HelpTooltip>
-                <Trans i18nKey="wizard.headNode.memoryBasedSchedulingEnabled.help">
-                  <a
-                    rel="noopener noreferrer"
-                    target="_blank"
-                    href="https://slurm.schedmd.com/cgroup.conf.html#OPT_ConstrainRAMSpace"
-                  ></a>
-                </Trans>
-              </HelpTooltip>
-            </div>
-          )}
           <div
             key="sgs"
             style={{

--- a/frontend/src/old-pages/Configure/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues.tsx
@@ -45,6 +45,8 @@ import {
 } from './Components'
 import HelpTooltip from '../../components/HelpTooltip'
 import {Trans, useTranslation} from 'react-i18next'
+import {SlurmMemorySettings} from './SlurmMemorySettings'
+import {useFeatureFlag} from '../../feature-flags/useFeatureFlag'
 
 // Constants
 const queuesPath = ['app', 'wizard', 'config', 'Scheduling', 'SlurmQueues']
@@ -660,7 +662,12 @@ function QueuesView() {
 }
 
 function Queues() {
+  const {t} = useTranslation()
+  const isMemoryBasedSchedulingActive = useFeatureFlag(
+    'memory_based_scheduling',
+  )
   let queues = useState(queuesPath) || []
+
   const addQueue = () => {
     setState(
       [...queuesPath],
@@ -685,20 +692,27 @@ function Queues() {
   }
 
   return (
-    <Container header={<Header variant="h2">Queues</Header>}>
-      <div>
-        <QueuesView />
-      </div>
-      <div className="wizard-compute-add">
-        <Button
-          disabled={queues.length >= 5}
-          onClick={addQueue}
-          iconName={'add-plus'}
-        >
-          Add Queue
-        </Button>
-      </div>
-    </Container>
+    <ColumnLayout>
+      {isMemoryBasedSchedulingActive && <SlurmMemorySettings />}
+      <Container
+        header={
+          <Header variant="h2">{t('wizard.queues.container.title')}</Header>
+        }
+      >
+        <div>
+          <QueuesView />
+        </div>
+        <div className="wizard-compute-add">
+          <Button
+            disabled={queues.length >= 5}
+            onClick={addQueue}
+            iconName={'add-plus'}
+          >
+            {t('wizard.queues.addQueueButton.label')}
+          </Button>
+        </div>
+      </Container>
+    </ColumnLayout>
   )
 }
 

--- a/frontend/src/old-pages/Configure/SlurmMemorySettings.tsx
+++ b/frontend/src/old-pages/Configure/SlurmMemorySettings.tsx
@@ -1,0 +1,110 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react'
+import {Trans, useTranslation} from 'react-i18next'
+import {
+  Container,
+  Header,
+  Alert,
+  Toggle,
+  SpaceBetween,
+} from '@awsui/components-react'
+import {setState, getState, useState, clearState} from '../../store'
+
+function SlurmMemorySettings() {
+  const {t} = useTranslation()
+  const [infoAlertVisible, setInfoAlertVisible] = React.useState(false)
+  const slurmSettingsPath = [
+    'app',
+    'wizard',
+    'config',
+    'Scheduling',
+    'SlurmSettings',
+  ]
+  const memoryBasedSchedulingEnabledPath = [
+    ...slurmSettingsPath,
+    'EnableMemoryBasedScheduling',
+  ]
+  const memoryBasedSchedulingEnabled = useState(
+    memoryBasedSchedulingEnabledPath,
+  )
+
+  const toggleMemoryBasedSchedulingEnabled = () => {
+    const setMemoryBasedSchedulingEnabled = !memoryBasedSchedulingEnabled
+    if (setMemoryBasedSchedulingEnabled)
+      setState(
+        memoryBasedSchedulingEnabledPath,
+        setMemoryBasedSchedulingEnabled,
+      )
+    else {
+      clearState(memoryBasedSchedulingEnabledPath)
+      if (Object.keys(getState([...slurmSettingsPath])).length === 0)
+        clearState([...slurmSettingsPath])
+    }
+  }
+
+  return (
+    <Container
+      header={
+        <Header variant="h2">
+          <SpaceBetween size="xs" direction="horizontal">
+            {t('wizard.queues.slurmMemorySettings.container.title')}
+            <a
+              href="#"
+              onClick={() => setInfoAlertVisible(true)}
+              style={{
+                fontWeight: '700',
+                fontStyle: 'normal',
+                fontSize: '12px',
+                color: '#0073BB',
+              }}
+            >
+              {t('wizard.queues.slurmMemorySettings.container.info')}
+            </a>
+          </SpaceBetween>
+        </Header>
+      }
+    >
+      <SpaceBetween size={'s'} direction={'vertical'}>
+        <div
+          key="memory-based-scheduling-enabled"
+          style={{
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <Toggle
+            checked={memoryBasedSchedulingEnabled}
+            onChange={toggleMemoryBasedSchedulingEnabled}
+          >
+            <Trans i18nKey="wizard.queues.slurmMemorySettings.toggle.label" />
+          </Toggle>
+        </div>
+        <Alert
+          onDismiss={() => setInfoAlertVisible(false)}
+          visible={infoAlertVisible}
+          dismissAriaLabel={t(
+            'wizard.queues.slurmMemorySettings.info.dismissAriaLabel',
+          )}
+          dismissible
+          header={t('wizard.queues.slurmMemorySettings.info.header')}
+        >
+          {t('wizard.queues.slurmMemorySettings.info.body')}
+        </Alert>
+      </SpaceBetween>
+    </Container>
+  )
+}
+
+export {SlurmMemorySettings}

--- a/frontend/src/old-pages/Configure/SlurmMemorySettings.tsx
+++ b/frontend/src/old-pages/Configure/SlurmMemorySettings.tsx
@@ -17,6 +17,8 @@ import {
   Alert,
   Toggle,
   SpaceBetween,
+  Popover,
+  Link,
 } from '@awsui/components-react'
 import {setState, getState, useState, clearState} from '../../store'
 
@@ -58,18 +60,25 @@ function SlurmMemorySettings() {
         <Header variant="h2">
           <SpaceBetween size="xs" direction="horizontal">
             {t('wizard.queues.slurmMemorySettings.container.title')}
-            <a
-              href="#"
-              onClick={() => setInfoAlertVisible(true)}
-              style={{
-                fontWeight: '700',
-                fontStyle: 'normal',
-                fontSize: '12px',
-                color: '#0073BB',
-              }}
+            <Popover
+              dismissButton={true}
+              position="right"
+              size="small"
+              triggerType="custom"
+              content={
+                <Trans i18nKey="wizard.queues.slurmMemorySettings.container.help">
+                  <a
+                    rel="noopener noreferrer"
+                    target="_blank"
+                    href="https://slurm.schedmd.com/cgroup.conf.html#OPT_ConstrainRAMSpace"
+                  ></a>
+                </Trans>
+              }
             >
-              {t('wizard.queues.slurmMemorySettings.container.info')}
-            </a>
+              <Link variant="info">
+                {t('wizard.queues.slurmMemorySettings.container.info')}
+              </Link>
+            </Popover>
           </SpaceBetween>
         </Header>
       }


### PR DESCRIPTION
## Description

Following the UX refactoring of ParallelCluster Manager, this PR aims at moving the 'Enable Slurm Memory Based Scheduling' toggle from the HeadNode to the Queues wizard section, in a new, dedicated box.

With PC 3.3, multiple `InstanceTypes` per queues have been introduced. We need to disable `Slurm Memory Based Scheduling` in case of multiple instance types have been selected. This issue will be handled in a dedicated PR.

## Changelog entry

* Moved Slurm memory based scheduling from 'HeadNode' to 'Queues' wizard section

## How Has This Been Tested?
* Successfully created cluster with Slurm Memory Based Scheduling enabled
* Successfully created cluster without Slurm Memory Based Scheduling enabled
* Info button works as expected

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
