### PR TITLE
Add validation for multi-AZ and EFA/Placement groups

### DIFF
--- a/frontend/src/old-pages/Configure/Queues/__tests__/multiAZ.test.tsx
+++ b/frontend/src/old-pages/Configure/Queues/__tests__/multiAZ.test.tsx
@@ -1,0 +1,35 @@
+import {areMultiAZSelected} from '../Queues'
+
+describe('Given a list of subnets', () => {
+  describe('when zero subnets are selected', () => {
+    it('should keep EFA and Placement groups enabled', () => {
+      const {multiAZ, canUseEFA, canUsePlacementGroup} = areMultiAZSelected([])
+      expect(multiAZ).toBe(false)
+      expect(canUseEFA).toBe(true)
+      expect(canUsePlacementGroup).toBe(true)
+    })
+  })
+
+  describe('when a single subnet is selected', () => {
+    it('should keep EFA and Placement groups enabled', () => {
+      const {multiAZ, canUseEFA, canUsePlacementGroup} = areMultiAZSelected([
+        'subnet-a',
+      ])
+      expect(multiAZ).toBe(false)
+      expect(canUseEFA).toBe(true)
+      expect(canUsePlacementGroup).toBe(true)
+    })
+  })
+
+  describe('when more than one subnet is selected', () => {
+    it('should keep EFA and Placement groups disabled', () => {
+      const {multiAZ, canUseEFA, canUsePlacementGroup} = areMultiAZSelected([
+        'subnet-a',
+        'subnet-b',
+      ])
+      expect(multiAZ).toBe(true)
+      expect(canUseEFA).toBe(false)
+      expect(canUsePlacementGroup).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Description

Disable EFA and Placement groups when more than one subnet is select (at the queue level).
Memoize some values in `Queues` and `MultiInstanceComputeResource` to avoid endless renders after the introduction of `useEffect`.

## How Has This Been Tested?

Manually used multi-AZ and verified EFA/PG cannot be enabled

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [x] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
