### PR TITLE
Match tags when authenticating to AWS in a release

### DIFF
--- a/infrastructure/github-env-setup-prod.yml
+++ b/infrastructure/github-env-setup-prod.yml
@@ -18,9 +18,9 @@ Resources:
             Principal:
               Federated: !Ref GithubOidc
             Condition:
-              StringEquals:
+              StringLike:
                 token.actions.githubusercontent.com:aud: sts.amazonaws.com
-                token.actions.githubusercontent.com:sub: !Sub repo:${GitHubOrg}/${RepositoryName}:ref:refs/heads/main
+                token.actions.githubusercontent.com:sub: !Sub repo:${GitHubOrg}/${RepositoryName}:ref:refs/tags/*
       Policies:
         - PolicyName: PushPublicECR
           PolicyDocument:


### PR DESCRIPTION
## Description

When releasing ParallelCluster Manager to customers a new tag is created.
Previously, to authenticate with AWS there was a strong check with the source branch: in the release case there's no branch and this was failing.

## Changes

- authenticate the release role only if coming from a tag

## How Has This Been Tested?

https://github.com/aws-samples/pcluster-manager/actions/runs/3427737937

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
