### PR TITLE
Added public endpoint to push log entry to from the frontend

### DIFF
--- a/api/exception/__init__.py
+++ b/api/exception/__init__.py
@@ -2,7 +2,8 @@ from boto3.exceptions import Boto3Error
 from botocore.exceptions import ClientError
 from werkzeug.routing import WebsocketMismatch
 
-from .handlers import global_exception_handler, boto3_exception_handler, websocket_mismatch_nop_handler
+from .handlers import global_exception_handler, boto3_exception_handler, websocket_mismatch_nop_handler, \
+    value_error_handler
 
 
 class ExceptionHandler(object):
@@ -16,6 +17,7 @@ class ExceptionHandler(object):
         app.register_error_handler(Boto3Error, boto3_exception_handler)
         app.register_error_handler(ClientError, boto3_exception_handler)
 
+        app.register_error_handler(ValueError, value_error_handler)
         app.register_error_handler(Exception, global_exception_handler)
 
         # in local dev, handle specific Exception caused by HMR requests from FE

--- a/api/exception/handlers.py
+++ b/api/exception/handlers.py
@@ -15,6 +15,11 @@ def websocket_mismatch_nop_handler(err):
     """ Handles websocket error caused by HMR in local development"""
     return {}, 200
 
+def value_error_handler(err):
+    descr, code = str(err), 400
+    logger.error(descr, extra=dict(status=code, exception=type(err)))
+    return __handler_response(code, descr)
+
 def global_exception_handler(err):
     try:
         code = err.code
@@ -23,5 +28,9 @@ def global_exception_handler(err):
     descr = str(err)
 
     logger.error(descr, extra=dict(status=code, exception=type(err)))
-    response = {'Code': code, 'Message': 'Something went wrong'}
+    return __handler_response(code)
+
+
+def __handler_response(code, description='Something went wrong'):
+    response = {'Code': code, 'Message': description}
     return jsonify(error=response), code

