### PR TITLE
Disable Slurm Memory Based Scheduling toggle if multiple instance types are selected

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -303,8 +303,7 @@
         },
         "info": {
           "header": "Slurm Memory Based Scheduling can be enabled if only one instance type is selected",
-          "body": "If more than one instance type is selected in any queue, Slurm Memory Based Scheduling is disabled by default.",
-          "dismissAriaLabel": "Close alert"
+          "body": "If more than one instance type is selected in any queue, Slurm Memory Based Scheduling is disabled by default."
         }
       },
       "allocationStrategy": {

--- a/frontend/src/old-pages/Configure/Queues/__tests__/hasMultipleInstanceTypes.test.tsx
+++ b/frontend/src/old-pages/Configure/Queues/__tests__/hasMultipleInstanceTypes.test.tsx
@@ -1,0 +1,107 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Queue} from '../queues.types'
+import {hasMultipleInstanceTypes} from '../SlurmMemorySettings'
+
+describe('Given a function to validate if mutiple instance types have been selected', () => {
+  describe('if at least a resource of a queue has multiple instance types selected', () => {
+    const queues: Queue[] = [
+      {
+        Name: 'queue1',
+        AllocationStrategy: 'capacity-optimized',
+        ComputeResources: [
+          {
+            Name: 'cr1',
+            MaxCount: 4,
+            MinCount: 0,
+            Instances: [
+              {InstanceType: 'c5.small'},
+              {InstanceType: 'c5.xlarge'},
+            ],
+          },
+        ],
+      },
+      {
+        Name: 'queue2',
+        AllocationStrategy: 'capacity-optimized',
+        ComputeResources: [
+          {
+            Name: 'cr2',
+            MaxCount: 2,
+            MinCount: 0,
+            Instances: [{InstanceType: 'c4.small'}],
+          },
+        ],
+      },
+    ]
+    it('should be valid', () => {
+      expect(hasMultipleInstanceTypes(queues)).toBeTruthy()
+    })
+  })
+  describe('if all the resources of every queue have one instance type selected', () => {
+    const queues: Queue[] = [
+      {
+        Name: 'queue1',
+        AllocationStrategy: 'lowest-price',
+        ComputeResources: [
+          {
+            Name: 'cr1',
+            MaxCount: 4,
+            MinCount: 0,
+            Instances: [{InstanceType: 't3.small'}],
+          },
+        ],
+      },
+      {
+        Name: 'queue2',
+        AllocationStrategy: 'lowest-price',
+        ComputeResources: [
+          {
+            Name: 'cr2-a',
+            MaxCount: 2,
+            MinCount: 0,
+            Instances: [{InstanceType: 't3.medium'}],
+          },
+          {
+            Name: 'cr2-b',
+            MaxCount: 3,
+            MinCount: 1,
+            Instances: [{InstanceType: 'c5.medium'}],
+          },
+        ],
+      },
+    ]
+    it('should fail the validation', () => {
+      expect(hasMultipleInstanceTypes(queues)).toBeFalsy()
+    })
+  })
+  describe('if default values are selected', () => {
+    const queues: Queue[] = [
+      {
+        Name: 'queue0',
+        AllocationStrategy: 'capacity-optimized',
+        ComputeResources: [
+          {
+            Name: 'cr0',
+            MaxCount: 4,
+            MinCount: 0,
+            Instances: [{InstanceType: 'c5n.xlarge'}],
+          },
+        ],
+      },
+    ]
+    it('should fail the validation', () => {
+      expect(hasMultipleInstanceTypes(queues)).toBeFalsy()
+    })
+  })
+})

--- a/frontend/src/old-pages/Configure/Queues/queues.types.ts
+++ b/frontend/src/old-pages/Configure/Queues/queues.types.ts
@@ -1,3 +1,9 @@
+export type Queue = {
+  Name: string
+  AllocationStrategy: AllocationStrategy
+  ComputeResources: MultiInstanceComputeResource[]
+}
+
 export type QueueValidationErrors = Record<
   number,
   'instance_type_unique' | 'instance_types_empty'


### PR DESCRIPTION
## Description

With ParallelCluster 3.3.0, multiple instance types per compute resource can be selected. 

If a user selects more than one instance type (in at least one compute resource, and in any queue) we need to ensure that Slurm Memory Based Scheduling cannot be enabled.

## Changes
* Disable Slurm Memory Based Scheduling toggle if multiple instance types are selected

## How Has This Been Tested?

* Unit tests
* Verified with 3.3.0 that if multiple instance types are selected, slurm memory based scheduling toggle is disabled and an alert is shown
* Verified with 3.2.0 that alert is never displayed and slurm memory based scheduling can be checked/unchecked

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [x] I added tests to new or existing code
- [x] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
