### PR TITLE
Fix "Disable Rollback button not working"

### DIFF
--- a/frontend/src/__tests__/CreateCluster.test.ts
+++ b/frontend/src/__tests__/CreateCluster.test.ts
@@ -85,7 +85,7 @@ describe('given a CreateCluster command and a cluster configuration', () => {
     describe('when stack rollback on failure is disabled', () => {
       const mockDisableRollback = true
 
-      it('should add set the disableRollback query parameter', async () => {
+      it('should add set the rollbackOnFailure query parameter', async () => {
         await CreateCluster(
           clusterName,
           clusterConfiguration,
@@ -95,7 +95,7 @@ describe('given a CreateCluster command and a cluster configuration', () => {
         )
         expect(mockPost).toHaveBeenCalledTimes(1)
         expect(mockPost).toHaveBeenCalledWith(
-          'api?path=/v3/clusters&disableRollback=true&region=some-region',
+          'api?path=/v3/clusters&rollbackOnFailure=false&region=some-region',
           expect.any(Object),
           expect.any(Object),
         )

--- a/frontend/src/__tests__/CreateCluster.test.ts
+++ b/frontend/src/__tests__/CreateCluster.test.ts
@@ -1,0 +1,139 @@
+import {CreateCluster} from '../model'
+
+const mockPost = jest.fn()
+
+jest.mock('axios', () => ({
+  create: () => ({
+    post: (...args: unknown[]) => mockPost(...args),
+  }),
+}))
+
+describe('given a CreateCluster command and a cluster configuration', () => {
+  const clusterName = 'any-name'
+  const clusterConfiguration = {}
+  const mockRegion = 'some-region'
+  const mockSelectedRegion = 'some-region'
+
+  describe('when the cluster can be created successfully', () => {
+    beforeEach(() => {
+      jest.clearAllMocks()
+      const mockResponse = {
+        status: 202,
+        data: {
+          some: 'data',
+        },
+      }
+      mockPost.mockResolvedValueOnce(mockResponse)
+    })
+
+    it('should emit the API request', async () => {
+      const expectedBody = {
+        clusterConfiguration,
+        clusterName,
+      }
+
+      await CreateCluster(
+        clusterName,
+        clusterConfiguration,
+        mockRegion,
+        mockSelectedRegion,
+      )
+      expect(mockPost).toHaveBeenCalledTimes(1)
+      expect(mockPost).toHaveBeenCalledWith(
+        'api?path=/v3/clusters&region=some-region',
+        expectedBody,
+        expect.any(Object),
+      )
+    })
+
+    it('should call the success callback', async () => {
+      const mockSuccessCallback = jest.fn()
+      await CreateCluster(
+        clusterName,
+        clusterConfiguration,
+        mockRegion,
+        mockSelectedRegion,
+        false,
+        false,
+        mockSuccessCallback,
+      )
+      expect(mockSuccessCallback).toHaveBeenCalledTimes(1)
+      expect(mockSuccessCallback).toHaveBeenCalledWith({some: 'data'})
+    })
+
+    describe('when a dryrun is requested', () => {
+      const mockDryRun = true
+
+      it('should add set the dryrun query parameter', async () => {
+        await CreateCluster(
+          clusterName,
+          clusterConfiguration,
+          mockRegion,
+          mockSelectedRegion,
+          false,
+          mockDryRun,
+        )
+        expect(mockPost).toHaveBeenCalledTimes(1)
+        expect(mockPost).toHaveBeenCalledWith(
+          'api?path=/v3/clusters&dryrun=true&region=some-region',
+          expect.any(Object),
+          expect.any(Object),
+        )
+      })
+    })
+
+    describe('when stack rollback on failure is disabled', () => {
+      const mockDisableRollback = true
+
+      it('should add set the disableRollback query parameter', async () => {
+        await CreateCluster(
+          clusterName,
+          clusterConfiguration,
+          mockRegion,
+          mockSelectedRegion,
+          mockDisableRollback,
+        )
+        expect(mockPost).toHaveBeenCalledTimes(1)
+        expect(mockPost).toHaveBeenCalledWith(
+          'api?path=/v3/clusters&disableRollback=true&region=some-region',
+          expect.any(Object),
+          expect.any(Object),
+        )
+      })
+    })
+  })
+
+  describe('when the cluster creation fails', () => {
+    let mockError: any
+
+    beforeEach(() => {
+      mockError = {
+        response: {
+          data: {
+            message: 'some-error-message',
+          },
+        },
+      }
+      mockPost.mockRejectedValueOnce(mockError)
+    })
+
+    it('should call the error callback', async () => {
+      const mockErrorCallback = jest.fn()
+      await CreateCluster(
+        clusterName,
+        clusterConfiguration,
+        mockRegion,
+        mockSelectedRegion,
+        false,
+        false,
+        undefined,
+        mockErrorCallback,
+      )
+      await Promise.resolve()
+      expect(mockErrorCallback).toHaveBeenCalledTimes(1)
+      expect(mockErrorCallback).toHaveBeenCalledWith({
+        message: 'some-error-message',
+      })
+    })
+  })
+})

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -105,7 +105,7 @@ function CreateCluster(
 ) {
   var url = 'api?path=/v3/clusters'
   url += dryrun ? '&dryrun=true' : ''
-  url += disableRollback ? '&disableRollback=true' : ''
+  url += disableRollback ? '&rollbackOnFailure=false' : ''
   url += region ? `&region=${region}` : ''
   var body = {clusterName: clusterName, clusterConfiguration: clusterConfig}
   request('post', url, body)

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -97,12 +97,12 @@ function CreateCluster(
   clusterName: any,
   clusterConfig: any,
   region: string,
+  selectedRegion: string,
   disableRollback = false,
   dryrun = false,
   successCallback?: Callback,
   errorCallback?: Callback,
 ) {
-  const selectedRegion = getState(['app', 'selectedRegion'])
   var url = 'api?path=/v3/clusters'
   url += dryrun ? '&dryrun=true' : ''
   url += disableRollback ? '&disableRollback=true' : ''

--- a/frontend/src/old-pages/Configure/Create.tsx
+++ b/frontend/src/old-pages/Configure/Create.tsx
@@ -49,6 +49,7 @@ function handleCreate(handleClose: any, navigate: any) {
   const clusterConfig = getState(configPath) || ''
   const dryRun = false
   const region = getState(['app', 'wizard', 'config', 'Region'])
+  const selectedRegion = getState(['app', 'selectedRegion'])
   var errHandler = (err: any) => {
     setState(['app', 'wizard', 'errors', 'create'], err)
     setState(['app', 'wizard', 'pending'], false)
@@ -82,6 +83,7 @@ function handleCreate(handleClose: any, navigate: any) {
       clusterName,
       clusterConfig,
       region,
+      selectedRegion,
       disableRollback,
       dryRun,
       successHandler,
@@ -96,6 +98,7 @@ function handleDryRun() {
   const forceUpdate = getState(['app', 'wizard', 'forceUpdate'])
   const clusterConfig = getState(configPath) || ''
   const region = getState(['app', 'wizard', 'config', 'Region'])
+  const selectedRegion = getState(['app', 'selectedRegion'])
   const disableRollback = false
   const dryRun = true
   var errHandler = (err: any) => {
@@ -122,6 +125,7 @@ function handleDryRun() {
       clusterName,
       clusterConfig,
       region,
+      selectedRegion,
       disableRollback,
       dryRun,
       successHandler,


### PR DESCRIPTION
## Description

This PR fixes the Disable Rollback feature not actually disabling the stack rollback on failure

## Changes

- add spec for the `CreateCluster` command
- use correct `rollbackOnFailure` query parameter as [documented](https://github.com/aws/aws-parallelcluster/blob/develop/api/spec/openapi/ParallelCluster.openapi.yaml#L115)

## Changelog entry

Fix Disable Rollback toggle not actually disabling the stack rollback on failure

## How Has This Been Tested?

- unit tests
- creating a cluster and checking with `aws cloudformation describe-stacks --stack-name myteststack` that `DisableRollback` is set to `True`

## References

- [Stack failure options](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stack-failure-options.html)
- [PC API documentation](https://github.com/aws/aws-parallelcluster/blob/develop/api/spec/openapi/ParallelCluster.openapi.yaml#L115)

Closes #270 

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
