### PR TITLE
Change e2e and documentation triggers

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -1,8 +1,14 @@
 name: e2e
-on: workflow_dispatch
+
+on:
+  push:
+    branches:
+      - main
+
 permissions:
   id-token: write
   contents: read
+
 jobs:
   e2e-tests:
     timeout-minutes: 60

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,6 +1,7 @@
 name: Deploy public documentation
 
 on:
+  workflow_dispatch:
   push:
     tags: '*'
 


### PR DESCRIPTION
## Description

Runs e2e tests after each PRs so we can get used to Playwright.
Adds also the ability to publish documentation on-demand, without waiting for a release.

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
