### PR TITLE
Clean up codebase from guest/users roles

### DIFF
--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -141,7 +141,7 @@ def authenticate(groups):
         
     jwt_roles = set(decoded.get(USER_ROLES_CLAIM, []))
     groups_granted = groups.intersection(jwt_roles)
-    if ("guest" not in groups) and len(groups_granted) == 0:
+    if len(groups_granted) == 0:
         return abort(403)
 
 def authenticated(groups={"admin"}):

--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -595,7 +595,7 @@ def get_identity():
         if "username" not in identity:
             return {"message": "No username present in access or id token."}, 400
         if "user_roles" not in identity:
-            identity["user_roles"] = ["user"]
+            return {"message": "No user_roles present in access or id token."}, 400
 
     except jwt.ExpiredSignatureError:
         return {"message": "Signature expired."}, 401

--- a/api/tests/test_authenticate.py
+++ b/api/tests/test_authenticate.py
@@ -80,17 +80,6 @@ def test_authenticate_when_no_groups_are_given_it_should_return_403(mocker, app)
 
         mock_abort.assert_called_once_with(403)
 
-def test_authenticate_with_guest_group_succeeds(mocker, app):
-    with app.test_request_context(headers={'Cookie': 'accessToken=access-token'}):
-        mock_abort = mocker.patch('api.PclusterApiHandler.abort')
-        mocker.patch('api.PclusterApiHandler.jwt_decode',
-                     return_value={'cognito:groups': ['other-group']})
-
-        authenticate({'guest'})
-
-        mock_abort.assert_not_called()
-
-
 def test_authenticate_with_group_in_user_role_claim_succeeds(mocker, app):
     with app.test_request_context(headers={'Cookie': 'accessToken=access-token'}):
         mock_abort = mocker.patch('api.PclusterApiHandler.abort')
@@ -107,6 +96,6 @@ def test_authenticate_with_admin_not_in_the_user_group_succeds(mocker, app):
         mocker.patch('api.PclusterApiHandler.jwt_decode',
                      return_value={'cognito:groups': ['admin']})
 
-        authenticate({'user', 'admin'})
+        authenticate({'some-group', 'admin'})
 
         mock_abort.assert_not_called()

