### PR TITLE
Safely import ComputeResources config created with single instance type

### DIFF
--- a/e2e/configs/environment.ts
+++ b/e2e/configs/environment.ts
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+export const ENVIRONMENT_CONFIG = {
+  URL: process.env.E2E_TEST_URL || 'https://080pcqu70j.execute-api.eu-west-1.amazonaws.com'
+}

--- a/e2e/configs/login.ts
+++ b/e2e/configs/login.ts
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+export const LOGIN_CONFIG = {
+  username: process.env.E2E_TEST1_EMAIL || '',
+  password: process.env.E2E_TEST1_PASSWORD || ''
+}

--- a/e2e/fixtures/wizard.template.yaml
+++ b/e2e/fixtures/wizard.template.yaml
@@ -1,0 +1,29 @@
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-006e97a9837b1710d
+  LocalStorage:
+    RootVolume:
+      VolumeType: gp3
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue0
+      AllocationStrategy: lowest-price
+      ComputeResources:
+        - Name: queue0-compute-resource-0
+          InstanceType: c5n.large
+          MinCount: 0
+          MaxCount: 4
+      Networking:
+        SubnetIds:
+          - subnet-006e97a9837b1710d
+      ComputeSettings:
+        LocalStorage:
+          RootVolume:
+            VolumeType: gp3
+  SlurmSettings: {}
+Region: ca-central-1
+Image:
+  Os: alinux2
+

--- a/e2e/fixtures/wizard.template.yaml
+++ b/e2e/fixtures/wizard.template.yaml
@@ -9,7 +9,6 @@ Scheduling:
   Scheduler: slurm
   SlurmQueues:
     - Name: queue0
-      AllocationStrategy: lowest-price
       ComputeResources:
         - Name: queue0-compute-resource-0
           InstanceType: c5n.large
@@ -22,7 +21,6 @@ Scheduling:
         LocalStorage:
           RootVolume:
             VolumeType: gp3
-  SlurmSettings: {}
 Region: ca-central-1
 Image:
   Os: alinux2

--- a/e2e/specs/wizard.spec.ts
+++ b/e2e/specs/wizard.spec.ts
@@ -1,16 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
 
 import { expect, test } from '@playwright/test';
