### PR TITLE
Enable access logs on the API Gateway

### DIFF
--- a/infrastructure/pcluster-manager.yaml
+++ b/infrastructure/pcluster-manager.yaml
@@ -174,16 +174,12 @@ Resources:
       Name: PclusterManager
       Description: PclusterManager Lambda Proxy
       ProtocolType: HTTP
-      Target: !Sub
-        - arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:PclusterManagerFunction-${StackIdSuffix}/invocations
-        - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
 
   ApiGatewayRoute:
     Type: AWS::ApiGatewayV2::Route
     Properties:
       ApiId: !Ref ApiGateway
-      OperationName: ANY
-      RouteKey: 'ANY /'
+      RouteKey: $default
       Target: !Sub
         - 'integrations/${IntegrationId}'
         - { IntegrationId: !Ref ApiGatewayIntegration }
@@ -199,6 +195,21 @@ Resources:
         - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
       PayloadFormatVersion: 2.0
       TimeoutInMillis: 30000
+
+  PCMApiGatewayAccessLog:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 90
+
+  ApiGatewayStage:
+    Type: AWS::ApiGatewayV2::Stage
+    Properties: 
+      AccessLogSettings: 
+        DestinationArn: !GetAtt PCMApiGatewayAccessLog.Arn
+        Format: '{ "requestId":"$context.requestId", "ip": "$context.identity.sourceIp", "requestTime":"$context.requestTime", "httpMethod":"$context.httpMethod","path":"$context.path", "status":"$context.status","protocol":"$context.protocol", "responseLength":"$context.responseLength" }'
+      ApiId: !Ref ApiGateway
+      StageName: $default
+      AutoDeploy: True
 
   PrivateEcrRepository:
     DependsOn: ParallelClusterApi


### PR DESCRIPTION
## Description

Enable logging of every call made to the API gateway.

**N.B. the demo environment must be recreated from scratch as soon as this PR gets merged.**

## Changes

- **breaking**: manage manually the stage for the API Gateway so that log settings can be added (it's a breaking change only for stack updates since CloudFormation fails doing that operation)
- add logs settings to the API Gateway stage
- replaced the route matching in place with `$default` as it does exactly what we need to do (match all routes and every method)

## How Has This Been Tested?

Create a new stack and do some manual calls, veryfing the output in the CloudWatch console.

![Screenshot 2022-12-02 at 18 16 58](https://user-images.githubusercontent.com/3091286/205628769-906042ca-8e9d-485e-a090-3da3dcaea116.png)
![Screenshot 2022-12-02 at 18 17 10](https://user-images.githubusercontent.com/3091286/205628774-3bcfa123-1944-4ad1-bcce-9e1a5878a040.png)

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
