### PR TITLE
Limit demo deploy concurrency

### DIFF
--- a/.github/workflows/demo_deploy.yml
+++ b/.github/workflows/demo_deploy.yml
@@ -9,6 +9,8 @@ permissions:
   id-token: write
   contents: read
 
+concurrency: ci-${{ github.ref }}
+
 jobs:
   frontend-tests:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
## Description

Deploy to the demo environment can fail if PRs are merged over a short period of time.
See this [run](https://github.com/aws-samples/pcluster-manager/actions/runs/3310735081/attempts/1) for a failed CFN update, because another one was already in progress.

## Changes

Limits the deploy to demo to have only 1 job running at a time (concurrency=1)

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
