### PR TITLE
Follow-up of #424

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -10,7 +10,8 @@
     },
     "errors": {
       "csrfError": "An unexpected error occurred. Please reload the page and try again"
-    }
+    },
+    "openNewTab": "Open in a new tab"
   },
   "errorBoundary": {
     "modal": {
@@ -25,7 +26,6 @@
       "learnMore": "Learn more",
       "docs": {
         "title": "AWS ParallelCluster Manager documentation",
-        "externalIconAriaLabel": "Open in a new tab",
         "link": "https://pcluster.cloud/"
       }
     },

--- a/frontend/src/components/InfoLink.tsx
+++ b/frontend/src/components/InfoLink.tsx
@@ -3,7 +3,7 @@ import {ReactElement} from 'react'
 import {useTranslation} from 'react-i18next'
 import {useHelpPanel} from './help-panel/HelpPanel'
 
-interface InfoLinkProps {
+type InfoLinkProps = {
   ariaLabel: string
   helpPanel: ReactElement
 }

--- a/frontend/src/components/help-panel/TitleDescriptionHelpPanel.tsx
+++ b/frontend/src/components/help-panel/TitleDescriptionHelpPanel.tsx
@@ -36,9 +36,7 @@ function TitleDescriptionHelpPanel({
             <li>
               <Link
                 external
-                externalIconAriaLabel={t(
-                  'helpPanel.footer.docs.externalIconAriaLabel',
-                )}
+                externalIconAriaLabel={t('global.openNewTab')}
                 href={t('helpPanel.footer.docs.link')}
               >
                 {t('helpPanel.footer.docs.title')}


### PR DESCRIPTION
## Description

This PR addresses nitpicks pointed out in https://github.com/aws-samples/pcluster-manager/pull/424:
* Use `type` instead of `interface` for `InfoLinkProps`
* Move external link aria label to a global namespace in i18n strings

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
