### PR TITLE
Disable cluster edit button in case ParallelCluster API full version does not match cluster full version

### DIFF
--- a/frontend/src/old-pages/Clusters/Actions.tsx
+++ b/frontend/src/old-pages/Clusters/Actions.tsx
@@ -61,6 +61,9 @@ export default function Actions() {
   let navigate = useNavigate()
   const {t} = useTranslation()
 
+  const apiVersion = useState(['app', 'version', 'full'])
+  const clusterVersion = useState([...clusterPath, 'version'])
+
   const fleetStatus = useState([...clusterPath, 'computeFleetStatus'])
   const clusterStatus = useState([...clusterPath, 'clusterStatus'])
   const dcvEnabled = useState([
@@ -153,6 +156,7 @@ export default function Actions() {
             clusterStatus === ClusterStatus.CreateInProgress ||
             clusterStatus === ClusterStatus.DeleteInProgress ||
             clusterStatus === ClusterStatus.CreateFailed ||
+            clusterVersion !== apiVersion ||
             !isAdmin()
           }
           variant="normal"


### PR DESCRIPTION
## Description

ParallelCluster does not allow updating a cluster when the version of PC used to create such cluster does not match the version of PC in use. 

On ParallelCluster Manager side, allowing to do so, has the following consequences:
* the editing user flow will potentially break client-side
* the PC backend will return an error anyway, when submitting the update at the end of the wizard

## Changelog entry
* Disabled cluster edit button in case ParallelCluster API full version does not match cluster full version

## How Has This Been Tested?
* Locally exported `API_VERSION` env variable to `3.3.0`
   * Verified that, when selected, clusters with version `3.3.0` have *Edit* button enabled
   * Verified that, when selected, clusters with version different from `3.3.0` have *Edit* button disabled
   
   <!-- The tests you ran to verify your changes -->


## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
