### PR TITLE
Log page navigations and wizard navigations

### DIFF
--- a/frontend/src/navigation/useLocationChangeLog.ts
+++ b/frontend/src/navigation/useLocationChangeLog.ts
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {useEffect} from 'react'
+import {useLocation} from 'react-router-dom'
+import {useLogger} from '../logger/LoggerProvider'
+
+export function useLocationChangeLog() {
+  const logger = useLogger()
+  const location = useLocation()
+
+  useEffect(() => {
+    logger.info('Location changed', {
+      to: location.pathname,
+    })
+  }, [location, logger])
+}

--- a/frontend/src/navigation/useWizardSectionChangeLog.ts
+++ b/frontend/src/navigation/useWizardSectionChangeLog.ts
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {useEffect} from 'react'
+import {useLogger} from '../logger/LoggerProvider'
+import {useState} from '../store'
+
+export function useWizardSectionChangeLog() {
+  const page = useState(['app', 'wizard', 'page'])
+  const logger = useLogger()
+
+  useEffect(() => {
+    if (!page) return
+
+    logger.info('Wizard section changed:', {
+      to: page,
+    })
+  }, [logger, page])
+}

--- a/frontend/src/old-pages/Configure/Configure.tsx
+++ b/frontend/src/old-pages/Configure/Configure.tsx
@@ -53,6 +53,7 @@ import Loading from '../../components/Loading'
 // Icons
 import {useTranslation} from 'react-i18next'
 import Layout from '../Layout'
+import {useWizardSectionChangeLog} from '../../navigation/useWizardSectionChangeLog'
 
 function wizardShow(navigate: any) {
   const editing = getState(['app', 'wizard', 'editing'])
@@ -64,7 +65,6 @@ function wizardShow(navigate: any) {
     setState(['app', 'wizard', 'editing'], false)
     setState(['app', 'wizard', 'page'], 'source')
   }
-  console.log('page: ', page)
   if (!page) setState(['app', 'wizard', 'page'], 'source')
   navigate('/configure')
 }
@@ -297,6 +297,8 @@ function Configure() {
     window.addEventListener('keydown', close)
     return () => window.removeEventListener('keydown', close)
   }, [clearStateAndCloseWizard])
+
+  useWizardSectionChangeLog()
 
   return (
     <Layout contentType="form">

--- a/frontend/src/old-pages/Layout.tsx
+++ b/frontend/src/old-pages/Layout.tsx
@@ -20,12 +20,15 @@ import {Flashbar} from '@cloudscape-design/components'
 import TopBar from '../components/TopBar'
 import SideBar from '../components/SideBar'
 import {PropsWithChildren} from 'react'
+import {useLocationChangeLog} from '../navigation/useLocationChangeLog'
 
 export default function Layout({
   children,
   ...props
 }: PropsWithChildren<Partial<AppLayoutProps>>) {
   const messages = useState(['app', 'messages']) || []
+  useLocationChangeLog()
+
   return (
     <>
       <TopBar />


### PR DESCRIPTION
## Description

This PR adds logs when:
- user navigates to another page
- user navigates to another section of the cluster creation wizard

See below screenshot for a sample of the outputs

## Changes

- add `useLocationChangeLog` to `Layout` component
- add `useWizardSectionChangeLog` to `Configure` component

## How Has This Been Tested?

- manually

## References

<img width="766" alt="image" src="https://user-images.githubusercontent.com/11457067/207578478-3a5392a9-03c1-4dab-874b-adc79326c58c.png">


## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [x] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
