### PR TITLE
Fix EBS st1 volume type

### DIFF
--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -759,7 +759,7 @@ function RootVolume({basePath, errorsPath}: any) {
   )
   const rootVolumeType = useState(rootVolumeTypePath)
   const defaultRootVolumeType = 'gp3'
-  const volumeTypes = ['gp3', 'gp2', 'io1', 'io2', 'sc1', 'stl', 'standard']
+  const volumeTypes = ['gp3', 'gp2', 'io1', 'io2', 'sc1', 'st1', 'standard']
 
   const rootVolumeErrors = useState([...errorsPath, 'rootVolume'])
   const editing = useState(['app', 'wizard', 'editing'])

--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -569,7 +569,7 @@ function EbsSettings({index}: any) {
   const {t} = useTranslation()
   const ebsPath = [...storagePath, index, 'EbsSettings']
   const volumeTypePath = [...ebsPath, 'VolumeType']
-  const volumeTypes = ['gp3', 'gp2', 'io1', 'io2', 'sc1', 'stl', 'standard']
+  const volumeTypes = ['gp3', 'gp2', 'io1', 'io2', 'sc1', 'st1', 'standard']
   const defaultVolumeType = 'gp3'
   const volumeSizePath = [...ebsPath, 'Size']
   const encryptedPath = [...ebsPath, 'Encrypted']


### PR DESCRIPTION
## Description

`st1` volumes have a typo (`stl`) preventing the cluster creation.

## How Has This Been Tested?

Created a cluster with an EBS volume of type `st1`: the error about `stl` is now gone

## PR Quality Checklist
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
