### PR TITLE
Pin Flask version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Flask-RESTful==0.3.9
 Flask-Cors==3.0.10
+Flask==2.1.2
 boto3==1.24.30
 requests==2.28.1
 python-jose==3.3.0


### PR DESCRIPTION
## Description

This PR pins Flask version to 2.1.2, instead of letting the dependent packages (such as Flask-REST) to install the most current version of Flask

## Changes

- add `Flask` 2.1.2 to `requirements.txt`

## How Has This Been Tested?

- Starting from an environment with Flask 2.2.2: 
    - removed every Python dependency, and reinstalled
    - checked with [`pipdeptree`](https://pypi.org/project/pipdeptree/) the actual installed version is 2.1.2

Command output

```
Flask-Cors==3.0.10
  - Flask [required: >=0.9, installed: 2.1.2]
    ....
Flask-RESTful==0.3.9
    ...
  - Flask [required: >=0.8, installed: 2.1.2]
    ....
```

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
