### PR TITLE
Update CF parameters used in demo infra + fix typo

### DIFF
--- a/infrastructure/environments/demo-cfn.yaml
+++ b/infrastructure/environments/demo-cfn.yaml
@@ -6,6 +6,8 @@ Parameters:
     ParameterValue: https://pcluster-manager-github-infrastructurebucket-7y5h202iem8l.s3.eu-west-1.amazonaws.com
   - ParameterKey: AdminUserEmail
     UsePreviousValue: true
+  - ParameterKey: PublicEcrImageUri
+    ParameterValue: public.ecr.aws/pcm/pcluster-manager-awslambda:latest
 Capabilities:
   - CAPABILITY_AUTO_EXPAND
   - CAPABILITY_NAMED_IAM

--- a/infrastructure/update-environment-infra.sh
+++ b/infrastructure/update-environment-infra.sh
@@ -15,8 +15,8 @@
 # and a CloudFormation request file where the stack update can be customized,
 # for example by changing the parameters provided to the previous version of the stack
 #
-# Usage: ./infrastructure/update-infrastructure.sh [ENVIRONMENT]
-# Example: ./infrastructure/update-infrastructure.sh demo
+# Usage: ./infrastructure/update-environment-infra.sh [ENVIRONMENT]
+# Example: ./infrastructure/update-environment-infra.sh demo
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 FILES=(SSMSessionProfile-cfn.yaml pcluster-manager-cognito.yaml pcluster-manager.yaml)


### PR DESCRIPTION
## Description
This PR solves an issue where our demo env would file updating the infrastructure because of the new tagging strategy in our docker images.
<!-- Summary of what this PR introduces and possibly why -->

## Changes
- added `PublicEcrImageUri` to point to the latest image available in the repo
- fixed a typo in `update-infrastructure-infra.sh` in comments
<!-- List of relevant changes introduced -->

<!-- A sentence to be added to the next release's changelog that captures the changes in this PR -->

## How Has This Been Tested?
Manually
<!-- The tests you ran to verify your changes -->


In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
