### PR TITLE
Setup e2e workflow IAM roles and credentials

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - e2e-credentials
+permissions:
+  id-token: write
+  contents: read
 jobs:
   e2e-tests:
     timeout-minutes: 60

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -1,8 +1,5 @@
 name: e2e
-on:
-  push:
-    branches:
-      - e2e-credentials
+on: workflow_dispatch
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -1,5 +1,8 @@
 name: e2e
-on: workflow_dispatch
+on:
+  push:
+    branches:
+      - e2e-credentials
 jobs:
   e2e-tests:
     timeout-minutes: 60
@@ -9,6 +12,19 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: 16
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-region: eu-west-1
+        role-to-assume: arn:aws:iam::063695377715:role/pcluster-manager-github-E2ETestExecution-Z7IMRUIJAZAO
+
+    - name: Retrieve test user email and password
+      uses: aws-actions/aws-secretsmanager-get-secrets@v1
+      with:
+        secret-ids: |
+          e2e/test1
+        parse-json-secrets: true
+      
     - name: Install dependencies
       run: npm ci
       working-directory: e2e

--- a/infrastructure/github-env-setup.yml
+++ b/infrastructure/github-env-setup.yml
@@ -171,8 +171,39 @@ Resources:
                 Resource:
                   - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/executionServiceEC2Role/pcluster-manager-demo-ImageBuilderInstanceRole*
 
+  E2ETestExecution:
+    Type: AWS::IAM::Role
+    Properties:
+      Description: "Role used to run PCM E2E test suite"
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRoleWithWebIdentity
+            Principal:
+              Federated: !If 
+                - CreateOIDCProvider
+                - !Ref GithubOidc
+                - !Ref OIDCProviderArn
+            Condition:
+              StringEquals:
+                token.actions.githubusercontent.com:aud: sts.amazonaws.com
+                token.actions.githubusercontent.com:sub: !Sub repo:${GitHubOrg}/${RepositoryName}:ref:refs/heads/main
+      Policies:
+        - PolicyName: SecretsManagerRead
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: secretsmanager:ListSecrets
+                Resource: "*"
+              - Effect: Allow
+                Action: secretsmanager:GetSecretValue
+                Resource: arn:aws:secretsmanager:eu-west-1:063695377715:secret:e2e/test1-AUsDgk
+
 Outputs:
   PrivateDeployRole:
     Value: !GetAtt PrivateDeployRole.Arn
   PrivateInfrastructureUpdateRole:
     Value: !GetAtt PrivateInfrastructureUpdateRole.Arn
+  E2ETestExecution:
+    Value: !GetAtt E2ETestExecution.Arn

--- a/infrastructure/github-env-setup.yml
+++ b/infrastructure/github-env-setup.yml
@@ -205,5 +205,5 @@ Outputs:
     Value: !GetAtt PrivateDeployRole.Arn
   PrivateInfrastructureUpdateRole:
     Value: !GetAtt PrivateInfrastructureUpdateRole.Arn
-  E2ETestExecution:
+  E2ETestExecutionRole:
     Value: !GetAtt E2ETestExecution.Arn

--- a/infrastructure/pcluster-manager-cognito.yaml
+++ b/infrastructure/pcluster-manager-cognito.yaml
@@ -200,7 +200,7 @@ Resources:
       UsernameConfiguration:
         CaseSensitive: false
       AdminCreateUserConfig:
-        AllowAdminCreateUserOnly: false
+        AllowAdminCreateUserOnly: true
         InviteMessageTemplate:
           EmailSubject: "[PclusterManager] Welcome to Pcluster Manager, please verify your account."
           EmailMessage: "Thanks for installing PclusterManager on your AWS account. The following user has been created: {username}<br /><br />Please use this temporary password to login to your account: {####}"


### PR DESCRIPTION
## Description

Creates a new role to execute e2e tests, and setup credentials for the test user with SecretsManager.
E2E credentials are available under the env variables `E2E_TEST1_EMAIL` and `E2E_TEST1_PASSWORD`.

## Changes
- mimic existing IAM roles to let Github download test user secrets
- don't let external users sign up to the portal: users must be created either on the console or inside the portal directly

<!-- List of relevant changes introduced -->

## How Has This Been Tested?

Manually run the workflow https://github.com/aws-samples/pcluster-manager/actions/runs/3658679383

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
