### PR TITLE
Replace HelpTooltip in custom AMI selection

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -25,6 +25,7 @@
       "learnMore": "Learn more",
       "docs": {
         "title": "AWS ParallelCluster Manager documentation",
+        "externalIconAriaLabel": "Open in a new tab",
         "link": "https://pcluster.cloud/"
       }
     },
@@ -32,6 +33,9 @@
       "title": "ParallelCluster Manager",
       "description": "Quickly and easily create HPC cluster in AWS using ParallelCluster Manager. This UI uses the AWS ParallelCluster API to Create, Update and Delete Clusters as well as access, view logs, and build Amazon Machine Images (AMI's)."
     }
+  },
+  "infoLink": {
+    "label": "Info"
   },
   "cluster": {
     "properties": {
@@ -440,8 +444,13 @@
     },
     "components": {
       "customAmi": {
+        "ariaLabel": "Use Custom AMI?",
         "label": "Use Custom AMI?",
-        "help": "Custom AMI's provide a way to customize the cluster. See the <0>Image section</0> of the documentation for more information.",
+        "helpPanel": {
+          "title": "Custom AMI",
+          "description": "Custom AMI's provide a way to customize the cluster. See the <0>Image section</0> of the documentation for more information.",
+          "link": "https://docs.aws.amazon.com/parallelcluster/latest/ug/pcluster.build-image-v3.html"
+        },
         "suggestLabel": "Custom AMI ID"
       },
       "rootVolume": {

--- a/frontend/src/components/InfoLink.tsx
+++ b/frontend/src/components/InfoLink.tsx
@@ -1,0 +1,27 @@
+import {Link} from '@cloudscape-design/components'
+import {ReactElement} from 'react'
+import {useTranslation} from 'react-i18next'
+import {useHelpPanel} from './help-panel/HelpPanel'
+
+interface InfoLinkProps {
+  ariaLabel: string
+  helpPanel: ReactElement
+}
+
+function InfoLink({ariaLabel, helpPanel}: InfoLinkProps) {
+  const {setContent, setVisible} = useHelpPanel()
+  const {t} = useTranslation()
+
+  const setHelpPanel = () => {
+    setContent(helpPanel)
+    setVisible(true)
+  }
+
+  return (
+    <Link variant="info" onFollow={setHelpPanel} ariaLabel={ariaLabel}>
+      {t('infoLink.label')}
+    </Link>
+  )
+}
+
+export default InfoLink

--- a/frontend/src/components/help-panel/TitleDescriptionHelpPanel.tsx
+++ b/frontend/src/components/help-panel/TitleDescriptionHelpPanel.tsx
@@ -9,13 +9,13 @@
 // OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {HelpPanel, Icon} from '@cloudscape-design/components'
-import * as React from 'react'
+import {HelpPanel, Icon, Link} from '@cloudscape-design/components'
+import {ReactElement} from 'react'
 import {useTranslation} from 'react-i18next'
 
 interface TitleDescriptionHelpPanelProps {
-  title: string
-  description: string
+  title: string | ReactElement
+  description: string | ReactElement
 }
 
 function TitleDescriptionHelpPanel({
@@ -34,9 +34,15 @@ function TitleDescriptionHelpPanel({
           </h3>
           <ul>
             <li>
-              <a href={t('helpPanel.footer.docs.link')}>
+              <Link
+                external
+                externalIconAriaLabel={t(
+                  'helpPanel.footer.docs.externalIconAriaLabel',
+                )}
+                href={t('helpPanel.footer.docs.link')}
+              >
                 {t('helpPanel.footer.docs.title')}
-              </a>
+              </Link>
             </li>
           </ul>
         </div>

--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -45,6 +45,9 @@ import {
 // Components
 import HelpTooltip from '../../components/HelpTooltip'
 import {NonCancelableEventHandler} from '@cloudscape-design/components/internal/events'
+import {useHelpPanel} from '../../components/help-panel/HelpPanel'
+import TitleDescriptionHelpPanel from '../../components/help-panel/TitleDescriptionHelpPanel'
+import InfoLink from '../../components/InfoLink'
 
 // Helper Functions
 function strToOption(str: any) {
@@ -317,14 +320,7 @@ function CustomAMISettings({basePath, appPath, errorsPath, validate}: any) {
 
   return (
     <>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'row',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-        }}
-      >
+      <SpaceBetween direction="horizontal" size={'xxs'}>
         <Toggle
           disabled={editing}
           checked={customAmiEnabled}
@@ -332,16 +328,24 @@ function CustomAMISettings({basePath, appPath, errorsPath, validate}: any) {
         >
           <Trans i18nKey="wizard.components.customAmi.label" />
         </Toggle>
-        <HelpTooltip>
-          <Trans i18nKey="wizard.components.customAmi.help">
-            <a
-              rel="noreferrer"
-              target="_blank"
-              href="https://docs.aws.amazon.com/parallelcluster/latest/ug/pcluster.build-image-v3.html"
-            ></a>
-          </Trans>
-        </HelpTooltip>
-      </div>
+        <InfoLink
+          ariaLabel={t('wizard.components.customAmi.ariaLabel')}
+          helpPanel={
+            <TitleDescriptionHelpPanel
+              title={t('wizard.components.customAmi.helpPanel.title')}
+              description={
+                <Trans i18nKey="wizard.components.customAmi.helpPanel.description">
+                  <a
+                    rel="noreferrer"
+                    target="_blank"
+                    href={t('wizard.components.customAmi.helpPanel.link')}
+                  />
+                </Trans>
+              }
+            />
+          }
+        />
+      </SpaceBetween>
       {customAmiEnabled && (
         <FormField
           label={t('wizard.components.customAmi.suggestLabel')}


### PR DESCRIPTION
## Description

Following https://github.com/aws-samples/pcluster-manager/pull/419 and https://github.com/aws-samples/pcluster-manager/pull/420, this PR is the first step towards replacing all instances of `HelpTooltip` with `useHelpPanel()` hook calls in order to be compliant with the CloudScape [help system](https://cloudscape.design/patterns/general/help-system/).

This PR fixes also the link in the footer of `TitleDescriptionHelpPanel` which was not opening a new tab when clicked.

## How Has This Been Tested?

* Manually clicked on new `info` link and verified that help panel is opened and filled as expected

## References

* https://cloudscape.design/examples/react/onboarding.html

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<img width="1726" alt="Screenshot 2022-12-20 at 16 15 18" src="https://user-images.githubusercontent.com/25930133/208700781-67706e0b-cd41-4ea4-a74b-907f5f017fdb.png">
