### PR TITLE
Fix Lambda powertools version

### DIFF
--- a/Dockerfile.awslambda
+++ b/Dockerfile.awslambda
@@ -4,7 +4,7 @@ COPY --from=frontend-awslambda /app/build ${LAMBDA_TASK_ROOT}/frontend/public
 
 COPY requirements.txt  .
 RUN  pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}" && \
-     pip3 install aws-lambda-powertools
+     pip3 install aws-lambda-powertools==1.31.1
 
 COPY app.py ${LAMBDA_TASK_ROOT}
 COPY api ${LAMBDA_TASK_ROOT}/api

--- a/awslambda/entrypoint.py
+++ b/awslambda/entrypoint.py
@@ -15,9 +15,6 @@ from typing import Any, Dict
 import app
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.typing import LambdaContext
-from aws_xray_sdk.core import xray_recorder
-from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
-
 from awslambda.serverless_wsgi import handle_request
 
 logger = Logger(service="pcluster_manager", location="%(filename)s:%(lineno)s:%(funcName)s()")
@@ -48,12 +45,6 @@ def lambda_handler(event: Dict[str, Any], context: LambdaContext) -> Dict[str, A
         if not pcluster_manager_api:
             logger.info("Initializing Flask Application")
             pcluster_manager_api = _init_flask_app()
-            # X-Ray doesn't work in GovCloud per https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-xray.html
-            # as of 2022.02.11 - cg3
-            # Instrument X-Ray recorder to trace requests served by the Flask application
-            # if event.get("version") == "2.0":
-            #    xray_recorder.configure(service="PclusterManager Flask App")
-            #    XRayMiddleware(pcluster_manager_api, xray_recorder)
         # Setting default region to region where lambda function is executed
         os.environ["AWS_DEFAULT_REGION"] = os.environ["AWS_REGION"]
         return handle_request(pcluster_manager_api, event, context)


### PR DESCRIPTION
## Description

This PR originates after new errors rising from the demo environment:

`[ERROR] Runtime.ImportModuleError: Unable to import module 'awslambda.entrypoint': No module named 'aws_xray_sdk' Traceback (most recent call last):`

Specifically, AWS Lambda Powertools [released a new breaking version](https://github.com/awslabs/aws-lambda-powertools-python/releases/tag/v2.0.0), causing the bad behaviour.
We are impacted because the Powertools are outside the requirements.txt and don't have a fixed version.

## Changes

Fixed the version of AWS Lambda Powertools

## How Has This Been Tested?

Run a Docker build of the Lambda image and verified it's working correctly

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
