### PR TITLE
Remove user group from authorization model

### DIFF
--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -144,7 +144,7 @@ def authenticate(groups):
     if ("guest" not in groups) and len(groups_granted) == 0:
         return abort(403)
 
-def authenticated(groups={"user"}):
+def authenticated(groups={"admin"}):
     def _authenticated(func):
         @functools.wraps(func)
         def _wrapper_authenticated(*args, **kwargs):

--- a/api/tests/test_exception_handlers.py
+++ b/api/tests/test_exception_handlers.py
@@ -10,11 +10,11 @@ def client_error_response():
 
 
 def test_boto3_exception_handler(client, client_error_response, app, monkeypatch):
-    def set_user_role_raising_clienterror():
+    def delete_user_raising_clienterror():
         raise client_error_response
 
-    monkeypatch.setitem(app.view_functions, 'set_user_role_', set_user_role_raising_clienterror)
-    response = client.put('/manager/set_user_role', json={'username': 'some-user', 'role': 'some-role'})
+    monkeypatch.setitem(app.view_functions, 'delete_user_', delete_user_raising_clienterror)
+    response = client.delete('/manager/delete_user', json={'username': 'some-user'})
 
     assert response.status_code == 400
     assert response.json == {'error': {'Code': 400, 'Message': 'Operation failed'}}

--- a/app.py
+++ b/app.py
@@ -38,13 +38,11 @@ from api.PclusterApiHandler import (
     queue_status,
     sacct,
     scontrol_job,
-    set_user_role,
     submit_job,
     logger,
 )
 from api.pcm_globals import set_global_logger
 
-ADMINS_USERS_GROUP = { "user", "admin" }
 ADMINS_GROUP = { "admin" }
 
 class RegexConverter(BaseConverter):
@@ -82,32 +80,32 @@ def run():
         return utils.serve_frontend(app, path)
 
     @app.route("/manager/ec2_action", methods=["POST"])
-    @authenticated(ADMINS_USERS_GROUP)
+    @authenticated(ADMINS_GROUP)
     def ec2_action_():
         return ec2_action()
 
     @app.route("/manager/get_cluster_configuration")
-    @authenticated(ADMINS_USERS_GROUP)
+    @authenticated(ADMINS_GROUP)
     def get_cluster_config_():
         return get_cluster_config()
 
     @app.route("/manager/get_custom_image_configuration")
-    @authenticated(ADMINS_USERS_GROUP)
+    @authenticated(ADMINS_GROUP)
     def get_custom_image_config_():
         return get_custom_image_config()
 
     @app.route("/manager/get_aws_configuration")
-    @authenticated(ADMINS_USERS_GROUP)
+    @authenticated(ADMINS_GROUP)
     def get_aws_config_():
         return get_aws_config()
 
     @app.route("/manager/get_instance_types")
-    @authenticated(ADMINS_USERS_GROUP)
+    @authenticated(ADMINS_GROUP)
     def get_instance_types_():
         return get_instance_types()
 
     @app.route("/manager/get_dcv_session")
-    @authenticated(ADMINS_USERS_GROUP)
+    @authenticated(ADMINS_GROUP)
     def get_dcv_session_():
         return get_dcv_session()
 
@@ -139,38 +137,33 @@ def run():
     def delete_user_():
         return delete_user()
 
-    @app.route("/manager/set_user_role", methods=["PUT"])
-    @authenticated(ADMINS_GROUP)
-    def set_user_role_():
-        return set_user_role()
-
     @app.route("/manager/queue_status")
-    @authenticated(ADMINS_USERS_GROUP)
+    @authenticated(ADMINS_GROUP)
     def queue_status_():
         return queue_status()
 
     @app.route("/manager/cancel_job")
-    @authenticated(ADMINS_USERS_GROUP)
+    @authenticated(ADMINS_GROUP)
     def cancel_job_():
         return cancel_job()
 
     @app.route("/manager/price_estimate")
-    @authenticated(ADMINS_USERS_GROUP)
+    @authenticated(ADMINS_GROUP)
     def price_estimate_():
         return price_estimate()
 
     @app.route("/manager/submit_job", methods=["POST"])
-    @authenticated(ADMINS_USERS_GROUP)
+    @authenticated(ADMINS_GROUP)
     def submit_job_():
         return submit_job()
 
     @app.route("/manager/sacct", methods=["POST"])
-    @authenticated(ADMINS_USERS_GROUP)
+    @authenticated(ADMINS_GROUP)
     def sacct_():
         return sacct()
 
     @app.route("/manager/scontrol_job")
-    @authenticated(ADMINS_USERS_GROUP)
+    @authenticated(ADMINS_GROUP)
     def scontrol_job_():
         return scontrol_job()
 
