### PR TITLE
Fix a bug crashing the wizard when there's a cluster in deletion

### DIFF
--- a/frontend/src/old-pages/Configure/Source.tsx
+++ b/frontend/src/old-pages/Configure/Source.tsx
@@ -136,36 +136,45 @@ function ClusterSelect() {
   const selectedPath = ['app', 'wizard', 'source', 'selectedCluster']
   const apiVersion = useState(['app', 'version', 'full'])
   const clusters = useState(['clusters', 'list']) || []
-  const filteredClusters = clusters.filter((cluster: ClusterInfoSummary) =>
-    checkMinorVersion(cluster.version, apiVersion),
-  )
+  const selectableClusters = clusters
+    .filter(
+      (cluster: ClusterInfoSummary) =>
+        cluster.clusterStatus != ClusterStatus.DeleteInProgress,
+    )
+    .filter((cluster: ClusterInfoSummary) =>
+      checkMinorVersion(cluster.version, apiVersion),
+    )
+
   const selected = useState(selectedPath)
   const errors = useState([...sourceErrorsPath, 'sourceClusterName'])
   let source = useState([...sourcePath, 'type'])
   let validated = useState([...sourceErrorsPath, 'validated'])
 
-  const itemToOption = (item: ClusterInfoSummary) => {
-    if (item && item.clusterStatus != ClusterStatus.DeleteInProgress)
-      return {label: item.clusterName, value: item.clusterName}
-    else return null
-  }
+  const itemToOption = (item: ClusterInfoSummary) => ({
+    label: item.clusterName,
+    value: item.clusterName,
+  })
 
   return (
     <FormField errorText={errors}>
       <Select
         disabled={source !== 'cluster'}
-        selectedOption={itemToOption(
-          findFirst(filteredClusters, (x: any) => {
-            return x.clusterName === selected
-          }),
-        )}
+        selectedOption={
+          selected
+            ? itemToOption(
+                findFirst(selectableClusters, (x: any) => {
+                  return x.clusterName === selected
+                }),
+              )
+            : null
+        }
         onChange={({detail}) => {
           setState(selectedPath, detail.selectedOption.value)
           validated && sourceValidate(true)
         }}
         placeholder={i18next.t('wizard.source.clusterSelect.placeholder')}
         selectedAriaLabel="Selected"
-        options={filteredClusters.map(itemToOption)}
+        options={selectableClusters.map(itemToOption)}
         empty={i18next.t('wizard.source.sourceOptions.cluster.empty')}
       />
     </FormField>


### PR DESCRIPTION
## Description

After the latest changes there's a bug preventing the user from filling the wizard if a cluster is currently being deleted.

## Changes

Filter out all clusters in deletion from the cluster import options

## How Has This Been Tested?

- Start a wizard when a cluster is not being deleted, everything works correctly
- Start a wizard when a cluster is being delete: the product is not crashing and the cluster is not listed in the select

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
