### PR TITLE
Add first e2e test

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,15 +1,14 @@
 {
-  "name": "pcluster-manager",
+  "name": "e2e",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "pcluster-manager",
-      "version": "1.0.0",
-      "license": "ISC",
+      "name": "e2e",
       "devDependencies": {
-        "@playwright/test": "^1.28.1"
+        "@playwright/test": "^1.28.1",
+        "@types/node": "^18.11.13"
       }
     },
     "node_modules/@playwright/test": {
@@ -29,9 +28,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.11.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.11.tgz",
-      "integrity": "sha512-KJ021B1nlQUBLopzZmPBVuGU9un7WJd/W4ya7Ih02B4Uwky5Nja0yGYav2EfYIk0RR2Q9oVhf60S2XR1BCWJ2g==",
+      "version": "18.11.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.13.tgz",
+      "integrity": "sha512-IASpMGVcWpUsx5xBOrxMj7Bl8lqfuTY7FKAnPmu5cHkfQVWF8GulWS1jbRqA934qZL35xh5xN/+Xe/i26Bod4w==",
       "dev": true
     },
     "node_modules/playwright-core": {
@@ -59,9 +58,9 @@
       }
     },
     "@types/node": {
-      "version": "18.11.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.11.tgz",
-      "integrity": "sha512-KJ021B1nlQUBLopzZmPBVuGU9un7WJd/W4ya7Ih02B4Uwky5Nja0yGYav2EfYIk0RR2Q9oVhf60S2XR1BCWJ2g==",
+      "version": "18.11.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.13.tgz",
+      "integrity": "sha512-IASpMGVcWpUsx5xBOrxMj7Bl8lqfuTY7FKAnPmu5cHkfQVWF8GulWS1jbRqA934qZL35xh5xN/+Xe/i26Bod4w==",
       "dev": true
     },
     "playwright-core": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -4,6 +4,7 @@
     "e2e:test": "playwright test"
   },
   "devDependencies": {
-    "@playwright/test": "^1.28.1"
+    "@playwright/test": "^1.28.1",
+    "@types/node": "^18.11.13"
   }
 }

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -7,13 +7,13 @@ import { devices } from '@playwright/test';
 const config: PlaywrightTestConfig = {
   testDir: './specs',
   /* Maximum time one test can run for. */
-  timeout: 30 * 1000,
+  timeout: 180 * 1000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: 5000
+    timeout: 10000
   },
   /* Run tests in files in parallel */
   fullyParallel: true,

--- a/e2e/specs/example.spec.ts
+++ b/e2e/specs/example.spec.ts
@@ -1,5 +1,0 @@
-import { test } from '@playwright/test';
-
-test('visits page', async ({ page }) => {
-  await page.goto('https://0l0pqd58m8.execute-api.eu-west-1.amazonaws.com/');
-});

--- a/e2e/specs/wizard.spec.ts
+++ b/e2e/specs/wizard.spec.ts
@@ -1,0 +1,39 @@
+
+import { expect, test } from '@playwright/test';
+
+const E2E_URL = 'https://080pcqu70j.execute-api.eu-west-1.amazonaws.com'
+
+test.describe('Given an endpoint where ParallelCluster Manager is deployed', () => {
+  test('a user should be able to login, navigate till the end of the cluster creation wizard, and perform a dry-run successfully', async ({ page }) => {
+    await page.goto(E2E_URL);
+    await page.getByRole('textbox', { name: 'name@host.com' }).click();
+    await page.getByRole('textbox', { name: 'name@host.com' }).fill(process.env.E2E_TEST1_EMAIL!);
+    await page.getByRole('textbox', { name: 'name@host.com' }).press('Tab');
+    await page.getByRole('textbox', { name: 'Password' }).fill(process.env.E2E_TEST1_PASSWORD!);
+    await page.getByRole('button', { name: 'submit' }).click();
+  
+    await page.getByRole('button', { name: 'Create Cluster' }).click();
+    await expect(page.getByRole('heading', { name: 'Cluster Name' })).toBeVisible()
+    await page.getByRole('textbox', { name: 'Enter your cluster name' }).fill("testcluster");
+    await page.getByRole('button', { name: 'Next' }).click();
+    
+    await expect(page.getByRole('heading', { name: 'Cluster Properties' })).toBeVisible()
+    await page.getByRole('button', { name: 'Select a VPC' }).click();
+    await page.getByText(/vpc-.*/).first().click();
+    await page.getByRole('button', { name: 'Next' }).click();
+    
+    await expect(page.getByRole('heading', { name: 'Head Node Properties' })).toBeVisible()
+    await page.getByRole('button', { name: 'Next' }).click();
+  
+    await expect(page.getByRole('heading', { name: 'Storage Properties' })).toBeVisible()
+    await page.getByRole('button', { name: 'Next' }).click();
+  
+    await expect(page.getByRole('heading', { name: 'Queues' })).toBeVisible()
+    await page.getByRole('button', { name: 'Next' }).click();
+  
+    await expect(page.getByRole('heading', { name: 'Cluster Configuration' })).toBeVisible()
+    await page.getByRole('button', { name: 'Dry Run' }).click();
+  
+    await expect(page.getByText('Request would have succeeded, but DryRun flag is set.')).toBeVisible()
+  });
+})


### PR DESCRIPTION
## Description

Following https://github.com/aws-samples/pcluster-manager/pull/387 and https://github.com/aws-samples/pcluster-manager/pull/398, this PR introduces the first e2e test in ParallelCluster Manager. The test performs the following steps:

1. Log into the portal using e2e test account
2. Click on `Create Cluster` button
3. Navigate through the wizard leaving all default options (selecting first VPC only)
4. Perform a dry-run and check that it doesn't fail

Future improvements:
* Retrieve demo environment public URL through Cloudformation
* Leverage Playwright [signed in state](https://playwright.dev/docs/auth) to isolate the login phase. In this way we can log in only once and then skip the log in step for all of the subsequent tests.

## Changelog entry

* Added first e2e test

## How Has This Been Tested?

* Manually triggered `e2e` workflow on `ŧsscarla/e2e` branch

## References

* https://playwright.dev/

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
