### PR TITLE
Fix sidebar activeHref not being set on full page reload

### DIFF
--- a/frontend/src/components/SideBar.tsx
+++ b/frontend/src/components/SideBar.tsx
@@ -13,16 +13,14 @@ import * as React from 'react'
 import {useTranslation} from 'react-i18next'
 import {useLocation, useNavigate} from 'react-router-dom'
 import {USER_ROLES_CLAIM} from '../auth/constants'
-import {isAdmin, isGuest, isUser, useState} from '../store'
+import {isAdmin, isUser, useState} from '../store'
 
 export default function SideBar() {
   const {t} = useTranslation()
   const navigate = useNavigate()
   const location = useLocation()
-  const defaultPage = isGuest() ? '/home' : '/clusters'
-  const currentHref = '/' + location.pathname.split('/')?.[1]
 
-  const [activeHref, setActiveHref] = React.useState(currentHref || defaultPage)
+  const activeHref = '/' + location.pathname.split('/')?.[1]
   const identity = useState(['identity', USER_ROLES_CLAIM])
 
   const header = React.useMemo(
@@ -73,7 +71,6 @@ export default function SideBar() {
     event => {
       if (!event.detail.external) {
         event.preventDefault()
-        setActiveHref(event.detail.href)
         navigate(event.detail.href)
       }
     },


### PR DESCRIPTION
## Description

This PR fixes the following scenario:

- full page reload of the `/` page
- sidebar active item not being highlighted

## Changes

- derive `activeHref` from the pathname at every location change

## How Has This Been Tested?

- full page reload
- navigation through all sections
- full page reload of deep nested path (`/clusters/{clustername}`)

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
