### PR TITLE
Fix per unit storage throughput

### DIFF
--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -107,6 +107,16 @@ function storageValidate() {
   return valid
 }
 
+const LUSTRE_PERSISTENT1_DEFAULT_THROUGHPUT = 200
+const LUSTRE_PERSISTENT2_DEFAULT_THROUGHPUT = 125
+const storageThroughputsP1 = [50, 100, LUSTRE_PERSISTENT1_DEFAULT_THROUGHPUT]
+const storageThroughputsP2 = [
+  LUSTRE_PERSISTENT2_DEFAULT_THROUGHPUT,
+  250,
+  500,
+  1000,
+]
+
 function FsxLustreSettings({index}: any) {
   const {t} = useTranslation()
   const isLustrePersistent2Active = useFeatureFlag('lustre_persistent2')
@@ -124,8 +134,6 @@ function FsxLustreSettings({index}: any) {
     'SCRATCH_2',
   ].filter(Boolean)
   const storageThroughputPath = [...fsxPath, 'PerUnitStorageThroughput']
-  const storageThroughputsP1 = [50, 100, 200]
-  const storageThroughputsP2 = [125, 250, 500, 1000]
   const importPathPath = [...fsxPath, 'ImportPath']
   const exportPathPath = [...fsxPath, 'ExportPath']
   const compressionPath = [...fsxPath, 'DataCompressionType']
@@ -233,11 +241,12 @@ function FsxLustreSettings({index}: any) {
             selectedOption={strToOption(lustreType || 'PERSISTENT_1')}
             onChange={({detail}) => {
               setState(lustreTypePath, detail.selectedOption.value)
-              if (detail.selectedOption.value === 'PERSISTENT_1') {
-                setState(storageThroughputPath, 200)
-              } else {
-                clearState(storageThroughputPath)
-              }
+              setState(
+                storageThroughputPath,
+                detail.selectedOption.value === 'PERSISTENT_1'
+                  ? LUSTRE_PERSISTENT1_DEFAULT_THROUGHPUT
+                  : LUSTRE_PERSISTENT2_DEFAULT_THROUGHPUT,
+              )
             }}
             options={lustreTypes.map(strToOption)}
           />

--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -117,7 +117,7 @@ const storageThroughputsP2 = [
   1000,
 ]
 
-function FsxLustreSettings({index}: any) {
+export function FsxLustreSettings({index}: any) {
   const {t} = useTranslation()
   const isLustrePersistent2Active = useFeatureFlag('lustre_persistent2')
   const useExisting =
@@ -342,7 +342,7 @@ function FsxLustreSettings({index}: any) {
         >
           <FormField label={t('wizard.storage.Fsx.throughput.label')}>
             <Select
-              selectedOption={strToOption(storageThroughput)}
+              selectedOption={strToOption(storageThroughput || '')}
               onChange={({detail}) => {
                 setState(storageThroughputPath, detail.selectedOption.value)
               }}

--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -153,6 +153,14 @@ function FsxLustreSettings({index}: any) {
     const lustreTypePath = [...fsxPath, 'DeploymentType']
     if (storageCapacity === null && !useExisting)
       setState(storageCapacityPath, 1200)
+    if (!storageThroughput && !useExisting) {
+      setState(
+        storageThroughputPath,
+        lustreType === 'PERSISTENT_1'
+          ? LUSTRE_PERSISTENT1_DEFAULT_THROUGHPUT
+          : LUSTRE_PERSISTENT2_DEFAULT_THROUGHPUT,
+      )
+    }
     if (lustreType === null && !useExisting)
       setState(
         lustreTypePath,
@@ -160,6 +168,7 @@ function FsxLustreSettings({index}: any) {
       )
   }, [
     storageCapacity,
+    storageThroughputPath,
     lustreType,
     storageThroughput,
     index,

--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -342,7 +342,7 @@ function FsxLustreSettings({index}: any) {
         >
           <FormField label={t('wizard.storage.Fsx.throughput.label')}>
             <Select
-              selectedOption={strToOption(storageThroughput || 125)}
+              selectedOption={strToOption(storageThroughput)}
               onChange={({detail}) => {
                 setState(storageThroughputPath, detail.selectedOption.value)
               }}

--- a/frontend/src/old-pages/Configure/storage.test.tsx
+++ b/frontend/src/old-pages/Configure/storage.test.tsx
@@ -1,0 +1,176 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {render} from '@testing-library/react'
+import {I18nextProvider} from 'react-i18next'
+import i18n from 'i18next'
+import {initReactI18next} from 'react-i18next'
+import mock from 'jest-mock-extended/lib/Mock'
+import {Store} from '@reduxjs/toolkit'
+import {Provider} from 'react-redux'
+jest.mock('../../store', () => {
+  const originalModule = jest.requireActual('../../store')
+
+  return {
+    __esModule: true, // Use it when dealing with esModules
+    ...originalModule,
+    setState: jest.fn(),
+  }
+})
+
+jest.mock('../../feature-flags/useFeatureFlag', () => ({
+  useFeatureFlag: () => true,
+}))
+import {setState} from '../../store'
+import {FsxLustreSettings} from './Storage'
+
+i18n.use(initReactI18next).init({
+  resources: {},
+  lng: 'en',
+})
+
+const mockStore = mock<Store>()
+const MockProviders = (props: any) => (
+  <Provider store={mockStore}>
+    <I18nextProvider i18n={i18n}>{props.children}</I18nextProvider>
+  </Provider>
+)
+
+describe('Given a Lustre storage component', () => {
+  beforeEach(() => {
+    ;(setState as jest.Mock).mockClear()
+  })
+  describe("when it's initialized", () => {
+    describe('with a Persistent_1 type', () => {
+      beforeEach(() => {
+        mockStore.getState.mockReturnValue({
+          app: {
+            wizard: {
+              config: {
+                SharedStorage: [
+                  {
+                    FsxLustreSettings: {
+                      DeploymentType: 'PERSISTENT_1',
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        })
+      })
+      it('should set the correct PerUnitStorageThroughPut value in the config', () => {
+        render(
+          <MockProviders>
+            <FsxLustreSettings index={0} />
+          </MockProviders>,
+        )
+        expect(setState).toHaveBeenCalledWith(
+          [
+            'app',
+            'wizard',
+            'config',
+            'SharedStorage',
+            0,
+            'FsxLustreSettings',
+            'PerUnitStorageThroughput',
+          ],
+          200,
+        )
+      })
+    })
+    describe('with a Persistent_2 type', () => {
+      beforeEach(() => {
+        mockStore.getState.mockReturnValue({
+          app: {
+            wizard: {
+              config: {
+                SharedStorage: [
+                  {
+                    FsxLustreSettings: {
+                      DeploymentType: 'PERSISTENT_2',
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        })
+      })
+      it('should set the correct PerUnitStorageThroughPut value in the config', () => {
+        render(
+          <MockProviders>
+            <FsxLustreSettings index={0} />
+          </MockProviders>,
+        )
+        expect(setState).toHaveBeenCalledWith(
+          [
+            'app',
+            'wizard',
+            'config',
+            'SharedStorage',
+            0,
+            'FsxLustreSettings',
+            'PerUnitStorageThroughput',
+          ],
+          125,
+        )
+      })
+    })
+
+    describe('when the user wants to link an already created Lustre', () => {
+      beforeEach(() => {
+        mockStore.getState.mockReturnValue({
+          app: {
+            wizard: {
+              storage: {
+                ui: [
+                  {
+                    useExisting: true,
+                  },
+                ],
+              },
+              config: {
+                SharedStorage: [
+                  {
+                    FsxLustreSettings: {
+                      DeploymentType: 'PERSISTENT_2',
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        })
+      })
+
+      it('should not set the PerUnitStorageThroughPut in the config', () => {
+        render(
+          <MockProviders>
+            <FsxLustreSettings index={0} />
+          </MockProviders>,
+        )
+        expect(setState).not.toHaveBeenCalledWith(
+          [
+            'app',
+            'wizard',
+            'config',
+            'SharedStorage',
+            0,
+            'FsxLustreSettings',
+            'PerUnitStorageThroughput',
+          ],
+          expect.any(Number),
+        )
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Description

Fixes the `PerUnitStorageThroughput` on Lustre FSx not being added to the final cluster configuration, starting from an empty template.
Closes https://github.com/aws-samples/pcluster-manager/issues/274.

## Changes

- put `PerUnitStorageThroughput` in the configuration when a FSx Lustre is created
- extracted `PerUnitStorageThroughput` default values into their own constants

## Changelog entry

- Fixes `PerUnitStorageThroughput` on Lustre FSx not being added to the final cluster configuration

## How Has This Been Tested?

- Started a new wizard, adding a FSx Lustre filesystem: the `PerUnitStorageThroughput` parameter is added to the configuration
- When changing the value of `PerUnitStorageThroughput` it is reflected in the configuration


## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
