### PR TITLE
Replace HelpTooltips with HelpPanel on wizard HeadNode section

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -35,7 +35,8 @@
     }
   },
   "infoLink": {
-    "label": "Info"
+    "label": "Info",
+    "ariaLabel": "Info"
   },
   "cluster": {
     "properties": {
@@ -174,6 +175,7 @@
       }
     },
     "headNode": {
+      "title": "HeadNode",
       "validation": {
         "selectSubnet": "You must select a Subnet.",
         "selectInstanceType": "You must select an instance type.",

--- a/frontend/src/components/InfoLink.tsx
+++ b/frontend/src/components/InfoLink.tsx
@@ -4,8 +4,8 @@ import {useTranslation} from 'react-i18next'
 import {useHelpPanel} from './help-panel/HelpPanel'
 
 type InfoLinkProps = {
-  ariaLabel: string
   helpPanel: ReactElement
+  ariaLabel?: string
 }
 
 function InfoLink({ariaLabel, helpPanel}: InfoLinkProps) {
@@ -18,7 +18,11 @@ function InfoLink({ariaLabel, helpPanel}: InfoLinkProps) {
   }
 
   return (
-    <Link variant="info" onFollow={setHelpPanel} ariaLabel={ariaLabel}>
+    <Link
+      variant="info"
+      onFollow={setHelpPanel}
+      ariaLabel={ariaLabel || t('infoLink.ariaLabel')}
+    >
       {t('infoLink.label')}
     </Link>
   )

--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -49,12 +49,13 @@ import {
   SubnetSelect,
   IamPoliciesEditor,
 } from './Components'
-import HelpTooltip from '../../components/HelpTooltip'
 import {useFeatureFlag} from '../../feature-flags/useFeatureFlag'
 import {
   SlurmSettings,
   validateSlurmSettings,
 } from './SlurmSettings/SlurmSettings'
+import InfoLink from '../../components/InfoLink'
+import TitleDescriptionHelpPanel from '../../components/help-panel/TitleDescriptionHelpPanel'
 
 // Constants
 const headNodePath = ['app', 'wizard', 'config', 'HeadNode']
@@ -266,6 +267,16 @@ function SsmSettings() {
       <FormField
         label={t('wizard.headNode.Ssm.title')}
         description={t('wizard.headNode.Ssm.description')}
+        info={
+          <InfoLink
+            helpPanel={
+              <TitleDescriptionHelpPanel
+                title={t('wizard.headNode.title')}
+                description={t('wizard.headNode.Ssm.help')}
+              />
+            }
+          />
+        }
       >
         <Toggle
           checked={ssmEnabled}
@@ -275,9 +286,6 @@ function SsmSettings() {
           <Trans i18nKey="wizard.headNode.Ssm.label" />
         </Toggle>
       </FormField>
-      <HelpTooltip>
-        <Trans i18nKey="wizard.headNode.Ssm.help" />
-      </HelpTooltip>
     </div>
   )
 }
@@ -316,6 +324,16 @@ function DcvSettings() {
       <FormField
         label={t('wizard.headNode.Dcv.label')}
         description={t('wizard.headNode.Dcv.description')}
+        info={
+          <InfoLink
+            helpPanel={
+              <TitleDescriptionHelpPanel
+                title={t('wizard.headNode.title')}
+                description={t('wizard.headNode.Dcv.help')}
+              />
+            }
+          />
+        }
       >
         <SpaceBetween direction="vertical" size="xxxs">
           <Toggle disabled={editing} checked={dcvEnabled} onChange={toggleDcv}>
@@ -352,9 +370,6 @@ function DcvSettings() {
           </SpaceBetween>
         </SpaceBetween>
       </FormField>
-      <HelpTooltip>
-        <Trans i18nKey="wizard.headNode.Dcv.help" />
-      </HelpTooltip>
     </div>
   )
 }
@@ -412,44 +427,42 @@ function HeadNode() {
           <RootVolume basePath={headNodePath} errorsPath={errorsPath} />
           <SsmSettings />
           <DcvSettings />
-          <div
-            key="imds-secured"
-            style={{
-              display: 'flex',
-              flexDirection: 'row',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-            }}
-          >
+          <SpaceBetween size="xs" direction="horizontal">
             <Toggle checked={imdsSecured || false} onChange={toggleImdsSecured}>
               <Trans i18nKey="wizard.headNode.imdsSecured.label" />
             </Toggle>
-            <HelpTooltip>
-              <Trans i18nKey="wizard.headNode.imdsSecured.help">
-                <a
-                  rel="noreferrer"
-                  target="_blank"
-                  href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html#instance-metadata-v2-how-it-works"
-                ></a>
-              </Trans>
-            </HelpTooltip>
-          </div>
-          <div
-            key="sgs"
-            style={{
-              display: 'flex',
-              flexDirection: 'row',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-            }}
+            <InfoLink
+              helpPanel={
+                <TitleDescriptionHelpPanel
+                  title={t('wizard.headNode.title')}
+                  description={
+                    <Trans i18nKey="wizard.headNode.imdsSecured.help">
+                      <a
+                        rel="noreferrer"
+                        target="_blank"
+                        href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html#instance-metadata-v2-how-it-works"
+                      ></a>
+                    </Trans>
+                  }
+                />
+              }
+            />
+          </SpaceBetween>
+          <FormField
+            label={t('wizard.headNode.securityGroups.label')}
+            info={
+              <InfoLink
+                helpPanel={
+                  <TitleDescriptionHelpPanel
+                    title={t('wizard.headNode.title')}
+                    description={t('wizard.headNode.securityGroups.help')}
+                  />
+                }
+              />
+            }
           >
-            <FormField label={t('wizard.headNode.securityGroups.label')}>
-              <SecurityGroups basePath={headNodePath} />
-            </FormField>
-            <HelpTooltip>
-              <Trans i18nKey="wizard.headNode.securityGroups.help" />
-            </HelpTooltip>
-          </div>
+            <SecurityGroups basePath={headNodePath} />
+          </FormField>
           <ExpandableSection header="Advanced options">
             <ActionsEditor basePath={headNodePath} errorsPath={errorsPath} />
             <ExpandableSection header="IAM Policies">


### PR DESCRIPTION
## Description

This PR uses the HelpPanel in the HeadNode section.

## Changes

- make `ariaLabel` of the `InfoLink` optional since the Info text is always the same

## How Has This Been Tested?

Manually

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