--- a/api/tests/test_get_identity.py
+++ b/api/tests/test_get_identity.py
@@ -90,7 +90,7 @@ def test_get_identity_auth_enabled_no_user_roles_provided(monkeypatch, mocker, a
     Given an handler for the /get-identity endpoint
       When authentication is enabled
       When user roles could not be retrieved
-        Then it should fallback to "user" as user role
+        Then it should return 400
     """
     monkeypatch.setenv("ENABLE_AUTH", "true")
     monkeypatch.setattr('api.PclusterApiHandler.USER_ROLES_CLAIM', 'user_roles_claim')
@@ -102,9 +102,5 @@ def test_get_identity_auth_enabled_no_user_roles_provided(monkeypatch, mocker, a
     with app.test_request_context(headers={'Cookie': 'accessToken=access-token; idToken=identity-token'}):
       mocker.patch('api.PclusterApiHandler.jwt_decode', side_effect=[accessTokenDecoded, identityTokenDecoded])
 
-      assert get_identity() == {
-        'attributes': {'email': 'id-token-email'},
-        'user_roles': ['user'],
-        'username': 'id-token-username'
-      }
+      assert get_identity() == ({"message": "No user_roles present in access or id token."}, 400)
       

--- a/app.py
+++ b/app.py
@@ -110,7 +110,7 @@ def run():
         return get_dcv_session()
 
     @app.route("/manager/get_identity")
-    @authenticated({"guest"})
+    @authenticated(ADMINS_GROUP)
     def get_identity_():
         return get_identity()
 

--- a/frontend/src/components/SideBar.tsx
+++ b/frontend/src/components/SideBar.tsx
@@ -8,12 +8,15 @@
 // or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 // OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
-import {SideNavigation, SideNavigationProps} from '@cloudscape-design/components'
+import {
+  SideNavigation,
+  SideNavigationProps,
+} from '@cloudscape-design/components'
 import * as React from 'react'
 import {useTranslation} from 'react-i18next'
 import {useLocation, useNavigate} from 'react-router-dom'
 import {USER_ROLES_CLAIM} from '../auth/constants'
-import {isAdmin, isUser, useState} from '../store'
+import {isAdmin, useState} from '../store'
 
 export default function SideBar() {
   const {t} = useTranslation()
@@ -35,17 +38,17 @@ export default function SideBar() {
     React.useMemo(() => {
       return [
         {type: 'link', text: t('global.menu.home'), href: '/home'},
-        isUser()
+        isAdmin()
           ? {type: 'link', text: t('global.menu.clusters'), href: '/clusters'}
           : null,
-        isUser()
+        isAdmin()
           ? {
               type: 'link',
               text: t('global.menu.customImages'),
               href: '/custom-images',
             }
           : null,
-        isUser()
+        isAdmin()
           ? {
               type: 'link',
               text: t('global.menu.officialImages'),

--- a/frontend/src/components/SideBar.tsx
+++ b/frontend/src/components/SideBar.tsx
@@ -15,8 +15,6 @@ import {
 import * as React from 'react'
 import {useTranslation} from 'react-i18next'
 import {useLocation, useNavigate} from 'react-router-dom'
-import {USER_ROLES_CLAIM} from '../auth/constants'
-import {isAdmin, useState} from '../store'
 
 export default function SideBar() {
   const {t} = useTranslation()
@@ -24,7 +22,6 @@ export default function SideBar() {
   const location = useLocation()
 
   const activeHref = '/' + location.pathname.split('/')?.[1]
-  const identity = useState(['identity', USER_ROLES_CLAIM])
 
   const header = React.useMemo(
     () => ({
@@ -38,26 +35,18 @@ export default function SideBar() {
     React.useMemo(() => {
       return [
         {type: 'link', text: t('global.menu.home'), href: '/home'},
-        isAdmin()
-          ? {type: 'link', text: t('global.menu.clusters'), href: '/clusters'}
-          : null,
-        isAdmin()
-          ? {
-              type: 'link',
-              text: t('global.menu.customImages'),
-              href: '/custom-images',
-            }
-          : null,
-        isAdmin()
-          ? {
-              type: 'link',
-              text: t('global.menu.officialImages'),
-              href: '/official-images',
-            }
-          : null,
-        isAdmin()
-          ? {type: 'link', text: t('global.menu.users'), href: '/users'}
-          : null,
+        {type: 'link', text: t('global.menu.clusters'), href: '/clusters'},
+        {
+          type: 'link',
+          text: t('global.menu.customImages'),
+          href: '/custom-images',
+        },
+        {
+          type: 'link',
+          text: t('global.menu.officialImages'),
+          href: '/official-images',
+        },
+        {type: 'link', text: t('global.menu.users'), href: '/users'},
         {type: 'divider'},
         {
           type: 'link',
@@ -65,10 +54,8 @@ export default function SideBar() {
           href: '/license.txt',
           external: true,
         },
-      ].filter(Boolean) as ReadonlyArray<SideNavigationProps.Item>
-      // we need to recompute navigationItems according to identity change
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [t, identity])
+      ]
+    }, [t])
 
   const onFollow = React.useCallback(
     event => {

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -962,23 +962,12 @@ async function LoadInitialState() {
   clearAllState()
   GetVersion()
   await GetAppConfig()
-  GetIdentity((identity: any) => {
-    let groups = identity[USER_ROLES_CLAIM]
-
-    if (!groups) {
-      return
-    }
-
-    if (groups.includes('admin')) {
-      ListUsers()
-    }
-
-    if (groups.includes('admin') || groups.includes('user')) {
-      ListClusters()
-      ListCustomImages()
-      ListOfficialImages()
-      LoadAwsConfig(region)
-    }
+  GetIdentity(_ => {
+    ListUsers()
+    ListClusters()
+    ListCustomImages()
+    ListOfficialImages()
+    LoadAwsConfig(region)
   })
 }
 

--- a/frontend/src/old-pages/Clusters/Actions.tsx
+++ b/frontend/src/old-pages/Clusters/Actions.tsx
@@ -15,13 +15,7 @@ import {useNavigate} from 'react-router-dom'
 // @ts-expect-error TS(7016) FIXME: Could not find a declaration file for module 'js-y... Remove this comment to see the full error message
 import jsyaml from 'js-yaml'
 
-import {
-  setState,
-  useState,
-  isAdmin,
-  ssmPolicy,
-  consoleDomain,
-} from '../../store'
+import {setState, useState, ssmPolicy, consoleDomain} from '../../store'
 import {
   UpdateComputeFleet,
   GetConfiguration,
@@ -149,8 +143,7 @@ export default function Actions() {
             clusterStatus === ClusterStatus.CreateInProgress ||
             clusterStatus === ClusterStatus.DeleteInProgress ||
             clusterStatus === ClusterStatus.CreateFailed ||
-            clusterVersion !== apiVersion ||
-            !isAdmin()
+            clusterVersion !== apiVersion
           }
           variant="normal"
           onClick={editConfiguration}
@@ -168,9 +161,7 @@ export default function Actions() {
           </Button>
         )}
         <Button
-          disabled={
-            clusterStatus === ClusterStatus.DeleteInProgress || !isAdmin()
-          }
+          disabled={clusterStatus === ClusterStatus.DeleteInProgress}
           onClick={() => {
             showDialog('deleteCluster')
           }}

--- a/frontend/src/old-pages/Clusters/Clusters.tsx
+++ b/frontend/src/old-pages/Clusters/Clusters.tsx
@@ -15,7 +15,7 @@ import {
 import React, {useEffect} from 'react'
 import {NavigateFunction, useNavigate, useParams} from 'react-router-dom'
 import {DescribeCluster, GetConfiguration, ListClusters} from '../../model'
-import {useState, clearState, setState, isAdmin} from '../../store'
+import {useState, clearState, setState} from '../../store'
 import {selectCluster} from './util'
 import {findFirst} from '../../util'
 import {useTranslation} from 'react-i18next'
@@ -103,7 +103,7 @@ function ClusterList({clusters}: {clusters: ClusterInfoSummary[]}) {
           title={t('cluster.list.filtering.empty.title')}
           subtitle={t('cluster.list.filtering.empty.subtitle')}
           action={
-            <Button onClick={configure} disabled={!isAdmin()}>
+            <Button onClick={configure}>
               {t('cluster.list.filtering.empty.action')}
             </Button>
           }
@@ -138,11 +138,7 @@ function ClusterList({clusters}: {clusters: ClusterInfoSummary[]}) {
             <SpaceBetween direction="horizontal" size="xs">
               {selectedClusterName && <Actions />}
               {clusters && (
-                <Button
-                  onClick={configure}
-                  variant="primary"
-                  disabled={!isAdmin()}
-                >
+                <Button onClick={configure} variant="primary">
                   {t('cluster.list.actions.create')}
                 </Button>
               )}

--- a/frontend/src/old-pages/CustomImages/CustomImages.tsx
+++ b/frontend/src/old-pages/CustomImages/CustomImages.tsx
@@ -14,7 +14,7 @@ import {useSelector} from 'react-redux'
 
 import {ListCustomImages, DescribeCustomImage} from '../../model'
 
-import {setState, useState, getState, clearState, isAdmin} from '../../store'
+import {setState, useState, getState, clearState} from '../../store'
 
 import {useCollection} from '@cloudscape-design/collection-hooks'
 
@@ -22,13 +22,10 @@ import {useCollection} from '@cloudscape-design/collection-hooks'
 import EmptyState from '../../components/EmptyState'
 import ImageBuildDialog from './ImageBuildDialog'
 import CustomImageDetails from './CustomImageDetails'
-import Loading from '../../components/Loading'
 
 // UI Elements
 import {
-  AppLayout,
   Button,
-  Container,
   Header,
   Pagination,
   Select,
@@ -130,7 +127,6 @@ function CustomImagesList() {
                 className="action"
                 onClick={buildImage}
                 iconName={'add-plus'}
-                disabled={!isAdmin()}
               >
                 Build Image
               </Button>

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -26,8 +26,6 @@ import Home from '../old-pages/Home/Home'
 // Components
 import Loading from '../components/Loading'
 
-import {isGuest} from '../store'
-
 export default function App() {
   const identity = useState(['identity'])
 
@@ -42,16 +40,9 @@ export default function App() {
           <Routes>
             <Route
               path="index.html"
-              element={
-                isGuest() ? <Home /> : <Navigate replace to="/clusters" />
-              }
+              element={<Navigate replace to="/clusters" />}
             />
-            <Route
-              index
-              element={
-                isGuest() ? <Home /> : <Navigate replace to="/clusters" />
-              }
-            />
+            <Route index element={<Navigate replace to="/clusters" />} />
             <Route path="home" element={<Home />} />
             <Route path="clusters" element={<Clusters />}>
               <Route path=":clusterName" element={<div></div>}>

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -149,16 +149,6 @@ function isAdmin() {
   return groups && groups.includes('admin')
 }
 
-function isUser() {
-  let groups = getState(['identity', USER_ROLES_CLAIM]) || []
-  return groups && (groups.includes('admin') || groups.includes('user'))
-}
-
-function isGuest() {
-  let identity = getState(['identity'])
-  return identity && !isAdmin() && !isUser()
-}
-
 function ssmPolicy(region: any) {
   const partition = region && region.startsWith('us-gov') ? 'aws-us-gov' : 'aws'
   return `arn:${partition}:iam::aws:policy/AmazonSSMManagedInstanceCore`
@@ -181,8 +171,6 @@ export {
   useState,
   updateState,
   isAdmin,
-  isUser,
-  isGuest,
   ssmPolicy,
   consoleDomain,
 }

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -144,11 +144,6 @@ function useState(path: any) {
   return useSelector(s => getState(s, path))
 }
 
-function isAdmin() {
-  let groups = getState(['identity', USER_ROLES_CLAIM]) || []
-  return groups && groups.includes('admin')
-}
-
 function ssmPolicy(region: any) {
   const partition = region && region.startsWith('us-gov') ? 'aws-us-gov' : 'aws'
   return `arn:${partition}:iam::aws:policy/AmazonSSMManagedInstanceCore`
@@ -170,7 +165,6 @@ export {
   clearAllState,
   useState,
   updateState,
-  isAdmin,
   ssmPolicy,
   consoleDomain,
 }


### PR DESCRIPTION
## Description

Following #375, this PR cleans up the codebase removing references to deprecated user and guest roles

## Changes

- remove distinction between `user` and `admin` from the SideBar
- remove `guest` from the authorized user groups
- fail `get_identity` when no groups for the user are set

## How Has This Been Tested?

- unit tests
- manually by following these steps:
    - create a new user via PCM
    - logged in with the new user
    - created a new cluster successfully

## References

- #375 

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
