### PR TITLE
Remove help tooltip from cluster status indicator

### DIFF
--- a/frontend/src/components/Status.tsx
+++ b/frontend/src/components/Status.tsx
@@ -18,52 +18,13 @@ import {
 import {InstanceState, Instance, EC2Instance} from '../types/instances'
 import {StackEvent} from '../types/stackevents'
 import {JobStateCode} from '../types/jobs'
-import React, {useCallback} from 'react'
-import {Trans} from 'react-i18next'
-import {Link as InternalLink} from 'react-router-dom'
-import {useNavigate} from 'react-router-dom'
-
-import HelpTooltip from '../components/HelpTooltip'
+import React from 'react'
 import {
-  Link,
   StatusIndicator,
   StatusIndicatorProps,
 } from '@cloudscape-design/components'
-import {useState} from '../store'
 
 export type StatusMap = Record<string, StatusIndicatorProps.Type>
-
-function ClusterFailedHelp({
-  cluster,
-}: {
-  cluster: ClusterInfoSummary | ClusterDescription
-}) {
-  const {clusterName} = cluster
-  let navigate = useNavigate()
-
-  const clusterPath = ['clusters', 'index', clusterName]
-  const headNode = useState([...clusterPath, 'headNode'])
-  let href = `/clusters/${clusterName}/logs`
-  let cfnHref = `/clusters/${clusterName}/stack-events?filter=_FAILED`
-  if (headNode) href += `?instance=${headNode.instanceId}`
-
-  const navigateLogs = useCallback(
-    e => {
-      navigate(href)
-      e.preventDefault()
-    },
-    [href, navigate],
-  )
-
-  return (
-    <HelpTooltip>
-      <Trans i18nKey="components.ClusterFailedHelp.errorMessage">
-        <InternalLink to={cfnHref}></InternalLink>
-        <Link onFollow={navigateLogs}></Link>
-      </Trans>
-    </HelpTooltip>
-  )
-}
 
 function ClusterStatusIndicator({
   cluster,
@@ -71,11 +32,6 @@ function ClusterStatusIndicator({
   cluster: ClusterInfoSummary | ClusterDescription
 }) {
   const {clusterStatus}: {clusterStatus: ClusterStatus} = cluster
-  const failedStatuses = new Set<ClusterStatus>([
-    ClusterStatus.CreateFailed,
-    ClusterStatus.DeleteFailed,
-    ClusterStatus.UpdateFailed,
-  ])
 
   const statusMap: Record<ClusterStatus, StatusIndicatorProps.Type> = {
     CREATE_COMPLETE: 'success',
@@ -92,9 +48,6 @@ function ClusterStatusIndicator({
   return (
     <StatusIndicator type={statusMap[clusterStatus]}>
       {clusterStatus.replaceAll('_', ' ')}
-      {failedStatuses.has(clusterStatus) && (
-        <ClusterFailedHelp cluster={cluster} />
-      )}
     </StatusIndicator>
   )
 }


### PR DESCRIPTION
## Description

This PR removes the help tooltip from the cluster status indicator

## Changes

- remove HelpTooltip from `ClusterStatusIndicator`

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
