### PR TITLE
Don't display SSH Command if HeadNode ip not available

### DIFF
--- a/frontend/src/old-pages/Clusters/Properties.tsx
+++ b/frontend/src/old-pages/Clusters/Properties.tsx
@@ -91,6 +91,7 @@ export default function ClusterProperties() {
       <Container header={<Header variant="h3">Properties</Header>}>
         <ColumnLayout columns={3} variant="text-grid">
           <SpaceBetween size="l">
+          { headNode && headNode.publicIpAddress && (
             <ValueWithLabel label={t('cluster.properties.sshcommand.label')}>
               <div className="custom-wrapping">
                 <Box margin={{right: 'xxs'}} display="inline-block">
@@ -131,6 +132,7 @@ export default function ClusterProperties() {
                 </HelpTooltip>
               </div>
             </ValueWithLabel>
+            )}
             <ValueWithLabel label="clusterConfiguration">
               <Button
                 disabled={cluster.clusterStatus === ClusterStatus.CreateFailed}


### PR DESCRIPTION
Signed-off-by: Sean Smith <seaam@amazon.com>

## Description

Fixes an issue where for a cluster in `CREATE_IN_PROGRESS` or `DELETING` crashes since the `HeadNode.publicIP isn't available.

## Changes

<!-- List of relevant changes introduced -->

## Changelog entry

<!-- A sentence to be added to the next release's changelog that captures the changes in this PR -->

## How Has This Been Tested?

<!-- The tests you ran to verify your changes -->

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
