### PR TITLE
Bubble up boto3 Cognito exception for delete user operation

### DIFF
--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -600,14 +600,10 @@ def list_users():
 
 
 def delete_user():
-    try:
-        cognito = boto3.client("cognito-idp")
-        username = request.args.get("username")
-        cognito.admin_delete_user(UserPoolId=USER_POOL_ID, Username=username)
-        return {"Username": username}
-    except Exception as e:
-        return {"message": str(e)}, 500
-
+    cognito = boto3.client("cognito-idp")
+    username = request.args.get("username")
+    cognito.admin_delete_user(UserPoolId=USER_POOL_ID, Username=username)
+    return {"Username": username}
 
 def create_user():
     try:


### PR DESCRIPTION
## Description
Removed the try-except clause from the delete operation in order to bubble up the real Cognito exception raised so our Boto exception handler can handle it the right way.
<!-- Summary of what this PR introduces and possibly why -->

## How Has This Been Tested?
- manually
- existing unit tests
<!-- The tests you ran to verify your changes -->

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [x] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
