### PR TITLE
Fix Logs and Stack Events not being searchable

### DIFF
--- a/frontend/src/old-pages/Clusters/Logs.tsx
+++ b/frontend/src/old-pages/Clusters/Logs.tsx
@@ -100,7 +100,8 @@ function LogEventsTable() {
     filterProps.onChange({
       detail: {filteringText: searchParams.get('filter') || ''},
     })
-  }, [filterProps, searchParams])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams])
 
   return (
     <div>

--- a/frontend/src/old-pages/Clusters/StackEvents.tsx
+++ b/frontend/src/old-pages/Clusters/StackEvents.tsx
@@ -188,7 +188,8 @@ export default function ClusterStackEvents() {
     filterProps.onChange({
       detail: {filteringText: searchParams.get('filter') || ''},
     })
-  }, [filterProps, searchParams])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams])
 
   return events ? (
     <Table


### PR DESCRIPTION
## Description

Cluster logs are not searchable anymore following the release of 3.3.0 (see #356).
The problem started after linting the codebase, which changed the dependencies of the search hook of the component. 
Fixes #356.

## Changes

- removed the problematic dependency from search hook

## How Has This Been Tested?

Manually searched logs in the Logs and Stack Events tabs

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
