### PR TITLE
Configure the Ace library to run in CSP-compliant mode

### DIFF
--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -39,6 +39,7 @@ function App({Component, pageProps}: AppProps) {
     window.ace.config.set('loadWorkerFromBlob', false)
     window.ace.config.set('showFoldWidgets', false)
     window.ace.config.set('showPrintMargin', false)
+    window.ace.config.set('useStrictCSP', true)
   }, [])
 
   return (


### PR DESCRIPTION
## Description

The CloudScape `Code editor` component relies on the Ace library, which receives it as a property. In order to make it CSP-compliant, as specified in the [developer guidelines](https://cloudscape.design/components/code-editor/?tabId=api), we need to set the following configuration parameter to `true`:

```
window.ace.config.set('useStrictCSP', true)
```
This will result in avoiding to include some `<style>` tags into the `<head>` tag, as pointed out in https://github.com/ajaxorg/ace/issues/3260. The two attached images shows the difference of having the property unset / set to `true`.

## How Has This Been Tested?

* Run PCM locally and manually inspected through developer tools

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
![image (57)](https://user-images.githubusercontent.com/25930133/207103370-dc0ea79c-6c62-44f9-89dc-b6ee00f4da03.png)
![image (56)](https://user-images.githubusercontent.com/25930133/207103374-195fb101-c047-45e4-a83a-ad494cefb934.png)
