### PR TITLE
Add ADR on adopting release:* labels for PRs

### DIFF
--- a/decisions/20221107-adopt-github-labels-to-allow-automating-release-changelog-creation.md
+++ b/decisions/20221107-adopt-github-labels-to-allow-automating-release-changelog-creation.md
@@ -1,6 +1,6 @@
 # Adopt Github labels to allow automating release changelog creation
 
-- Status: accepted
+- Status: superseded by [20221129-adopt-releaselabels-to-automate-changelog-generation](20221129-adopt-releaselabels-to-automate-changelog-generation.md)
 - Deciders: Nuraghe team
 - Date: 2022-11-07
 - Tags: release, changelog, labels

--- a/decisions/20221129-adopt-releaselabels-to-automate-changelog-generation.md
+++ b/decisions/20221129-adopt-releaselabels-to-automate-changelog-generation.md
@@ -1,0 +1,20 @@
+# Adopt release:*labels to automate Changelog generation
+
+- Status: accepted
+- Deciders: Marco Basile
+- Tags: release changelog labels
+
+## Context
+In the superseded ADR, it had been decided to automatically generate the changelog with a simple release-include/exclude labeling system. In order to generate a more useful changelog for our users, we committed to improve on this mechanism
+
+## Decision
+We are adopting the following labels for our PRs:
+
+- release:breaking-change
+- release:bugfix
+- release:improvement
+- release:feature
+- release:deprecated
+
+## Links
+- Supersedes [20221107-adopt-github-labels-to-allow-automating-release-changelog-creation](20221107-adopt-github-labels-to-allow-automating-release-changelog-creation.md)


### PR DESCRIPTION
## Description

This PR adds an ADR to track the decision of adopting release:* labels on our PRs

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