@@ -183,7 +176,7 @@ def run():
         return logout()
 
     @app.route('/logs', methods=['POST'])
-    @authenticated(ADMINS_USERS_GROUP)
+    @authenticated(ADMINS_GROUP)
     def push_log():
         if 'level' not in request.json or 'message' not in request.json:
             raise ValueError('Request body missing one or more mandatory fields ["message", "level"]')

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -513,30 +513,6 @@ function DeleteUser(user: any, successCallback?: Callback) {
     })
 }
 
-function SetUserRole(user: any, role: any, callback?: Callback) {
-  var url = 'manager/set_user_role'
-  let body = {username: user.Username, role: role}
-  request('put', url, body)
-    .then((response: any) => {
-      if (response.status === 200) {
-        if (response.data.Username) {
-          setState(['users', 'index', response.data.Username], response.data)
-          callback && callback(response.data)
-        } else {
-          console.log(response.data)
-          notify(`Error updatin user: ${user}`, 'error')
-        }
-      } else {
-        console.log(response)
-      }
-    })
-    .catch((error: any) => {
-      if (error.response)
-        notify(`Error: ${error.response.data.message}`, 'error')
-      console.log(error.response)
-    })
-}
-
 function GetCustomImageStackEvents(imageId: any) {
   request('get', `api?path=/v3/images/custom/${imageId}/stackevents`)
     .then((response: any) => {
@@ -1037,7 +1013,6 @@ export {
   SlurmAccounting,
   JobInfo,
   ListUsers,
-  SetUserRole,
   notify,
   CreateUser,
   DeleteUser,

--- a/frontend/src/old-pages/Users/Users.tsx
+++ b/frontend/src/old-pages/Users/Users.tsx
@@ -13,7 +13,7 @@ import {useSelector} from 'react-redux'
 import {useCollection} from '@cloudscape-design/collection-hooks'
 import {clearState, setState, getState, useState} from '../../store'
 
-import {CreateUser, DeleteUser, ListUsers, SetUserRole} from '../../model'
+import {CreateUser, DeleteUser, ListUsers} from '../../model'
 
 // UI Elements
 import {
@@ -46,52 +46,6 @@ const errorsPath = ['app', 'wizard', 'errors', 'user']
 
 // selectors
 const selectUserIndex = (state: any) => state.users.index
-
-function userToRole(user: any) {
-  let user_groups = new Set(user.Groups.map((group: any) => group.GroupName))
-  for (const group of ['admin', 'user'])
-    if (user_groups.has(group)) return group
-  return 'guest'
-}
-
-function RoleSelector(props: any) {
-  const current_group = userToRole(props.user)
-  const [pending, setPending] = React.useState(false)
-
-  return (
-    <div>
-      {pending ? (
-        <Loading text="Updating..." />
-      ) : (
-        <Select
-          expandToViewport
-          placeholder="Role"
-          selectedOption={{
-            label:
-              current_group.charAt(0).toUpperCase() + current_group.slice(1),
-            value: current_group,
-          }}
-          onChange={({detail}) => {
-            setPending(true)
-            SetUserRole(
-              props.user,
-              detail.selectedOption.value,
-              (user: any) => {
-                setPending(false)
-              },
-            )
-          }}
-          options={[
-            {label: 'Guest', value: 'guest'},
-            {label: 'User', value: 'user'},
-            {label: 'Admin', value: 'admin'},
-          ]}
-          selectedAriaLabel="Selected"
-        />
-      )}
-    </div>
-  )
-}
 
 function UserActions({user}: any) {
   let email = useState(['identity', 'attributes', 'email'])
@@ -258,21 +212,6 @@ export default function Users(props: any) {
             header: 'Email',
             cell: item => item.Attributes.email || '-',
             sortingField: 'Attributes.email',
-          },
-          {
-            id: 'role',
-            header: (
-              <div className="whiteSpace">
-                Role
-                <HelpTooltip>
-                  <b>Guest</b> can login but not see any clusters.<b>User</b>{' '}
-                  can see clusters and access clusters but not create or delete.{' '}
-                  <b>Admin</b> has full access.
-                </HelpTooltip>
-              </div>
-            ),
-            cell: item => <RoleSelector user={item} />,
-            sortingField: 'Groups',
           },
           {
             id: 'created',


### PR DESCRIPTION
## Description

This PR removes the `user` group from the authorization model implemented on the backend. Since every user is going to belong to the `admin` group, the Users page now doesn't show the Role column anymore.

## Changes

- authenticated endpoints only allow `admin`s
- add new users to the `admin` group
- remove Role section from Users page
- remove `set_user_role` endpoint

## How Has This Been Tested?

- manually, by creating new users and checking they are marked as `admin`

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
