### PR TITLE
Log frontend API calls for debugging purposes

### DIFF
--- a/frontend/src/http/__tests__/httpLogs.test.ts
+++ b/frontend/src/http/__tests__/httpLogs.test.ts
@@ -1,0 +1,81 @@
+import axios, {AxiosInstance} from 'axios'
+import {mock} from 'jest-mock-extended'
+import {ILogger} from '../../logger/ILogger'
+import {enableHttpLogs} from '../httpLogs'
+
+describe('Given a logger and an axios instance', () => {
+  let axiosInstance: AxiosInstance
+  let logger: ILogger
+
+  beforeEach(() => {
+    axiosInstance = axios.create()
+    logger = mock<ILogger>()
+    enableHttpLogs(axiosInstance, logger)
+  })
+
+  describe('when a log request is started or received', () => {
+    it('it should not be logged', () => {
+      const requestHandler = (axiosInstance as any).interceptors.request
+        .handlers[0].fulfilled
+      requestHandler({
+        url: '/logs',
+      })
+
+      expect(logger.info).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when a generic request is started', () => {
+    it('should be logged', () => {
+      const requestHandler = (axiosInstance as any).interceptors.request
+        .handlers[0].fulfilled
+      requestHandler({
+        url: '/clusters',
+      })
+
+      expect(logger.info).toHaveBeenCalledWith(expect.any(String), {
+        url: '/clusters',
+      })
+    })
+  })
+
+  describe('when a generic request is successful', () => {
+    it('should be logged', () => {
+      const responseHandler = (axiosInstance as any).interceptors.response
+        .handlers[0].fulfilled
+      responseHandler({
+        config: {
+          url: '/clusters',
+        },
+        status: 200,
+      })
+
+      expect(logger.info).toHaveBeenCalledWith(expect.any(String), {
+        url: '/clusters',
+        statusCode: 200,
+      })
+    })
+  })
+
+  describe('when a generic request is not successful', () => {
+    it('should be logged', () => {
+      const responseHandler = (axiosInstance as any).interceptors.response
+        .handlers[0].rejected
+      try {
+        responseHandler({
+          config: {
+            url: '/clusters',
+          },
+          response: {
+            status: 401,
+          },
+        })
+      } catch (error) {
+        expect(logger.error).toHaveBeenCalledWith(expect.any(String), {
+          url: '/clusters',
+          statusCode: 401,
+        })
+      }
+    })
+  })
+})

--- a/frontend/src/http/__tests__/httpLogs.test.ts
+++ b/frontend/src/http/__tests__/httpLogs.test.ts
@@ -17,9 +17,30 @@ describe('Given a logger and an axios instance', () => {
     it('it should not be logged', () => {
       const requestHandler = (axiosInstance as any).interceptors.request
         .handlers[0].fulfilled
+      const responseHandler = (axiosInstance as any).interceptors.response
+        .handlers[0].fulfilled
+      const responseHandlerRejected = (axiosInstance as any).interceptors
+        .response.handlers[0].rejected
+
       requestHandler({
         url: '/logs',
       })
+      responseHandler({
+        config: {
+          url: '/logs',
+        },
+        status: 200,
+      })
+      try {
+        responseHandlerRejected({
+          config: {
+            url: '/logs',
+          },
+          response: {
+            status: 401,
+          },
+        })
+      } catch {}
 
       expect(logger.info).not.toHaveBeenCalled()
     })

--- a/frontend/src/http/httpLogs.ts
+++ b/frontend/src/http/httpLogs.ts
@@ -1,0 +1,43 @@
+import {AxiosError, AxiosInstance} from 'axios'
+import {ILogger} from '../logger/ILogger'
+
+export const enableHttpLogs = (
+  axiosInstance: AxiosInstance,
+  logger: ILogger,
+) => {
+  const requestInterceptor = axiosInstance.interceptors.request.use(config => {
+    if (!isLogEndpoint(config.url)) {
+      logger.info('HTTP request started', {
+        url: config.url,
+      })
+    }
+    return config
+  })
+  const responseInterceptor = axiosInstance.interceptors.response.use(
+    response => {
+      if (!isLogEndpoint(response.config?.url)) {
+        logger.info('HTTP response received', {
+          url: response.config?.url,
+          statusCode: response.status,
+        })
+      }
+      return response
+    },
+    (error: AxiosError) => {
+      if (!isLogEndpoint(error.config?.url)) {
+        logger.info('HTTP response received', {
+          url: error.config?.url,
+          statusCode: error.response?.status,
+        })
+      }
+      return Promise.reject(error)
+    },
+  )
+  return () => {
+    axiosInstance.interceptors.request.eject(requestInterceptor)
+    axiosInstance.interceptors.response.eject(responseInterceptor)
+  }
+}
+
+const isLogEndpoint = (url: string | undefined) =>
+  url && url.indexOf('/logs') > -1

--- a/frontend/src/http/httpLogs.ts
+++ b/frontend/src/http/httpLogs.ts
@@ -25,12 +25,12 @@ export const enableHttpLogs = (
     },
     (error: AxiosError) => {
       if (!isLogEndpoint(error.config?.url)) {
-        logger.info('HTTP response received', {
+        logger.error('HTTP response received', {
           url: error.config?.url,
           statusCode: error.response?.status,
         })
       }
-      return Promise.reject(error)
+      throw error
     },
   )
   return () => {

--- a/frontend/src/logger/LoggerProvider.tsx
+++ b/frontend/src/logger/LoggerProvider.tsx
@@ -1,34 +1,21 @@
 import React, {useContext} from 'react'
 import {ILogger} from './ILogger'
-import {AppConfig} from '../app-config/types'
-import {useState} from '../store'
 import {executeRequest} from '../http/executeRequest'
 import {ConsoleLogger} from './ConsoleLogger'
 import {Logger} from './RemoteLogger'
 
-const consoleLogger = new ConsoleLogger()
-const LoggerContext = React.createContext<ILogger>(consoleLogger)
+export const logger: ILogger =
+  process.env.NODE_ENV !== 'production'
+    ? new ConsoleLogger()
+    : new Logger(executeRequest)
+
+const LoggerContext = React.createContext<ILogger>(logger)
 
 export function useLogger(): ILogger {
   return useContext(LoggerContext)
 }
 
-const appConfigPath = ['app', 'appConfig']
-
-function makeLogger(appConfig?: AppConfig): ILogger {
-  if (process.env.NODE_ENV !== 'production') return consoleLogger
-  return new Logger(executeRequest, appConfig)
-}
-
 export function LoggerProvider(props: any) {
-  const [logger, setLogger] = React.useState<ILogger>(consoleLogger)
-  const appConfig: AppConfig | undefined = useState(appConfigPath)
-
-  React.useEffect(() => {
-    const _logger = makeLogger(appConfig)
-    setLogger(_logger)
-  }, [appConfig, setLogger])
-
   return (
     <LoggerContext.Provider value={logger}>
       {props.children}

--- a/frontend/src/logger/RemoteLogger.ts
+++ b/frontend/src/logger/RemoteLogger.ts
@@ -1,4 +1,3 @@
-import {AppConfig} from '../app-config/types'
 import {HTTPMethod} from '../http/executeRequest'
 import {AxiosError} from 'axios'
 import {ILogger} from './ILogger'
@@ -26,19 +25,15 @@ type PostLogSuccess = {}
 
 export class Logger implements ILogger {
   private readonly executeRequest
-  private appConfig: AppConfig | undefined
 
   constructor(
     executeRequest: (
       method: HTTPMethod,
       url: string,
       body?: any,
-      _appConfig?: AppConfig,
     ) => Promise<any>,
-    appConfig?: AppConfig,
   ) {
     this.executeRequest = executeRequest
-    this.appConfig = appConfig
   }
 
   private log(
@@ -47,7 +42,7 @@ export class Logger implements ILogger {
     extra?: Record<string, unknown>,
   ): Promise<PostLogSuccess> {
     const logEntry = this.buildMessage(logLevel, message, extra)
-    return this.executeRequest('post', '/logs', logEntry, this.appConfig).catch(
+    return this.executeRequest('post', '/logs', logEntry).catch(
       (err: AxiosError<PostLogError>) =>
         console.warn('Unable to push log entry'),
     )

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -22,7 +22,9 @@ import ErrorBoundary from '../components/ErrorBoundary'
 
 import i18n from '../i18n'
 import {store} from '../store'
-import {LoggerProvider} from '../logger/LoggerProvider'
+import {logger, LoggerProvider} from '../logger/LoggerProvider'
+import {enableHttpLogs} from '../http/httpLogs'
+import {axiosInstance} from '../http/executeRequest'
 
 const queryClient = new QueryClient()
 declare global {
@@ -31,6 +33,8 @@ declare global {
     editor: any
   }
 }
+
+enableHttpLogs(axiosInstance, logger)
 
 function App({Component, pageProps}: AppProps) {
   const onAceLoad = useCallback(() => {


### PR DESCRIPTION
## Description

Log every request and response made with the frontend to ease troubleshooting.

## Changes

- rework `RemoteLogger`, removing `AppConfig` from the constructor: there's no need to handle 401 and 403 errors inside log calls
- hook into Axios interceptors to log requests and responses

## How Has This Been Tested?

Run the frontend locally and verified that `/logs` endpoint is called correctly
```
127.0.0.1 - - [12/Dec/2022 16:26:33] "GET /api?path=/v3/clusters HTTP/1.1" 200 -
2022-12-12 16:26:33,100 - INFO - {'url': 'api?path=/v3/clusters', 'statusCode': 200, 'source': 'frontend', 'message': 'HTTP response received'}
```

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [x] I added tests to new or existing code
- [x] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [x] I checked that clusters are listed correctly

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
