### PR TITLE
Revert PCM version in infra

### DIFF
--- a/infrastructure/pcluster-manager.yaml
+++ b/infrastructure/pcluster-manager.yaml
@@ -76,8 +76,8 @@ Conditions:
 Mappings:
   PclusterManager:
     Constants:
-      Version: 3.3.0
-      ShortVersion: 3.3.0
+      Version: 3.2.0
+      ShortVersion: 3.2.0
 
 Resources:
 


### PR DESCRIPTION
## Description

Reverting the bump of PCM version in the infrastructure files.
This is not needed at the moment - it will be done when doing a new release - and it breaks the demo environment deploy due to lack of permissions when re-creating CFN resources.

## How Has This Been Tested?

Manually updated the template with the change.

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