--- a/api/tests/test_exception_handlers.py
+++ b/api/tests/test_exception_handlers.py
@@ -19,6 +19,15 @@ def test_boto3_exception_handler(client, client_error_response, app, monkeypatch
     assert response.status_code == 400
     assert response.json == {'error': {'Code': 400, 'Message': 'Operation failed'}}
 
+def test_value_error_exception_handler(client, app, monkeypatch):
+    def push_log_raising():
+        raise ValueError('Validation error')
+
+    monkeypatch.setitem(app.view_functions, 'push_log', push_log_raising)
+    response = client.post('/push-log')
+
+    assert response.status_code == 400
+    assert response.json == {'error': {'Code': 400, 'Message': 'Validation error'}}
 
 def test_global_exception_handler_with_app_logic(client, app, monkeypatch):
     def get_app_config_raising_generic_exception():

--- a/api/tests/test_exception_handlers.py
+++ b/api/tests/test_exception_handlers.py
@@ -24,7 +24,7 @@ def test_value_error_exception_handler(client, app, monkeypatch):
         raise ValueError('Validation error')
 
     monkeypatch.setitem(app.view_functions, 'push_log', push_log_raising)
-    response = client.post('/push-log')
+    response = client.post('/logs')
 
     assert response.status_code == 400
     assert response.json == {'error': {'Code': 400, 'Message': 'Validation error'}}

--- a/api/tests/test_push_log.py
+++ b/api/tests/test_push_log.py
@@ -34,7 +34,7 @@ def test_push_log_controller_with_invalid_message_key(client):
     assert response.json == {
         'error': {
             'Code': 400,
-            'Message': 'Request body missing on or more mandatory fields ["message", "level"]'
+            'Message': 'Request body missing one or more mandatory fields ["message", "level"]'
         }
     }
 
@@ -48,7 +48,7 @@ def test_push_log_controller_with_invalid_level_key(client):
     assert response.json == {
         'error': {
             'Code': 400,
-            'Message': 'Request body missing on or more mandatory fields ["message", "level"]'
+            'Message': 'Request body missing one or more mandatory fields ["message", "level"]'
         }
     }
 

--- a/api/tests/test_push_log.py
+++ b/api/tests/test_push_log.py
@@ -1,4 +1,7 @@
 
+def trim_log(caplog):
+    return caplog.text.replace('\n', '')
+
 def test_push_log_controller_with_valid_json_no_extra(client, caplog):
     request_body = {'message': 'sample-message', 'level': 'info'}
     expected_log = "INFO     pcluster-manager:logger.py:24 {'message': 'sample-message'}"
@@ -7,7 +10,7 @@ def test_push_log_controller_with_valid_json_no_extra(client, caplog):
     response = client.post('/push-log', json=request_body)
 
     assert response.status_code == 200
-    assert caplog.text == expected_log
+    assert trim_log(caplog) == expected_log
 
 
 def test_push_log_controller_with_valid_json_with_extra(client, caplog):
@@ -19,7 +22,7 @@ def test_push_log_controller_with_valid_json_with_extra(client, caplog):
     response = client.post('/push-log', json=request_body)
 
     assert response.status_code == 200
-    assert caplog.text.replace('\n', '') == expected_log
+    assert trim_log(caplog) == expected_log
 
 
 def test_push_log_controller_with_invalid_message_key(client):
@@ -45,7 +48,7 @@ def test_push_log_controller_with_invalid_level_key(client):
     assert response.json == {
         'error': {
             'Code': 400,
-            'Message': 'request body missing on or more mandatory fields ["message", "level"]'
+            'Message': 'Request body missing on or more mandatory fields ["message", "level"]'
         }
     }
 
@@ -59,7 +62,7 @@ def test_push_log_controller_with_invalid_level_value(client):
     assert response.json == {
         'error': {
             'Code': 400,
-            'Message': 'request body missing on or more mandatory fields ["message", "level"]'
+            'Message': 'Invalid logging level requested'
         }
     }
 
@@ -73,6 +76,6 @@ def test_push_log_controller_with_invalid_extra_value(client):
     assert response.json == {
         'error': {
             'Code': 400,
-            'Message': 'request body missing on or more mandatory fields ["message", "level"]'
+            'Message': 'Extra param must be a valid json object'
         }
     }

--- a/api/tests/test_push_log.py
+++ b/api/tests/test_push_log.py
@@ -1,0 +1,78 @@
+
+def test_push_log_controller_with_valid_json_no_extra(client, caplog):
+    request_body = {'message': 'sample-message', 'level': 'info'}
+    expected_log = "INFO     pcluster-manager:logger.py:24 {'message': 'sample-message'}"
+
+    caplog.clear()
+    response = client.post('/push-log', json=request_body)
+
+    assert response.status_code == 200
+    assert caplog.text == expected_log
+
+
+def test_push_log_controller_with_valid_json_with_extra(client, caplog):
+    request_body = {'message': 'sample-message', 'level': 'error',
+                    'extra': {'extra_1': 'value_1', 'extra_2': 'value_2'}}
+    expected_log = "ERROR    pcluster-manager:logger.py:30 {'extra_1': 'value_1', 'extra_2': 'value_2', 'message': 'sample-message'}"
+
+    caplog.clear()
+    response = client.post('/push-log', json=request_body)
+
+    assert response.status_code == 200
+    assert caplog.text.replace('\n', '') == expected_log
+
+
+def test_push_log_controller_with_invalid_message_key(client):
+    request_body = {'message_wrong': 'sample-message', 'level': 'info'}
+
+    response = client.post('/push-log', json=request_body)
+
+    assert response.status_code == 400
+    assert response.json == {
+        'error': {
+            'Code': 400,
+            'Message': 'Request body missing on or more mandatory fields ["message", "level"]'
+        }
+    }
+
+
+def test_push_log_controller_with_invalid_level_key(client):
+    request_body = {'message': 'sample-message', 'level_wrong': 'info'}
+
+    response = client.post('/push-log', json=request_body)
+
+    assert response.status_code == 400
+    assert response.json == {
+        'error': {
+            'Code': 400,
+            'Message': 'request body missing on or more mandatory fields ["message", "level"]'
+        }
+    }
+
+
+def test_push_log_controller_with_invalid_level_value(client):
+    request_body = {'message': 'sample-message', 'level': 'wrong-level'}
+
+    response = client.post('/push-log', json=request_body)
+
+    assert response.status_code == 400
+    assert response.json == {
+        'error': {
+            'Code': 400,
+            'Message': 'request body missing on or more mandatory fields ["message", "level"]'
+        }
+    }
+
+
+def test_push_log_controller_with_invalid_extra_value(client):
+    request_body = {'message': 'sample-message', 'level': 'info', 'extra': 'wrong-value'}
+
+    response = client.post('/push-log', json=request_body)
+
+    assert response.status_code == 400
+    assert response.json == {
+        'error': {
+            'Code': 400,
+            'Message': 'request body missing on or more mandatory fields ["message", "level"]'
+        }
+    }

--- a/api/tests/test_push_log.py
+++ b/api/tests/test_push_log.py
@@ -1,34 +1,43 @@
+from os import environ
+
+import pytest
+
 
 def trim_log(caplog):
     return caplog.text.replace('\n', '')
 
-def test_push_log_controller_with_valid_json_no_extra(client, caplog):
+@pytest.fixture(scope='function')
+def disable_auth(monkeypatch):
+    monkeypatch.setitem(environ, 'ENABLE_AUTH', 'false')
+
+
+def test_push_log_controller_with_valid_json_no_extra(client, caplog, disable_auth):
     request_body = {'message': 'sample-message', 'level': 'info'}
     expected_log = "INFO     pcluster-manager:logger.py:24 {'source': 'frontend', 'message': 'sample-message'}"
 
     caplog.clear()
-    response = client.post('/push-log', json=request_body)
+    response = client.post('/logs', json=request_body)
 
     assert response.status_code == 200
     assert trim_log(caplog) == expected_log
 
 
-def test_push_log_controller_with_valid_json_with_extra(client, caplog):
+def test_push_log_controller_with_valid_json_with_extra(client, caplog, disable_auth):
     request_body = {'message': 'sample-message', 'level': 'error',
                     'extra': {'extra_1': 'value_1', 'extra_2': 'value_2'}}
     expected_log = "ERROR    pcluster-manager:logger.py:30 {'extra_1': 'value_1', 'extra_2': 'value_2', 'source': 'frontend', 'message': 'sample-message'}"
 
     caplog.clear()
-    response = client.post('/push-log', json=request_body)
+    response = client.post('/logs', json=request_body)
 
     assert response.status_code == 200
     assert trim_log(caplog) == expected_log
 
 
-def test_push_log_controller_with_invalid_message_key(client):
+def test_push_log_controller_with_invalid_message_key(client, disable_auth):
     request_body = {'message_wrong': 'sample-message', 'level': 'info'}
 
-    response = client.post('/push-log', json=request_body)
+    response = client.post('/logs', json=request_body)
 
     assert response.status_code == 400
     assert response.json == {
@@ -39,10 +48,10 @@ def test_push_log_controller_with_invalid_message_key(client):
     }
 
 
-def test_push_log_controller_with_invalid_level_key(client):
+def test_push_log_controller_with_invalid_level_key(client, disable_auth):
     request_body = {'message': 'sample-message', 'level_wrong': 'info'}
 
-    response = client.post('/push-log', json=request_body)
+    response = client.post('/logs', json=request_body)
 
     assert response.status_code == 400
     assert response.json == {
@@ -53,10 +62,10 @@ def test_push_log_controller_with_invalid_level_key(client):
     }
 
 
-def test_push_log_controller_with_invalid_level_value(client):
+def test_push_log_controller_with_invalid_level_value(client, disable_auth):
     request_body = {'message': 'sample-message', 'level': 'wrong-level'}
 
-    response = client.post('/push-log', json=request_body)
+    response = client.post('/logs', json=request_body)
 
     assert response.status_code == 400
     assert response.json == {
@@ -67,10 +76,10 @@ def test_push_log_controller_with_invalid_level_value(client):
     }
 
 
-def test_push_log_controller_with_invalid_extra_value(client):
+def test_push_log_controller_with_invalid_extra_value(client, disable_auth):
     request_body = {'message': 'sample-message', 'level': 'info', 'extra': 'wrong-value'}
 
-    response = client.post('/push-log', json=request_body)
+    response = client.post('/logs', json=request_body)
 
     assert response.status_code == 400
     assert response.json == {

--- a/api/tests/test_push_log.py
+++ b/api/tests/test_push_log.py
@@ -4,7 +4,7 @@ def trim_log(caplog):
 
 def test_push_log_controller_with_valid_json_no_extra(client, caplog):
     request_body = {'message': 'sample-message', 'level': 'info'}
-    expected_log = "INFO     pcluster-manager:logger.py:24 {'message': 'sample-message'}"
+    expected_log = "INFO     pcluster-manager:logger.py:24 {'source': 'frontend', 'message': 'sample-message'}"
 
     caplog.clear()
     response = client.post('/push-log', json=request_body)
@@ -16,7 +16,7 @@ def test_push_log_controller_with_valid_json_no_extra(client, caplog):
 def test_push_log_controller_with_valid_json_with_extra(client, caplog):
     request_body = {'message': 'sample-message', 'level': 'error',
                     'extra': {'extra_1': 'value_1', 'extra_2': 'value_2'}}
-    expected_log = "ERROR    pcluster-manager:logger.py:30 {'extra_1': 'value_1', 'extra_2': 'value_2', 'message': 'sample-message'}"
+    expected_log = "ERROR    pcluster-manager:logger.py:30 {'extra_1': 'value_1', 'extra_2': 'value_2', 'source': 'frontend', 'message': 'sample-message'}"
 
     caplog.clear()
     response = client.post('/push-log', json=request_body)

--- a/app.py
+++ b/app.py
@@ -182,7 +182,8 @@ def run():
     def logout_():
         return logout()
 
-    @app.route('/push-log', methods=['POST'])
+    @app.route('/logs', methods=['POST'])
+    @authenticated(ADMINS_USERS_GROUP)
     def push_log():
         if 'level' not in request.json or 'message' not in request.json:
             raise ValueError('Request body missing one or more mandatory fields ["message", "level"]')

--- a/app.py
+++ b/app.py
@@ -197,6 +197,8 @@ def run():
         if logging_fun is None:
             raise ValueError('Invalid logging level requested')
 
+        extra = {} if extra is None else extra
+        extra['source'] = 'frontend'
         logging_fun(message, extra=extra)
         return Response(status=200)
 

--- a/app.py
+++ b/app.py
@@ -185,7 +185,7 @@ def run():
     @app.route('/push-log', methods=['POST'])
     def push_log():
         if 'level' not in request.json or 'message' not in request.json:
-            raise ValueError('Request body missing on or more mandatory fields ["message", "level"]')
+            raise ValueError('Request body missing one or more mandatory fields ["message", "level"]')
 
         _json = request.json.get
         level, message, extra = _json('level'), _json('message'), _json('extra')

--- a/app.py
+++ b/app.py
@@ -182,6 +182,24 @@ def run():
     def logout_():
         return logout()
 
+    @app.route('/push-log', methods=['POST'])
+    def push_log():
+        if 'level' not in request.json or 'message' not in request.json:
+            raise ValueError('Request body missing on or more mandatory fields ["message", "level"]')
+
+        level, message, extra = request.json['level'], request.json['message'], request.json['extra']
+        if not (extra is None or type(extra) is dict):
+            raise ValueError('Extra param must be a valid json object')
+
+        logging_fun = getattr(logger, level.lower())
+
+        if logging_fun is None:
+            raise ValueError('Invalid logging level requested')
+
+        logging_fun(message, extra=extra)
+        return Response(status=200)
+
+
     @app.route('/<regex("(home|clusters|users|configure|custom-images|official-images).*"):base>', defaults={"base": ""})
     def catch_all(base):
         return utils.serve_frontend(app, base)

--- a/app.py
+++ b/app.py
@@ -187,11 +187,12 @@ def run():
         if 'level' not in request.json or 'message' not in request.json:
             raise ValueError('Request body missing on or more mandatory fields ["message", "level"]')
 
-        level, message, extra = request.json['level'], request.json['message'], request.json['extra']
+        _json = request.json.get
+        level, message, extra = _json('level'), _json('message'), _json('extra')
         if not (extra is None or type(extra) is dict):
             raise ValueError('Extra param must be a valid json object')
 
-        logging_fun = getattr(logger, level.lower())
+        logging_fun = getattr(logger, level.lower(), None)
 
         if logging_fun is None:
             raise ValueError('Invalid logging level requested')


### PR DESCRIPTION
## Description
Added a public endpoint to allow the frontend to push log entries to the backend.

<!-- Summary of what this PR introduces and possibly why -->
## Changes
- Added a new exception handler to handle ValueError in case of API validation error
- Added a `/push-log` endpoint to log the log entries from the frontend
- Added tests for newly added ValueError exception handler and far all validation cases of the new endpoint
<!-- List of relevant changes introduced -->

<!-- A sentence to be added to the next release's changelog that captures the changes in this PR -->

## How Has This Been Tested?
Unit tests and manual integration tests
<!-- The tests you ran to verify your changes -->

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [x] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
