### PR TITLE
Add GitHub release config for changelog automation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,6 +7,7 @@ changelog:
       - invalid
       - question
       - wontfix
+      - release-exclude
   categories:
     - title: Features 🎉
       labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,16 @@
+
+changelog:
+  exclude:
+    labels:
+      - DON'T MERGE
+      - duplicate
+      - invalid
+      - question
+      - wontfix
+  categories:
+    - title: Features 🎉
+      labels:
+        - release-include
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
## Description
Add `release.yml` to the `.github` folder to allow the [automatic generation](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) of the release changelog when performing a new release from the GitHub UI.
<!-- Summary of what this PR introduces and possibly why -->
This config only considers two sections, using the `release-include` label for the "Features" section and a "Other Changes" section for all the other labels, excluding the following:
- DON'T MERGE
- duplicate
- invalid
- question
- wontfix

## How Has This Been Tested?
This first minimal version should be tested during our next release.
<!-- The tests you ran to verify your changes -->

## References
- [GitHub doc](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
