### PR TITLE
Add stacktraces to Lambda logs

### DIFF
--- a/api/logger.py
+++ b/api/logger.py
@@ -27,9 +27,7 @@ class DefaultLogger(object):
     self.logger.warning(self._log_output(msg, extra))   
     
   def error(self, msg, extra=None):
-    self.logger.error(self._log_output(msg, extra))
+    self.logger.error(self._log_output(msg, extra), exc_info=True)
 
   def critical(self, msg, extra=None):
-    self.logger.critical(self._log_output(msg, extra))
-
-
+    self.logger.critical(self._log_output(msg, extra), exc_info=True)

--- a/api/tests/test_push_log.py
+++ b/api/tests/test_push_log.py
@@ -25,7 +25,9 @@ def test_push_log_controller_with_valid_json_no_extra(client, caplog, disable_au
 def test_push_log_controller_with_valid_json_with_extra(client, caplog, disable_auth, mock_csrf_needed):
     request_body = {'message': 'sample-message', 'level': 'error',
                     'extra': {'extra_1': 'value_1', 'extra_2': 'value_2'}}
-    expected_log = "ERROR    pcluster-manager:logger.py:30 {'extra_1': 'value_1', 'extra_2': 'value_2', 'source': 'frontend', 'message': 'sample-message'}"
+    # NoneType: None is there since error logs from the client are not triggered from an actual exception,
+    # exc_info is not available and returns None
+    expected_log = "ERROR    pcluster-manager:logger.py:30 {'extra_1': 'value_1', 'extra_2': 'value_2', 'source': 'frontend', 'message': 'sample-message'}NoneType: None"
 
     caplog.clear()
     response = client.post('/logs', json=request_body)


### PR DESCRIPTION
## Description

Print the complete stacktrace when logging an error on CW.

Although it's not ideal to have each stacktrace entry on a separate line (and I thought this was an issue) it's actually the behavior of the Python Lambda runtime, and cannot be changed (more details [here](https://docs.aws.amazon.com/lambda/latest/dg/python-logging.html)).
This can behavior can be overcome by going through Logs Insights first to find the log stream and time of the error, then visiting the full log stream to see the stacktrace.

## How Has This Been Tested?

![Screenshot 2022-12-21 at 12 46 33](https://user-images.githubusercontent.com/3091286/208917156-dd26dad0-15dd-4ddf-a98a-1df9e220fd6d.png)


## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [x] I added tests to new or existing code
- [] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
