### PR TITLE
Replace HelpTooltips with HelpPanel in Accounting tab

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -95,6 +95,12 @@
         "noClusterSelectedText": "No cluster selected",
         "selectClusterText": "Select a cluster to see its details"
       }
+    },
+    "accounting": {
+      "costEstimate": {
+        "title": "Cost Estimate",
+        "help": "This cost estimate is based on the time the job took, the number of nodes and an estimate of the node cost. It could be inaccurate and is just meant to be an overall estimate."
+      }
     }
   },
   "wizard": {

--- a/frontend/src/old-pages/Clusters/Accounting.tsx
+++ b/frontend/src/old-pages/Clusters/Accounting.tsx
@@ -21,7 +21,6 @@ import {clusterDefaultUser, getIn, findFirst} from '../../util'
 import {JobStatusIndicator} from '../../components/Status'
 import EmptyState from '../../components/EmptyState'
 import Loading from '../../components/Loading'
-import HelpTooltip from '../../components/HelpTooltip'
 
 // UI Elements
 import {
@@ -41,6 +40,9 @@ import {
   Table,
   TextFilter,
 } from '@cloudscape-design/components'
+import InfoLink from '../../components/InfoLink'
+import TitleDescriptionHelpPanel from '../../components/help-panel/TitleDescriptionHelpPanel'
+import {useTranslation} from 'react-i18next'
 
 // Key:Value pair (label / children)
 const ValueWithLabel = ({label, children}: any) => (
@@ -229,6 +231,8 @@ function JobSteps({job}: any) {
 }
 
 function CostEstimate({job}: any) {
+  const {t} = useTranslation()
+
   return (
     <>
       <div
@@ -247,11 +251,14 @@ function CostEstimate({job}: any) {
             (getIn(job, ['time', 'elapsed']) / 3600.0)
           ).toFixed(5)}
         </span>
-        <HelpTooltip>
-          <b>Warning</b>This cost estimate is based on the time the job took,
-          the number of nodes and an estimate of the node cost. It could be
-          inaccurate and is just meant to be an overall estimate.
-        </HelpTooltip>
+        <InfoLink
+          helpPanel={
+            <TitleDescriptionHelpPanel
+              title={t('cluster.accounting.costEstimate.title')}
+              description={t('cluster.accounting.costEstimate.help')}
+            />
+          }
+        />
       </div>
     </>
   )

--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -43,9 +43,7 @@ import {
 } from '@cloudscape-design/components'
 
 // Components
-import HelpTooltip from '../../components/HelpTooltip'
 import {NonCancelableEventHandler} from '@cloudscape-design/components/internal/events'
-import {useHelpPanel} from '../../components/help-panel/HelpPanel'
 import TitleDescriptionHelpPanel from '../../components/help-panel/TitleDescriptionHelpPanel'
 import InfoLink from '../../components/InfoLink'
 


### PR DESCRIPTION
## Description

This PR uses the HelpPanel in the Accounting tab.

## Changes

- add copy to `string.json`
- replace `HelpTooltip` with `InfoLink`

## How Has This Been Tested?

manually

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
