### PR TITLE
Remove error notification from the UpdateCluster command

### DIFF
--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -103,7 +103,6 @@ function CreateCluster(
     })
     .catch((error: any) => {
       if (error.response) {
-        //notify(`Error (${clusterName}): ${error.response.data.message}`, 'error');
         errorCallback && errorCallback(error.response.data)
         console.log(error.response.data)
       }
@@ -139,10 +138,6 @@ function UpdateCluster(
     })
     .catch((error: any) => {
       if (error.response) {
-        notify(
-          `Error (${clusterName}): ${error.response.data.message}`,
-          'error',
-        )
         errorCallback && errorCallback(error.response.data)
         console.log(error.response.data)
       }


### PR DESCRIPTION
## Description

This PR removes the `notify()` call from the error case of the `UpdateCluster` command (same as it had been already done with the `CreateCluster`)

The error is handled via the `errorHandler` which takes care of setting the errors in the store

This also avoid displaying an error Flash message, in case of successful dry run (see screenshot below)

![image](https://user-images.githubusercontent.com/11457067/209173207-b1e30e43-8ad9-428e-a36c-b216ae36994f.png)

## How Has This Been Tested?

- manually

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
