### PR TITLE
Filter out clusters in configuration source 'From Cluster' dropdown in case they do not match up to the minor version of PC

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -92,7 +92,8 @@
         },
         "cluster": {
           "label": "From Cluster",
-          "description": "Use an existing cluster as a starting point for the configuration of your new cluster."
+          "description": "Use an existing cluster as a starting point for the configuration of your new cluster. Only clusters whose version matches the version of Pcluster Manager can be selected.",
+          "empty": "No cluster available"
         },
         "file": {
           "label": "Upload a file",

--- a/frontend/src/old-pages/Configure/Source.tsx
+++ b/frontend/src/old-pages/Configure/Source.tsx
@@ -128,9 +128,17 @@ function sourceValidate(suppressUpload = false) {
   return valid
 }
 
+function checkMinorVersion(v1: string, v2: string) {
+  return v1.split('.', 2).join('.') === v2.split('.', 2).join('.')
+}
+
 function ClusterSelect() {
   const selectedPath = ['app', 'wizard', 'source', 'selectedCluster']
+  const apiVersion = useState(['app', 'version', 'full'])
   const clusters = useState(['clusters', 'list']) || []
+  const filteredClusters = clusters.filter((cluster: ClusterInfoSummary) =>
+    checkMinorVersion(cluster.version, apiVersion),
+  )
   const selected = useState(selectedPath)
   const errors = useState([...sourceErrorsPath, 'sourceClusterName'])
   let source = useState([...sourcePath, 'type'])
@@ -139,7 +147,7 @@ function ClusterSelect() {
   const itemToOption = (item: ClusterInfoSummary) => {
     if (item && item.clusterStatus != ClusterStatus.DeleteInProgress)
       return {label: item.clusterName, value: item.clusterName}
-    else return {label: i18next.t('wizard.source.clusterSelect.placeholder')}
+    else return null
   }
 
   return (
@@ -147,7 +155,7 @@ function ClusterSelect() {
       <Select
         disabled={source !== 'cluster'}
         selectedOption={itemToOption(
-          findFirst(clusters, (x: any) => {
+          findFirst(filteredClusters, (x: any) => {
             return x.clusterName === selected
           }),
         )}
@@ -155,8 +163,10 @@ function ClusterSelect() {
           setState(selectedPath, detail.selectedOption.value)
           validated && sourceValidate(true)
         }}
+        placeholder={i18next.t('wizard.source.clusterSelect.placeholder')}
         selectedAriaLabel="Selected"
-        options={clusters.map(itemToOption)}
+        options={filteredClusters.map(itemToOption)}
+        empty={i18next.t('wizard.source.sourceOptions.cluster.empty')}
       />
     </FormField>
   )


### PR DESCRIPTION
## Description

Currently it is possible to choose as a template a previously created cluster from the wizard to use for a new cluster the user wants to create.

ParallelCluster doesn't allow cluster creation with configuration versions different from the PC version in use. So using a configuration from a previously created cluster (with a cluster config version from a different PC version) would raise an error on the PC side.

This PR aims to solve this issue, by filtering out clusters in the 'From Cluster' dropdown in case they do not match the exact version of PC.

## How Has This Been Tested?

* Exported locally `API_VERSION` env variable
   * Verified that clusters with the same version are displayed in the dropdown
   * Verified that clusters with a different version are not displayed in the dropdown

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
