### PR TITLE
Remove Lambda powertools

### DIFF
--- a/Dockerfile.awslambda
+++ b/Dockerfile.awslambda
@@ -4,8 +4,7 @@ COPY --from=frontend-awslambda /app/build ${LAMBDA_TASK_ROOT}/frontend/public
 
 COPY resources/attributions/docker-attributions.txt license.txt
 COPY requirements.txt  .
-RUN  pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}" && \
-     pip3 install aws-lambda-powertools==1.31.1
+RUN  pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
 
 COPY app.py ${LAMBDA_TASK_ROOT}
 COPY api ${LAMBDA_TASK_ROOT}/api


### PR DESCRIPTION
## Description

Removes Lambda powertools from the codebase as it's not strictly needed at this moment. Moreover, the lib raises some Xray issues on Lambda startup and it's one major version behind.

## How Has This Been Tested?

Updated an environment manually and verify that:
- Xray errors have disappeared
- logging is working the same

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
