### PR TITLE
Add Slurm QueueUpdateStrategy support

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -193,9 +193,9 @@
           "placeholder": "Select a queue update strategy",
           "selectedAriaLabel": "Selected",
           "options": {
-            "computeFleetStop": "COMPUTE_FLEET_STOP",
-            "drain": "DRAIN",
-            "terminate": "TERMINATE"
+            "computeFleetStop": "Compute Fleet Stop",
+            "drain": "Drain",
+            "terminate": "Terminate"
           }
         }
       }

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -187,6 +187,16 @@
         "scaledownIdleTime": {
           "label": "Scaledown Idle Time (minutes)",
           "placeholder": "10"
+        },
+        "queueUpdateStrategy": {
+          "label": "Queue Update Strategy",
+          "placeholder": "Select a queue update strategy",
+          "selectedAriaLabel": "Selected",
+          "options": {
+            "computeFleetStop": "COMPUTE_FLEET_STOP",
+            "drain": "DRAIN",
+            "terminate": "TERMINATE"
+          }
         }
       }
     },

--- a/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
+++ b/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
@@ -36,6 +36,7 @@ describe('given a feature flags provider and a list of rules', () => {
         'fsx_openzsf',
         'lustre_persistent2',
         'memory_based_scheduling',
+        'slurm_queue_update_strategy',
       ])
     })
   })
@@ -49,6 +50,7 @@ describe('given a feature flags provider and a list of rules', () => {
         'fsx_openzsf',
         'lustre_persistent2',
         'memory_based_scheduling',
+        'slurm_queue_update_strategy',
         'slurm_accounting',
       ])
     })

--- a/frontend/src/feature-flags/featureFlagsProvider.ts
+++ b/frontend/src/feature-flags/featureFlagsProvider.ts
@@ -18,6 +18,7 @@ const versionToFeaturesMap: Record<string, AvailableFeature[]> = {
     'lustre_persistent2',
     'memory_based_scheduling',
     'multiuser_cluster',
+    'slurm_queue_update_strategy',
   ],
   '3.3.0': ['slurm_accounting'],
 }

--- a/frontend/src/feature-flags/types.ts
+++ b/frontend/src/feature-flags/types.ts
@@ -15,3 +15,4 @@ export type AvailableFeature =
   | 'multiuser_cluster'
   | 'memory_based_scheduling'
   | 'slurm_accounting'
+  | 'slurm_queue_update_strategy'

--- a/frontend/src/old-pages/Configure/SlurmSettings/QueueUpdateStrategyForm.tsx
+++ b/frontend/src/old-pages/Configure/SlurmSettings/QueueUpdateStrategyForm.tsx
@@ -1,0 +1,82 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {FormField, Select, SelectProps} from '@awsui/components-react'
+import {NonCancelableEventHandler} from '@awsui/components-react/internal/events'
+import {useCallback} from 'react'
+import {useTranslation} from 'react-i18next'
+import {useFeatureFlag} from '../../../feature-flags/useFeatureFlag'
+
+interface Props {
+  value: string
+  onChange: (value: string) => void
+}
+
+export const QueueUpdateStrategyForm: React.FC<Props> = ({value, onChange}) => {
+  const {t} = useTranslation()
+  const isQueueUpdateStrategyEnabled = useFeatureFlag(
+    'slurm_queue_update_strategy',
+  )
+
+  const selectedAriaLabel = t(
+    'wizard.headNode.slurmSettings.queueUpdateStrategy.selectedAriaLabel',
+  )
+  const options = [
+    {
+      label: t(
+        'wizard.headNode.slurmSettings.queueUpdateStrategy.options.computeFleetStop',
+      ),
+      value: 'COMPUTE_FLEET_STOP',
+    },
+    {
+      label: t(
+        'wizard.headNode.slurmSettings.queueUpdateStrategy.options.drain',
+      ),
+      value: 'DRAIN',
+    },
+    {
+      label: t(
+        'wizard.headNode.slurmSettings.queueUpdateStrategy.options.terminate',
+      ),
+      value: 'TERMINATE',
+    },
+  ]
+
+  const selectedOption = options.find(option => option.value === value) || null
+
+  const onChangeCallback: NonCancelableEventHandler<SelectProps.ChangeDetail> =
+    useCallback(
+      ({detail: {selectedOption}}) => {
+        if (!selectedOption.value) return
+
+        onChange(selectedOption.value)
+      },
+      [onChange],
+    )
+
+  if (!isQueueUpdateStrategyEnabled) return null
+
+  return (
+    <FormField
+      label={t('wizard.headNode.slurmSettings.queueUpdateStrategy.label')}
+    >
+      <Select
+        selectedOption={selectedOption}
+        onChange={onChangeCallback}
+        options={options}
+        placeholder={t(
+          'wizard.headNode.slurmSettings.queueUpdateStrategy.placeholder',
+        )}
+        selectedAriaLabel={selectedAriaLabel}
+      />
+    </FormField>
+  )
+}

--- a/frontend/src/old-pages/Configure/SlurmSettings/SlurmSettings.tsx
+++ b/frontend/src/old-pages/Configure/SlurmSettings/SlurmSettings.tsx
@@ -19,6 +19,7 @@ import {
   ScaledownIdleTimeForm,
   validateScaledownIdleTime,
 } from './ScaledownIdleTimeForm'
