### PR TITLE
Update PC version to 3.3.0b1

### DIFF
--- a/infrastructure/environments/demo-cfn.yaml
+++ b/infrastructure/environments/demo-cfn.yaml
@@ -1,7 +1,7 @@
 TemplateURL: https://pcluster-manager-github-infrastructurebucket-7y5h202iem8l.s3.eu-west-1.amazonaws.com/pcluster-manager.yaml
 Parameters:
   - ParameterKey: Version
-    ParameterValue: 3.2.0
+    ParameterValue: 3.3.0b1
   - ParameterKey: InfrastructureBucket
     ParameterValue: https://pcluster-manager-github-infrastructurebucket-7y5h202iem8l.s3.eu-west-1.amazonaws.com
   - ParameterKey: AdminUserEmail

--- a/infrastructure/pcluster-manager.yaml
+++ b/infrastructure/pcluster-manager.yaml
@@ -24,7 +24,7 @@ Parameters:
   Version:
     Description: Version of AWS ParallelCluster to deploy
     Type: String
-    Default: 3.2.0
+    Default: 3.3.0b1
   ImageBuilderVpcId:
     Description: (Optional) Select the VPC to use for building the container images. If not selected, default VPC will be used.
     Type: String
@@ -76,8 +76,8 @@ Conditions:
 Mappings:
   PclusterManager:
     Constants:
-      Version: 3.2.0
-      ShortVersion: 3.2.0
+      Version: 3.3.0
+      ShortVersion: 3.3.0
 
 Resources:
 


### PR DESCRIPTION
## Description

Update the demo environment to the latest version available of ParallelCluster. 
This PR simply aligns the template with what's on the demo environment since it has been already updated manually.

## Changes

Update the relevant infrastructure files for PC 3.3

## How Has This Been Tested?

Updated the stack manually through CFN and verified the portal is running with the latest version

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
