### PR TITLE
Clean up infrastructure from users role

### DIFF
--- a/infrastructure/github-env-setup.yml
+++ b/infrastructure/github-env-setup.yml
@@ -146,6 +146,12 @@ Resources:
                   - lambda:UpdateFunctionConfiguration
                 Resource:
                   - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:PclusterManagerFunction-*
+              - Effect: Allow
+                Action:
+                  - cognito-idp:UpdateGroup
+                  - cognito-idp:DeleteGroup
+                Resource:
+                  - arn:aws:cognito-idp:eu-west-1:063695377715:userpool/*
         - PolicyName: ImageBuilderPolicy
           PolicyDocument:
             Version: 2012-10-17

--- a/infrastructure/pcluster-manager-cognito.yaml
+++ b/infrastructure/pcluster-manager-cognito.yaml
@@ -244,17 +244,9 @@ Resources:
   CognitoUserGroup:
     Type: AWS::Cognito::UserPoolGroup
     Properties:
-      Description: User group that can view and manage clusters
+      Description: User group that can manage clusters and users
       GroupName: admin
       Precedence: 1
-      UserPoolId: !Ref CognitoUserPool
-
-  CognitoAdminGroup:
-    Type: AWS::Cognito::UserPoolGroup
-    Properties:
-      Description: Administrator group that can promote users to be admins.
-      GroupName: user
-      Precedence: 2
       UserPoolId: !Ref CognitoUserPool
 
 Outputs:
@@ -280,10 +272,6 @@ Outputs:
   CognitoUserGroup:
     Description: Cognito User Group
     Value:  !Ref CognitoUserGroup
-
-  CognitoAdminGroup:
-    Description: Cognito Admin Group
-    Value:  !Ref CognitoAdminGroup
 
   UserPoolClientSecretArn:
     Description: The app client secret ARN for PclusterManager.

--- a/infrastructure/pcluster-manager.yaml
+++ b/infrastructure/pcluster-manager.yaml
@@ -529,13 +529,6 @@ Resources:
       Username: !Ref AdminUserEmail
       UserPoolId: !GetAtt [ PclusterManagerCognito, Outputs.UserPoolId ]
 
-  CognitoUserToAdminGroup:
-    Type: AWS::Cognito::UserPoolUserToGroupAttachment
-    Properties:
-      GroupName: !GetAtt [ PclusterManagerCognito, Outputs.CognitoAdminGroup ]
-      Username: !Ref CognitoAdminUser
-      UserPoolId: !GetAtt [ PclusterManagerCognito, Outputs.UserPoolId ]
-
   CognitoUserToUserGroup:
     Type: AWS::Cognito::UserPoolUserToGroupAttachment
     Properties:


### PR DESCRIPTION
## Description

Following #375, this PR removes the user group from Cognito

## Changes

- remove `CognitoAdminGroup` (please note, the actual group is `user` even though the logical name is `AdminGroup`)
- update `UpdateInfrastructurePolicy` to allow this change to be applied when updating the stack

**Please note**: I decided to not rename the `CognitoUserGroup` because otherwise CFN would conflict as it would temporarily see two groups with the same `groupName: admin`. This should not be a source of confusion in the future, as we only have one user role now and there is no need to distinguish between admins and non-admins

## How Has This Been Tested?

- manually, by updating a stack starting from the latest public release
- via CLI, by assuming the `PrivateInfrastructureUpdateRole` and updating our demo environment 

## References

#375 

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [x] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
