### PR TITLE
Introduce base help panel

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -20,6 +20,15 @@
       "button": "Go to Homepage"   
     }
   },
+  "helpPanel": {
+    "footer": {
+      "learnMore": "Learn more",
+      "docs": {
+        "title": "AWS ParallelCluster Manager documentation",
+        "link": "https://pcluster.cloud/"
+      }
+    }
+  },
   "cluster": {
     "properties": {
       "sshcommand": {

--- a/frontend/src/components/TitleDescriptionHelpPanel.tsx
+++ b/frontend/src/components/TitleDescriptionHelpPanel.tsx
@@ -30,11 +30,13 @@ function TitleDescriptionHelpPanel({
       footer={
         <div>
           <h3>
-            {t('helpPanel.learnMore')} <Icon name="external" />
+            {t('helpPanel.footer.learnMore')} <Icon name="external" />
           </h3>
           <ul>
             <li>
-              <a href="https://pcluster.cloud/">{t('helpPanel.docs')}</a>
+              <a href={t('helpPanel.footer.docs.link')}>
+                {t('helpPanel.footer.docs.title')}
+              </a>
             </li>
           </ul>
         </div>

--- a/frontend/src/components/TitleDescriptionHelpPanel.tsx
+++ b/frontend/src/components/TitleDescriptionHelpPanel.tsx
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {HelpPanel, Icon} from '@cloudscape-design/components'
+import * as React from 'react'
+import {useTranslation} from 'react-i18next'
+
+interface TitleDescriptionHelpPanelProps {
+  title: string
+  description: string
+}
+
+function TitleDescriptionHelpPanel({
+  title,
+  description,
+}: TitleDescriptionHelpPanelProps) {
+  const {t} = useTranslation()
+
+  return (
+    <HelpPanel
+      header={<h2>{title}</h2>}
+      footer={
+        <div>
+          <h3>
+            {t('helpPanel.learnMore')} <Icon name="external" />
+          </h3>
+          <ul>
+            <li>
+              <a href="https://pcluster.cloud/">{t('helpPanel.docs')}</a>
+            </li>
+          </ul>
+        </div>
+      }
+    >
+      <div>
+        <p>{description}</p>
+      </div>
+    </HelpPanel>
+  )
+}
+
+export default TitleDescriptionHelpPanel


### PR DESCRIPTION
## Description

In the context of aligning PCM with CloudScape help system, this PR introduces a base help panel component to ease the user experience of our customers, providing a way to show helper text for different sections of the product in a cohesive manner.

In subsequent PRs we will gradually remove existing `HelpTooltip` instances in favor of the new help panel.

## How Has This Been Tested?

* Added `TitleDescriptionHelpPanel` to `tools` property of `AppLayout` component in `Layout.tsx` and verified that help panel is displayed correctly 

## References
* https://cloudscape.design/components/help-panel/?tabId=playground

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
