### PR TITLE
Refactor ILogger to remove generic type signature

### DIFF
--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -12,7 +12,7 @@ import {useLogger} from '../logger/LoggerProvider'
 
 interface ErrorBoundaryProps {
   t: TFunction
-  logger: ILogger<any>
+  logger: ILogger
   windowObject?: Window
   children?: ReactNode
 }

--- a/frontend/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/frontend/src/components/__tests__/ErrorBoundary.test.tsx
@@ -22,10 +22,10 @@ const MockProviders = (props: any) => (
 )
 
 describe('Given an ErrorBoundary component', () => {
-  let mockLogger: MockProxy<ILogger<any>>
+  let mockLogger: MockProxy<ILogger>
 
   beforeEach(() => {
-    mockLogger = mock<ILogger<any>>()
+    mockLogger = mock<ILogger>()
   })
 
   describe('when there is an error in a Child component', () => {

--- a/frontend/src/logger/ConsoleLogger.ts
+++ b/frontend/src/logger/ConsoleLogger.ts
@@ -1,6 +1,6 @@
 import {ILogger} from './ILogger'
 
-export class ConsoleLogger implements ILogger<void> {
+export class ConsoleLogger implements ILogger {
   critical(message: string, extra?: Record<string, unknown>): void {
     console.error(this.formatMessage(message, extra))
   }

--- a/frontend/src/logger/ILogger.ts
+++ b/frontend/src/logger/ILogger.ts
@@ -1,11 +1,11 @@
-export interface ILogger<T> {
-  info(message: string, extra?: Record<string, unknown>): T
+export interface ILogger {
+  info(message: string, extra?: Record<string, unknown>): void
 
-  warning(message: string, extra?: Record<string, unknown>): T
+  warning(message: string, extra?: Record<string, unknown>): void
 
-  debug(message: string, extra?: Record<string, unknown>): T
+  debug(message: string, extra?: Record<string, unknown>): void
 
-  error(message: string, extra?: Record<string, unknown>): T
+  error(message: string, extra?: Record<string, unknown>): void
 
-  critical(message: string, extra?: Record<string, unknown>): T
+  critical(message: string, extra?: Record<string, unknown>): void
 }

--- a/frontend/src/logger/LoggerProvider.tsx
+++ b/frontend/src/logger/LoggerProvider.tsx
@@ -7,21 +7,21 @@ import {ConsoleLogger} from './ConsoleLogger'
 import {Logger} from './RemoteLogger'
 
 const consoleLogger = new ConsoleLogger()
-const LoggerContext = React.createContext<ILogger<any>>(consoleLogger)
+const LoggerContext = React.createContext<ILogger>(consoleLogger)
 
-export function useLogger(): ILogger<any> {
+export function useLogger(): ILogger {
   return useContext(LoggerContext)
 }
 
 const appConfigPath = ['app', 'appConfig']
 
-function makeLogger(appConfig?: AppConfig): ILogger<any> {
+function makeLogger(appConfig?: AppConfig): ILogger {
   if (process.env.NODE_ENV !== 'production') return consoleLogger
   return new Logger(executeRequest, appConfig)
 }
 
 export function LoggerProvider(props: any) {
-  const [logger, setLogger] = React.useState<ILogger<any>>(consoleLogger)
+  const [logger, setLogger] = React.useState<ILogger>(consoleLogger)
   const appConfig: AppConfig | undefined = useState(appConfigPath)
 
   React.useEffect(() => {

--- a/frontend/src/logger/RemoteLogger.ts
+++ b/frontend/src/logger/RemoteLogger.ts
@@ -24,7 +24,7 @@ interface PostLogError {
 
 type PostLogSuccess = {}
 
-export class Logger implements ILogger<Promise<any>> {
+export class Logger implements ILogger {
   private readonly executeRequest
   private appConfig: AppConfig | undefined
 


### PR DESCRIPTION
## Description

This PR makes it so the `ILogger` interface can be used without specifying the type of Logger is going to be used under the hood

## Changes

- remove generic type signature from `ILogger`

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
