### PR TITLE
Replace help popover with HelpPanel in slurm settings

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -358,7 +358,6 @@
       "slurmMemorySettings": {
         "container": {
           "title": "Slurm Memory Settings",
-          "info": "info",
           "help": "If enabled, users may use <i>--mem</i> to specify the amount of memory per node required by a job. For more information, see the <0>Slurm documentation for ConstrainRAMSpace</0>"
         },
         "toggle": {

--- a/frontend/src/old-pages/Configure/Queues/SlurmMemorySettings.tsx
+++ b/frontend/src/old-pages/Configure/Queues/SlurmMemorySettings.tsx
@@ -17,12 +17,12 @@ import {
   Alert,
   Toggle,
   SpaceBetween,
-  Popover,
-  Link,
 } from '@cloudscape-design/components'
 import {setState, getState, useState, clearState} from '../../../store'
 import {Queue} from './queues.types'
 import {useFeatureFlag} from '../../../feature-flags/useFeatureFlag'
+import TitleDescriptionHelpPanel from '../../../components/help-panel/TitleDescriptionHelpPanel'
+import InfoLink from '../../../components/InfoLink'
 
 const slurmSettingsPath = [
   'app',
@@ -82,29 +82,28 @@ function SlurmMemorySettings() {
   return (
     <Container
       header={
-        <Header variant="h2">
-          <SpaceBetween size="xs" direction="horizontal">
-            {t('wizard.queues.slurmMemorySettings.container.title')}
-            <Popover
-              dismissButton={true}
-              position="right"
-              size="small"
-              triggerType="custom"
-              content={
-                <Trans i18nKey="wizard.queues.slurmMemorySettings.container.help">
-                  <a
-                    rel="noopener noreferrer"
-                    target="_blank"
-                    href="https://slurm.schedmd.com/cgroup.conf.html#OPT_ConstrainRAMSpace"
-                  ></a>
-                </Trans>
+        <Header
+          variant="h2"
+          info={
+            <InfoLink
+              helpPanel={
+                <TitleDescriptionHelpPanel
+                  title={t('wizard.queues.slurmMemorySettings.container.title')}
+                  description={
+                    <Trans i18nKey="wizard.queues.slurmMemorySettings.container.help">
+                      <a
+                        rel="noopener noreferrer"
+                        target="_blank"
+                        href="https://slurm.schedmd.com/cgroup.conf.html#OPT_ConstrainRAMSpace"
+                      ></a>
+                    </Trans>
+                  }
+                />
               }
-            >
-              <Link variant="info">
-                {t('wizard.queues.slurmMemorySettings.container.info')}
-              </Link>
-            </Popover>
-          </SpaceBetween>
+            />
+          }
+        >
+          {t('wizard.queues.slurmMemorySettings.container.title')}
         </Header>
       }
     >


### PR DESCRIPTION
## Description

Replace a leftover help tooltip with the help panel. 

## How Has This Been Tested?

Manually

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