-
-const E2E_URL = 'https://080pcqu70j.execute-api.eu-west-1.amazonaws.com'
+import { visitAndLogin } from '../test-utils/login';
 
 test.describe('Given an endpoint where ParallelCluster Manager is deployed', () => {
   test('a user should be able to login, navigate till the end of the cluster creation wizard, and perform a dry-run successfully', async ({ page }) => {
-    await page.goto(E2E_URL);
-    await page.getByRole('textbox', { name: 'name@host.com' }).click();
-    await page.getByRole('textbox', { name: 'name@host.com' }).fill(process.env.E2E_TEST1_EMAIL!);
-    await page.getByRole('textbox', { name: 'name@host.com' }).press('Tab');
-    await page.getByRole('textbox', { name: 'Password' }).fill(process.env.E2E_TEST1_PASSWORD!);
-    await page.getByRole('button', { name: 'submit' }).click();
+    await visitAndLogin(page)
   
     await page.getByRole('button', { name: 'Create Cluster' }).first().click();
     await expect(page.getByRole('heading', { name: 'Cluster Name' })).toBeVisible()

--- a/e2e/specs/wizard.template.spec.ts
+++ b/e2e/specs/wizard.template.spec.ts
@@ -13,36 +13,38 @@ import { visitAndLogin } from '../test-utils/login';
 
 const TEMPLATE_PATH = './fixtures/wizard.template.yaml'
 
-test.describe('given a cluster configuration template created with single instance type', () => {
-  test.describe('when the file is imported as a template', () => {
-    test('user can perform a dry-run successfully', async ({ page }) => {
-      await visitAndLogin(page)
+test.describe('environment: @demo', () => {
+  test.describe('given a cluster configuration template created with single instance type', () => {
+    test.describe('when the file is imported as a template', () => {
+      test('user can perform a dry-run successfully', async ({ page }) => {
+        await visitAndLogin(page)
 
-      await page.getByRole('button', { name: 'Create Cluster' }).first().click();
-      await page.getByPlaceholder('Enter your cluster name').fill('sdasdasd');
+        await page.getByRole('button', { name: 'Create Cluster' }).first().click();
+        await page.getByPlaceholder('Enter your cluster name').fill('sdasdasd');
 
-      page.on("filechooser", (fileChooser: FileChooser) => {
-        fileChooser.setFiles([TEMPLATE_PATH]);
-      })
-      await page.getByRole('radio', { name: 'Template' }).click();
-      await page.getByRole('button', { name: 'Next' }).click();
+        page.on("filechooser", (fileChooser: FileChooser) => {
+          fileChooser.setFiles([TEMPLATE_PATH]);
+        })
+        await page.getByRole('radio', { name: 'Template' }).click();
+        await page.getByRole('button', { name: 'Next' }).click();
 
-      await expect(page.getByRole('heading', { name: 'Cluster Properties' })).toBeVisible()
-      await page.getByRole('button', { name: 'Next' }).click();
-      
-      await expect(page.getByRole('heading', { name: 'Head Node Properties' })).toBeVisible()
-      await page.getByRole('button', { name: 'Next' }).click();
-      
-      await expect(page.getByRole('heading', { name: 'Storage Properties' })).toBeVisible()
-      await page.getByRole('button', { name: 'Next' }).click();
-      
-      await expect(page.getByRole('heading', { name: 'Queues' })).toBeVisible()
-      await page.getByRole('button', { name: 'Next' }).click();
-      
-      await expect(page.getByRole('heading', { name: 'Cluster Configuration' })).toBeVisible()
-      await page.getByRole('button', { name: 'Dry Run' }).click();
-      
-      await expect(page.getByText('Request would have succeeded, but DryRun flag is set.')).toBeVisible()
+        await expect(page.getByRole('heading', { name: 'Cluster Properties' })).toBeVisible()
+        await page.getByRole('button', { name: 'Next' }).click();
+
+        await expect(page.getByRole('heading', { name: 'Head Node Properties' })).toBeVisible()
+        await page.getByRole('button', { name: 'Next' }).click();
+
+        await expect(page.getByRole('heading', { name: 'Storage Properties' })).toBeVisible()
+        await page.getByRole('button', { name: 'Next' }).click();
+
+        await expect(page.getByRole('heading', { name: 'Queues' })).toBeVisible()
+        await page.getByRole('button', { name: 'Next' }).click();
+
+        await expect(page.getByRole('heading', { name: 'Cluster Configuration' })).toBeVisible()
+        await page.getByRole('button', { name: 'Dry Run' }).click();
+
+        await expect(page.getByText('Request would have succeeded, but DryRun flag is set.')).toBeVisible()
+      });
     });
   });
 });

--- a/e2e/specs/wizard.template.spec.ts
+++ b/e2e/specs/wizard.template.spec.ts
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { expect, FileChooser, test } from '@playwright/test';
+
+const E2E_URL = 'https://080pcqu70j.execute-api.eu-west-1.amazonaws.com'
+const TEMPLATE_PATH = './fixtures/wizard.template.yaml'
+
+test.describe('given a cluster configuration template created with single instance type', () => {
+  test.describe('when the file is imported as a template', () => {
+    test('user can perform a dry-run successfully', async ({ page }) => {
+      await page.goto(E2E_URL);
+      await page.getByRole('textbox', { name: 'name@host.com' }).click();
+      await page.getByRole('textbox', { name: 'name@host.com' }).fill(process.env.E2E_TEST1_EMAIL!);
+      await page.getByRole('textbox', { name: 'name@host.com' }).press('Tab');
+      await page.getByRole('textbox', { name: 'Password' }).fill(process.env.E2E_TEST1_PASSWORD!);
+      await page.getByRole('button', { name: 'submit' }).click();
+
+      await page.getByRole('button', { name: 'Create Cluster' }).first().click();
+      await page.getByPlaceholder('Enter your cluster name').fill('sdasdasd');
+
+      page.on("filechooser", (fileChooser: FileChooser) => {
+        fileChooser.setFiles([TEMPLATE_PATH]);
+      })
+      await page.getByRole('radio', { name: 'Template' }).click();
+      await page.getByRole('button', { name: 'Next' }).click();
+
+      await expect(page.getByRole('heading', { name: 'Cluster Properties' })).toBeVisible()
+      await page.getByRole('button', { name: 'Next' }).click();
+      
+      await expect(page.getByRole('heading', { name: 'Head Node Properties' })).toBeVisible()
+      await page.getByRole('button', { name: 'Next' }).click();
+      
+      await expect(page.getByRole('heading', { name: 'Storage Properties' })).toBeVisible()
+      await page.getByRole('button', { name: 'Next' }).click();
+      
+      await expect(page.getByRole('heading', { name: 'Queues' })).toBeVisible()
+      await page.getByRole('button', { name: 'Next' }).click();
+      
+      await expect(page.getByRole('heading', { name: 'Cluster Configuration' })).toBeVisible()
+      await page.getByRole('button', { name: 'Dry Run' }).click();
+      
+      await expect(page.getByText('Request would have succeeded, but DryRun flag is set.')).toBeVisible()
+    });
+  });
+});

--- a/e2e/specs/wizard.template.spec.ts
+++ b/e2e/specs/wizard.template.spec.ts
@@ -9,19 +9,14 @@
 // limitations under the License.
 
 import { expect, FileChooser, test } from '@playwright/test';
+import { visitAndLogin } from '../test-utils/login';
 
-const E2E_URL = 'https://080pcqu70j.execute-api.eu-west-1.amazonaws.com'
 const TEMPLATE_PATH = './fixtures/wizard.template.yaml'
 
 test.describe('given a cluster configuration template created with single instance type', () => {
   test.describe('when the file is imported as a template', () => {
     test('user can perform a dry-run successfully', async ({ page }) => {
-      await page.goto(E2E_URL);
-      await page.getByRole('textbox', { name: 'name@host.com' }).click();
-      await page.getByRole('textbox', { name: 'name@host.com' }).fill(process.env.E2E_TEST1_EMAIL!);
-      await page.getByRole('textbox', { name: 'name@host.com' }).press('Tab');
-      await page.getByRole('textbox', { name: 'Password' }).fill(process.env.E2E_TEST1_PASSWORD!);
-      await page.getByRole('button', { name: 'submit' }).click();
+      await visitAndLogin(page)
 
       await page.getByRole('button', { name: 'Create Cluster' }).first().click();
       await page.getByPlaceholder('Enter your cluster name').fill('sdasdasd');

--- a/e2e/test-utils/login.ts
+++ b/e2e/test-utils/login.ts
@@ -1,0 +1,9 @@
+import { ENVIRONMENT_CONFIG } from "../configs/environment";
+import { LOGIN_CONFIG } from "../configs/login";
+
+export async function visitAndLogin(page) {
+  await page.goto(ENVIRONMENT_CONFIG.URL);
+  await page.getByRole('textbox', { name: 'name@host.com' }).fill(LOGIN_CONFIG.username);
+  await page.getByRole('textbox', { name: 'Password' }).fill(LOGIN_CONFIG.password);
+  await page.getByRole('button', { name: 'submit' }).click();
+}

--- a/frontend/src/old-pages/Configure/Queues/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.tsx
@@ -278,6 +278,9 @@ function Queue({index}: any) {
   ]
   const enablePlacementGroup = useState(enablePlacementGroupPath)
 
+  const isMultiInstanceTypesActive = useFeatureFlag(
+    'queues_multiple_instance_types',
+  )
   const allocationStrategyOptions = useAllocationStrategyOptions()
 
   const errorsPath = [...queuesErrorsPath, index]
@@ -416,7 +419,7 @@ function Queue({index}: any) {
               options={capacityTypes.map(itemToIconOption)}
             />
           </FormField>
-          {queue.AllocationStrategy ? (
+          {isMultiInstanceTypesActive ? (
             <FormField label={t('wizard.queues.allocationStrategy.title')}>
               <Select
                 options={allocationStrategyOptions}

--- a/frontend/src/old-pages/Configure/Queues/__tests__/mapComputeResources.test.ts
+++ b/frontend/src/old-pages/Configure/Queues/__tests__/mapComputeResources.test.ts
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {MockProxy} from 'jest-mock-extended'
+import {mapComputeResources} from '../queues.mapper'
+import {
+  MultiInstanceComputeResource,
+  SingleInstanceComputeResource,
+} from '../queues.types'
+
+describe('given a mapper to import the ComputeResources section of the Scheduling config', () => {
+  describe('when the configuration was created with the single instance type format', () => {
+    let mockComputeResources: MockProxy<SingleInstanceComputeResource[]>
+
+    beforeEach(() => {
+      mockComputeResources = [
+        {
+          Name: 'some-name',
+          MinCount: 0,
+          MaxCount: 1,
+          InstanceType: 'some-instance',
+        },
+      ]
+    })
+    it('should convert the configuration into the flexible instance typs format', () => {
+      const expected = [
+        {
+          Name: 'some-name',
+          MinCount: 0,
+          MaxCount: 1,
+          Instances: [
+            {
+              InstanceType: 'some-instance',
+            },
+          ],
+        },
+      ]
+      expect(mapComputeResources(mockComputeResources)).toEqual(expected)
+    })
+  })
+  describe('when the configuration was created with the flexible instance types format', () => {
+    let mockComputeResources: MockProxy<MultiInstanceComputeResource[]>
+
+    beforeEach(() => {
+      mockComputeResources = [
+        {
+          Name: 'some-name',
+          MinCount: 0,
+          MaxCount: 1,
+          Instances: [
+            {
+              InstanceType: 'some-instance',
+            },
+          ],
+        },
+      ]
+    })
+    it('should leave the configuration as is', () => {
+      expect(mapComputeResources(mockComputeResources)).toEqual(
+        mockComputeResources,
+      )
+    })
+  })
+})

--- a/frontend/src/old-pages/Configure/Queues/__tests__/mapComputeResources.test.ts
+++ b/frontend/src/old-pages/Configure/Queues/__tests__/mapComputeResources.test.ts
@@ -16,10 +16,74 @@ import {
 } from '../queues.types'
 
 describe('given a mapper to import the ComputeResources section of the Scheduling config', () => {
-  describe('when the configuration was created with the single instance type format', () => {
+  let mockVersion: string
+
+  describe('when the application supports multiple instance types', () => {
+    beforeEach(() => {
+      mockVersion = '3.3.0'
+    })
+
+    describe('when the configuration was created with the single instance type format', () => {
+      let mockComputeResources: MockProxy<SingleInstanceComputeResource[]>
+
+      beforeEach(() => {
+        mockComputeResources = [
+          {
+            Name: 'some-name',
+            MinCount: 0,
+            MaxCount: 1,
+            InstanceType: 'some-instance',
+          },
+        ]
+      })
+      it('should convert the configuration into the flexible instance typs format', () => {
+        const expected = [
+          {
+            Name: 'some-name',
+            MinCount: 0,
+            MaxCount: 1,
+            Instances: [
+              {
+                InstanceType: 'some-instance',
+              },
+            ],
+          },
+        ]
+        expect(mapComputeResources(mockVersion, mockComputeResources)).toEqual(
+          expected,
+        )
+      })
+    })
+    describe('when the configuration was created with the flexible instance types format', () => {
+      let mockComputeResources: MockProxy<MultiInstanceComputeResource[]>
+
+      beforeEach(() => {
+        mockComputeResources = [
+          {
+            Name: 'some-name',
+            MinCount: 0,
+            MaxCount: 1,
+            Instances: [
+              {
+                InstanceType: 'some-instance',
+              },
+            ],
+          },
+        ]
+      })
+      it('should leave the configuration as is', () => {
+        expect(mapComputeResources(mockVersion, mockComputeResources)).toEqual(
+          mockComputeResources,
+        )
+      })
+    })
+  })
+
+  describe('when the application does not support multiple instance types', () => {
     let mockComputeResources: MockProxy<SingleInstanceComputeResource[]>
 
     beforeEach(() => {
+      mockVersion = '3.2.0'
       mockComputeResources = [
         {
           Name: 'some-name',
@@ -29,41 +93,9 @@ describe('given a mapper to import the ComputeResources section of the Schedulin
         },
       ]
     })
-    it('should convert the configuration into the flexible instance typs format', () => {
-      const expected = [
-        {
-          Name: 'some-name',
-          MinCount: 0,
-          MaxCount: 1,
-          Instances: [
-            {
-              InstanceType: 'some-instance',
-            },
-          ],
-        },
-      ]
-      expect(mapComputeResources(mockComputeResources)).toEqual(expected)
-    })
-  })
-  describe('when the configuration was created with the flexible instance types format', () => {
-    let mockComputeResources: MockProxy<MultiInstanceComputeResource[]>
 
-    beforeEach(() => {
-      mockComputeResources = [
-        {
-          Name: 'some-name',
-          MinCount: 0,
-          MaxCount: 1,
-          Instances: [
-            {
-              InstanceType: 'some-instance',
-            },
-          ],
-        },
-      ]
-    })
     it('should leave the configuration as is', () => {
-      expect(mapComputeResources(mockComputeResources)).toEqual(
+      expect(mapComputeResources(mockVersion, mockComputeResources)).toEqual(
         mockComputeResources,
       )
     })

--- a/frontend/src/old-pages/Configure/Queues/queues.mapper.ts
+++ b/frontend/src/old-pages/Configure/Queues/queues.mapper.ts
@@ -8,6 +8,7 @@
 // OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {isFeatureEnabled} from '../../../feature-flags/useFeatureFlag'
 import {
   SingleInstanceComputeResource,
   MultiInstanceComputeResource,
@@ -33,9 +34,14 @@ function mapComputeResource(
 }
 
 export function mapComputeResources(
+  version: string,
   computeResourcesConfig:
     | SingleInstanceComputeResource[]
     | MultiInstanceComputeResource[],
-): MultiInstanceComputeResource[] {
+) {
+  if (!isFeatureEnabled(version, 'queues_multiple_instance_types')) {
+    return computeResourcesConfig
+  }
+
   return computeResourcesConfig.map(mapComputeResource)
 }

--- a/frontend/src/old-pages/Configure/Queues/queues.mapper.ts
+++ b/frontend/src/old-pages/Configure/Queues/queues.mapper.ts
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  SingleInstanceComputeResource,
+  MultiInstanceComputeResource,
+} from './queues.types'
+
+function mapComputeResource(
+  computeResource: SingleInstanceComputeResource | MultiInstanceComputeResource,
+): MultiInstanceComputeResource {
+  if ('Instances' in computeResource) {
+    return computeResource
+  }
+
+  const {InstanceType, ...otherComputeResourceConfig} = computeResource
+
+  return {
+    ...otherComputeResourceConfig,
+    Instances: [
+      {
+        InstanceType,
+      },
+    ],
+  }
+}
+
+export function mapComputeResources(
+  computeResourcesConfig:
+    | SingleInstanceComputeResource[]
+    | MultiInstanceComputeResource[],
+): MultiInstanceComputeResource[] {
+  return computeResourcesConfig.map(mapComputeResource)
+}

--- a/frontend/src/old-pages/Configure/util.tsx
+++ b/frontend/src/old-pages/Configure/util.tsx
@@ -13,6 +13,7 @@
 import {setState, getState, clearState} from '../../store'
 import {LoadAwsConfig} from '../../model'
 import {getIn, setIn} from '../../util'
+import {mapComputeResources} from './Queues/queues.mapper'
 
 function loadTemplateLazy(config: any, callback?: () => void) {
   const loadingPath = ['app', 'wizard', 'source', 'loading']
@@ -67,6 +68,12 @@ function loadTemplateLazy(config: any, callback?: () => void) {
         i,
         'ComputeResources',
       ])
+      computeResources = mapComputeResources(computeResources)
+      config = setIn(
+        config,
+        ['Scheduling', 'SlurmQueues', i, 'ComputeResources'],
+        computeResources,
+      )
       for (let j = 0; j < computeResources.length; j++) {
         if (
           getIn(config, [

--- a/frontend/src/old-pages/Configure/util.tsx
+++ b/frontend/src/old-pages/Configure/util.tsx
@@ -21,6 +21,7 @@ function loadTemplateLazy(config: any, callback?: () => void) {
   const keypairs = getState(['aws', 'keypairs']) || []
   const keypairNames = new Set(keypairs.map((kp: any) => kp.KeyName))
   const keypairPath = ['HeadNode', 'Ssh', 'KeyName']
+  const version = getState(['app', 'version', 'full'])
   if (getIn(config, ['Image', 'CustomAmi']))
     setState(['app', 'wizard', 'customAMI', 'enabled'], true)
 
@@ -68,7 +69,7 @@ function loadTemplateLazy(config: any, callback?: () => void) {
         i,
         'ComputeResources',
       ])
-      computeResources = mapComputeResources(computeResources)
+      computeResources = mapComputeResources(version, computeResources)
       config = setIn(
         config,
         ['Scheduling', 'SlurmQueues', i, 'ComputeResources'],


### PR DESCRIPTION
## Description

This PR fixes an issue causing the cluster creation wizard to crash whenever a template containing configuration for the single instance type is uploaded

Fixes #366 

## Changes

- add e2e spec
- add mapper to convert ComputeResources to flexible instance type format
- refactor e2e to centralize config and login steps

## Changelog entry

Fix cluster creation wizard failing when uploading a template created with the single instance type format (supported untile PC 3.2.0)

## How Has This Been Tested?

- manually, by importing a template and proceeding with the dry run
- e2e spec
- unit tests

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
