### PR TITLE
Remove useless experimental flag from NextJS config

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -11,12 +11,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  experimental: {
-    images: {
-      unoptimized: true, // disables next/image for static exports, otherwise the export is going to fail
-                         // it can be enabled when the Next server is used
-    },
-  },
   async rewrites() {
     return [
       /**


### PR DESCRIPTION
## Description

This PR removes unnecessary code from NextJS config file.

Following #336 the experimental flag to disable `next/image` for static exports is not relevant anymore

## Changes

- remove unnecessary experimental flag from `next.config.js`

## How Has This Been Tested?

- by running `npm run export` and checking that there are no errors

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
