### PR TITLE
Fetch and send CSRF token on every request

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -8,6 +8,9 @@
       "officialImages": "Official Images",
       "users": "Users",
       "viewLicense": "View License"
+    },
+    "errors": {
+      "csrfError": "An unexpected error occurred. Please reload the page and try again"
     }
   },
   "errorBoundary": {

--- a/frontend/src/auth/__tests__/getCsrfToken.test.ts
+++ b/frontend/src/auth/__tests__/getCsrfToken.test.ts
@@ -24,11 +24,11 @@ describe('given a function to fetch the CSRF token', () => {
     describe('when the token is retrieved successfully', () => {
       beforeEach(() => {
         const mockResponse = {
-          token: 'some-token',
+          csrf_token: 'some-token',
         }
         mockAxiosInstance.get.mockResolvedValueOnce({data: mockResponse})
       })
-      it('should map the received configuration to the known AppConfig', async () => {
+      it('should return the token', async () => {
         const token = await getCsrfToken(mockAxiosInstance)
         expect(token).toBe('some-token')
       })

--- a/frontend/src/auth/__tests__/getCsrfToken.test.ts
+++ b/frontend/src/auth/__tests__/getCsrfToken.test.ts
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {AxiosInstance} from 'axios'
+import {mock, MockProxy} from 'jest-mock-extended'
+import {getCsrfToken} from '../getCsrfToken'
+
+describe('given a function to fetch the CSRF token', () => {
+  describe('and an axios instance', () => {
+    let mockGet: jest.Mock
+    let mockAxiosInstance: MockProxy<AxiosInstance>
+    beforeEach(() => {
+      mockGet = jest.fn()
+      mockAxiosInstance = mock<AxiosInstance>()
+    })
+
+    describe('when the token is retrieved successfully', () => {
+      beforeEach(() => {
+        const mockResponse = {
+          token: 'some-token',
+        }
+        mockAxiosInstance.get.mockResolvedValueOnce({data: mockResponse})
+      })
+      it('should map the received configuration to the known AppConfig', async () => {
+        const token = await getCsrfToken(mockAxiosInstance)
+        expect(token).toBe('some-token')
+      })
+    })
+  })
+})

--- a/frontend/src/auth/getCsrfToken.ts
+++ b/frontend/src/auth/getCsrfToken.ts
@@ -13,6 +13,6 @@ import {AxiosInstance} from 'axios'
 export async function getCsrfToken(
   axiosInstance: AxiosInstance,
 ): Promise<string> {
-  const {data} = await axiosInstance.get('/csrf_token')
-  return data.token
+  const {data} = await axiosInstance.get('/csrf')
+  return data.csrf_token
 }

--- a/frontend/src/auth/getCsrfToken.ts
+++ b/frontend/src/auth/getCsrfToken.ts
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {AxiosInstance} from 'axios'
+
+export async function getCsrfToken(
+  axiosInstance: AxiosInstance,
+): Promise<string> {
+  const {data} = await axiosInstance.get('/csrf_token')
+  return data.token
+}

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -17,6 +17,7 @@ import {LoadInitialState} from '../model'
 // UI Elements
 import TopNavigation from '@cloudscape-design/components/top-navigation'
 import {useQueryClient} from 'react-query'
+import {useLogger} from '../logger/LoggerProvider'
 
 function regions(selected: any) {
   let supportedRegions = [
@@ -89,6 +90,7 @@ function regions(selected: any) {
 export default function Topbar() {
   let username = useState(['identity', 'attributes', 'email'])
   const queryClient = useQueryClient()
+  const logger = useLogger()
 
   const defaultRegion = useState(['aws', 'region']) || 'DEFAULT'
   const region = useState(['app', 'selectedRegion']) || defaultRegion
@@ -100,7 +102,7 @@ export default function Topbar() {
   const selectRegion = (region: any) => {
     let newRegion = region.detail.id
     setState(['app', 'selectedRegion'], newRegion)
-    LoadInitialState()
+    LoadInitialState(logger)
     queryClient.invalidateQueries()
   }
 

--- a/frontend/src/http/__tests__/setCsrfTokenHeader.test.ts
+++ b/frontend/src/http/__tests__/setCsrfTokenHeader.test.ts
@@ -17,18 +17,14 @@ describe('given a function to set the X-CSRF-Token header ', () => {
     let mockAxiosInstance: MockProxy<AxiosInstance>
     beforeEach(() => {
       mockAxiosInstance = mock<AxiosInstance>()
+      mockAxiosInstance.defaults.headers = {}
     })
 
-    describe('when the token is retrieved successfully', () => {
-      beforeEach(() => {
-        mockAxiosInstance.defaults.headers = {}
-      })
-      it('should map the received configuration to the known AppConfig', async () => {
-        setCsrfTokenHeader(mockAxiosInstance, 'some-token')
-        expect(mockAxiosInstance.defaults.headers['X-CSRF-Token']).toBe(
-          'some-token',
-        )
-      })
+    it('should set the X-CSRF-Token header', async () => {
+      setCsrfTokenHeader(mockAxiosInstance, 'some-token')
+      expect(mockAxiosInstance.defaults.headers['X-CSRF-Token']).toBe(
+        'some-token',
+      )
     })
   })
 })

--- a/frontend/src/http/__tests__/setCsrfTokenHeader.test.ts
+++ b/frontend/src/http/__tests__/setCsrfTokenHeader.test.ts
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {AxiosInstance} from 'axios'
+import {mock, MockProxy} from 'jest-mock-extended'
+import {setCsrfTokenHeader} from '../setCsrfTokenHeader'
+
+describe('given a function to set the X-CSRF-Token header ', () => {
+  describe('and an axios instance', () => {
+    let mockAxiosInstance: MockProxy<AxiosInstance>
+    beforeEach(() => {
+      mockAxiosInstance = mock<AxiosInstance>()
+    })
+
+    describe('when the token is retrieved successfully', () => {
+      beforeEach(() => {
+        mockAxiosInstance.defaults.headers = {}
+      })
+      it('should map the received configuration to the known AppConfig', async () => {
+        setCsrfTokenHeader(mockAxiosInstance, 'some-token')
+        expect(mockAxiosInstance.defaults.headers['X-CSRF-Token']).toBe(
+          'some-token',
+        )
+      })
+    })
+  })
+})

--- a/frontend/src/http/setCsrfTokenHeader.ts
+++ b/frontend/src/http/setCsrfTokenHeader.ts
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {AxiosInstance} from 'axios'
+
+export function setCsrfTokenHeader(
+  axiosInstance: AxiosInstance,
+  token: string,
+) {
+  axiosInstance.defaults.headers['X-CSRF-Token'] = token
+}

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -16,13 +16,15 @@ import {
   setState,
   updateState,
 } from './store'
-import {USER_ROLES_CLAIM} from './auth/constants'
 import {generateRandomId} from './util'
 
 // UI Elements
 import {AppConfig} from './app-config/types'
 import {getAppConfig} from './app-config'
 import {axiosInstance, executeRequest, HTTPMethod} from './http/executeRequest'
+import {getCsrfToken} from './auth/getCsrfToken'
+import {ILogger} from './logger/ILogger'
+import {setCsrfTokenHeader} from './http/setCsrfTokenHeader'
 
 // Types
 type Callback = (arg?: any) => void
@@ -956,10 +958,23 @@ async function GetAppConfig() {
   }
 }
 
-async function LoadInitialState() {
+async function LoadCsrfToken(logger: ILogger): Promise<string> {
+  try {
+    const token = await getCsrfToken(axiosInstance)
+    setCsrfTokenHeader(axiosInstance, token)
+    logger.info(`Set X-CSRF-Token header to ${token}`)
+    return token
+  } catch (error) {
+    logger.error('Could not fetch CSRF token')
+    throw error
+  }
+}
+
+async function LoadInitialState(logger: ILogger) {
   const region = getState(['app', 'selectedRegion'])
   clearState(['app', 'aws'])
   clearAllState()
+  await LoadCsrfToken(logger)
   GetVersion()
   await GetAppConfig()
   GetIdentity(_ => {

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -25,6 +25,7 @@ import {axiosInstance, executeRequest, HTTPMethod} from './http/executeRequest'
 import {getCsrfToken} from './auth/getCsrfToken'
 import {ILogger} from './logger/ILogger'
 import {setCsrfTokenHeader} from './http/setCsrfTokenHeader'
+import i18n from './i18n'
 
 // Types
 type Callback = (arg?: any) => void
@@ -958,7 +959,7 @@ async function GetAppConfig() {
   }
 }
 
-async function LoadCsrfToken(logger: ILogger): Promise<string> {
+async function LoadCsrfToken(logger: ILogger): Promise<string | null> {
   try {
     const token = await getCsrfToken(axiosInstance)
     setCsrfTokenHeader(axiosInstance, token)
@@ -966,7 +967,8 @@ async function LoadCsrfToken(logger: ILogger): Promise<string> {
     return token
   } catch (error) {
     logger.error('Could not fetch CSRF token')
-    throw error
+    notify(i18n.t('global.errors.csrfError'), 'error')
+    return null
   }
 }
 

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -25,13 +25,15 @@ import Home from '../old-pages/Home/Home'
 
 // Components
 import Loading from '../components/Loading'
+import {useLogger} from '../logger/LoggerProvider'
 
 export default function App() {
   const identity = useState(['identity'])
+  const logger = useLogger()
 
   React.useEffect(() => {
-    LoadInitialState()
-  }, [])
+    LoadInitialState(logger)
+  }, [logger])
 
   return (
     <>


### PR DESCRIPTION
## Description

This PR implements the Double Submit Cookie strategy on the frontend to prevent CSRF attacks.

## Changes

- fetch token via `GET /csrf` on application start
- set the `X-CSRF-Token` header for every subsequent request

## How Has This Been Tested?

- unit tests
- manually

## References

- [Double Submit Cookie](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie)

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [x] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
