### PR TITLE
Add Info links to MultiUser Properties section

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -395,22 +395,22 @@
     },
     "multiuser": {
       "domainName": {
-        "name": "Domain Name*",
+        "name": "Domain Name",
         "description": "The Active Directory (AD) domain that you use for identity information.",
         "help": "This property corresponds to the sssd-ldap parameter that's called ldap_search_base."
       },
       "domainAddress": {
-        "name": "Domain Address*",
+        "name": "Domain Address",
         "description": "The URI or URIs that point to the AD domain controller that's used as the LDAP server.",
         "help": "The URI corresponds to the sssd-ldap parameter that's called ldap_uri. The value can be a comma separated string of URIs. To use LDAP, you must add ldap:// to the beginning of the each URI."
       },
       "passwordSecretArn" : {
-        "name": "Password Secret ARN*",
+        "name": "Password Secret ARN",
         "description": "The Amazon Resource Name (ARN) of the AWS Secrets Manager secret that contains the DomainReadOnlyUser plaintext password.",
         "help": "The content of the secret corresponds to SSSD-LDAP parameter that's called ldap_default_authtok."
       },
       "domainReadOnlyUser": {
-        "name": "Domain Read Only User*",
+        "name": "Domain Read Only User",
         "description": "The identity that's used to query the AD domain for identity information when authenticating cluster user logins.",
         "help": "It corresponds to sssd-ldap parameter that's called ldap_default_bind_dn. Use your AD identity information for this value."
       },

--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -924,7 +924,19 @@ function HelpTextInput({
   let error = useState([...errorsPath, configKey])
 
   return (
-    <FormField label={name} errorText={error} description={description}>
+    <FormField
+      label={name}
+      errorText={error}
+      description={description}
+      info={
+        <InfoLink
+          ariaLabel={name}
+          helpPanel={
+            <TitleDescriptionHelpPanel title={name} description={help} />
+          }
+        />
+      }
+    >
       <div
         style={{
           display: 'flex',
@@ -941,7 +953,6 @@ function HelpTextInput({
             onChange={onChange}
           />
         </div>
-        <HelpTooltip>{help}</HelpTooltip>
       </div>
     </FormField>
   )

--- a/frontend/src/old-pages/Configure/MultiUser.tsx
+++ b/frontend/src/old-pages/Configure/MultiUser.tsx
@@ -29,9 +29,10 @@ import {
 import {setState, useState, getState, clearState} from '../../store'
 
 // Components
-import HelpTooltip from '../../components/HelpTooltip'
 import {HelpTextInput} from './Components'
 import {useTranslation} from 'react-i18next'
+import TitleDescriptionHelpPanel from '../../components/help-panel/TitleDescriptionHelpPanel'
+import InfoLink from '../../components/InfoLink'
 
 // Constants
 const errorsPath = ['app', 'wizard', 'errors', 'multiUser']
@@ -59,19 +60,24 @@ function multiUserValidate() {
   return valid
 }
 
-function HelpToggle({
-  name,
-  configKey,
-  description,
-  help,
-  placeholder,
-  defaultValue,
-}: any) {
+function HelpToggle({name, configKey, description, help, defaultValue}: any) {
   let value = useState([...dsPath, configKey])
   let error = useState([...errorsPath, configKey])
 
   return (
-    <FormField label={name} errorText={error} description={description}>
+    <FormField
+      label={name}
+      errorText={error}
+      description={description}
+      info={
+        <InfoLink
+          ariaLabel={name}
+          helpPanel={
+            <TitleDescriptionHelpPanel title={name} description={help} />
+          }
+        />
+      }
+    >
       <div
         style={{
           display: 'flex',
@@ -86,7 +92,6 @@ function HelpToggle({
             onChange={({detail}) => setState([...dsPath, configKey], !value)}
           />
         </div>
-        <HelpTooltip>{help}</HelpTooltip>
       </div>
     </FormField>
   )


### PR DESCRIPTION
## Description

This PR adds Info links to MultiUser Properties section (see screenshot below). It's using existing `name` and `help` properties to facilitate the migration

## Changes

- update `HelpTextInput` component to render `InfoLink` instead of `HelpTooltip`
- add `InfoLink` to Generate SSH keys toggle in MultiUser screen
- remove asterisks from labels, since it's not done anywhere else and it would cause the help panel to show the asterisk as well

## How Has This Been Tested?

<img width="1030" alt="image" src="https://user-images.githubusercontent.com/11457067/208951650-3f6aea36-0fe5-4bf7-aa7f-5020c1ea199b.png">

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
