### PR TITLE
Fix wizard.spec.ts test to handle the case of an empty cluster list

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -28,7 +28,7 @@ const config: PlaywrightTestConfig = {
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
-    actionTimeout: 0,
+    actionTimeout: 15000,
     /* Base URL to use in actions like `await page.goto('/')`. */
     // baseURL: 'http://localhost:3000',
 

--- a/e2e/specs/wizard.spec.ts
+++ b/e2e/specs/wizard.spec.ts
@@ -12,7 +12,7 @@ test.describe('Given an endpoint where ParallelCluster Manager is deployed', () 
     await page.getByRole('textbox', { name: 'Password' }).fill(process.env.E2E_TEST1_PASSWORD!);
     await page.getByRole('button', { name: 'submit' }).click();
   
-    await page.getByRole('button', { name: 'Create Cluster' }).click();
+    await page.getByRole('button', { name: 'Create Cluster' }).first().click();
     await expect(page.getByRole('heading', { name: 'Cluster Name' })).toBeVisible()
     await page.getByRole('textbox', { name: 'Enter your cluster name' }).fill("testcluster");
     await page.getByRole('button', { name: 'Next' }).click();


### PR DESCRIPTION
## Description

The e2e test `wizard.spec.ts` is failing due to the fact that in case the cluster list is empty, two buttons named "Create Cluster" are shown, which leads the `getByRole` locator to resolve to two elements.

This PR aims to solve the disambiguation, by calling `first()` method on the locator before the `click()` operation takes place.

Furthermore, the `actionTimeout` parameter in Playwright config has been increased from 0 to 15s in order to avoid sporadic failures.

## How Has This Been Tested?

* Run `npx playwright test` locally targeting demo environment
   * Tested with an empty list
   * Tested with a list with 1 cluster

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
