### PR TITLE
Deploy documentation only on releases

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,10 +1,8 @@
-name: github pages
+name: Deploy public documentation
 
 on:
   push:
-    branches:
-      - main  # Set a branch to deploy
-  pull_request:
+    tags: '*'
 
 jobs:
   deploy:

--- a/decisions/20221025-public-documentation-release.md
+++ b/decisions/20221025-public-documentation-release.md
@@ -1,0 +1,13 @@
+# Public documentation release
+
+- Status: accepted
+- Date: 2022-10-24
+
+## Context
+The [public documentation](https://pcluster.cloud/) is updated every time a new pull request is made. This is not always the desired behavior, especially when an amend is made to the documentation for unreleased ParallelCluster or ParallelCluster Manager features.
+
+## Decision
+Change the documentation workflow's trigger to run only on releases.
+
+## Consequences
+The documentation is updated only when ParallelCluster Mananager is released to customers. The downside is quick fixes to the documentation require more time to be released.


### PR DESCRIPTION
## Description

Changes the trigger of public documentation workflow to deploy updates only when a release is made. This is to avoid inadvertent deployments of documentation regarding unreleased PCM or PC versions.

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