+import {QueueUpdateStrategyForm} from './QueueUpdateStrategyForm'
 
 const slurmSettingsPath = [
   'app',
@@ -37,6 +38,7 @@ const usernameErrorPath = [...errorsPath, 'database', 'username']
 const passwordErrorPath = [...errorsPath, 'database', 'password']
 
 const scaledownIdleTimePath = [...slurmSettingsPath, 'ScaledownIdletime']
+const queueUpdateStrategyPath = [...slurmSettingsPath, 'QueueUpdateStrategy']
 
 function slurmAccountingValidateAndSetErrors(): boolean {
   const errorMask: Array<boolean> = [uriPath, usernamePath, passwordPath].map(
@@ -94,6 +96,7 @@ function validateSlurmSettings() {
 function SlurmSettings() {
   const {t} = useTranslation()
   const scaledownIdleTime = useState(scaledownIdleTimePath)
+  const queueUpdateStrategy = useState(queueUpdateStrategyPath)
 
   const onScaledownIdleTimeChange = React.useCallback(
     (value: number | null) => {
@@ -105,6 +108,10 @@ function SlurmSettings() {
     },
     [],
   )
+
+  const onQueueUpdateStrategyChange = React.useCallback((value: string) => {
+    setState(queueUpdateStrategyPath, value)
+  }, [])
 
   return (
     <Container
@@ -131,6 +138,10 @@ function SlurmSettings() {
         <ScaledownIdleTimeForm
           value={scaledownIdleTime}
           onChange={onScaledownIdleTimeChange}
+        />
+        <QueueUpdateStrategyForm
+          value={queueUpdateStrategy}
+          onChange={onQueueUpdateStrategyChange}
         />
       </ColumnLayout>
     </Container>

--- a/frontend/src/old-pages/Configure/SlurmSettings/__tests__/QueueUpdateStrategyForm.test.tsx
+++ b/frontend/src/old-pages/Configure/SlurmSettings/__tests__/QueueUpdateStrategyForm.test.tsx
@@ -1,0 +1,85 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import wrapper from '@awsui/components-react/test-utils/dom'
+import {render, RenderResult} from '@testing-library/react'
+import i18n from 'i18next'
+import {I18nextProvider, initReactI18next} from 'react-i18next'
+import {QueueUpdateStrategyForm} from '../QueueUpdateStrategyForm'
+
+i18n.use(initReactI18next).init({
+  resources: {},
+  lng: 'en',
+})
+
+const MockProviders = (props: any) => (
+  <I18nextProvider i18n={i18n}>{props.children}</I18nextProvider>
+)
+
+const mockUseFeatureFlag = jest.fn()
+
+jest.mock('../../../../feature-flags/useFeatureFlag', () => ({
+  useFeatureFlag: () => mockUseFeatureFlag(),
+}))
+
+describe("given a component to set the Slurm's queue update strategy", () => {
+  let screen: RenderResult
+  let mockOnChange: jest.Mock
+
+  describe('when the slurm_queue_update_strategy flag is not set', () => {
+    beforeEach(() => {
+      mockOnChange = jest.fn()
+      mockUseFeatureFlag.mockReturnValueOnce(false)
+
+      screen = render(
+        <MockProviders>
+          <QueueUpdateStrategyForm value={''} onChange={mockOnChange} />
+        </MockProviders>,
+      )
+    })
+
+    it('should not render anything', () => {
+      expect(
+        screen.queryByLabelText(
+          'wizard.headNode.slurmSettings.queueUpdateStrategy.label',
+        ),
+      ).toBe(null)
+    })
+  })
+
+  describe('when the slurm_queue_update_strategy flag is set', () => {
+    beforeEach(() => {
+      mockOnChange = jest.fn()
+      mockUseFeatureFlag.mockReturnValueOnce(true)
+
+      screen = render(
+        <MockProviders>
+          <QueueUpdateStrategyForm value={''} onChange={mockOnChange} />
+        </MockProviders>,
+      )
+    })
+
+    describe('when the user selects a value', () => {
+      const mockSelectedValue = 'COMPUTE_FLEET_STOP'
+
+      beforeEach(async () => {
+        const selectComponent = wrapper(screen.container).findSelect()!
+        selectComponent.openDropdown()
+        selectComponent.selectOptionByValue(mockSelectedValue)
+      })
+
+      it('should call the onChange handler with the value ', () => {
+        expect(mockOnChange).toHaveBeenCalledTimes(1)
+        expect(mockOnChange).toHaveBeenCalledWith(mockSelectedValue)
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Description

This PR adds support for the `QueueUpdateStrategy` Slurm setting

## Changes

- add `slurm_queue_update_strategy` feature flag and map it to PC version 3.2.0
- add `QueueUpdateStrategyForm` component
- hide component when flag is not active

## Changelog entry

Add support for the the [QueueUpdateStrategy Slurm setting](https://docs.aws.amazon.com/parallelcluster/latest/ug/Scheduling-v3.html#yaml-Scheduling-SlurmSettings-QueueUpdateStrategy)

## How Has This Been Tested?

- unit tests
- manually tested successful dry run for each of the three options

## References

- [QueueUpdateStrategy documentation](https://docs.aws.amazon.com/parallelcluster/latest/ug/Scheduling-v3.html#yaml-Scheduling-SlurmSettings-QueueUpdateStrategy)

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
