### PR TITLE
Add support for Multi-AZ

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -347,6 +347,7 @@
         "instanceTypeUnique": "Instance types must be unique within a Queue.",
         "instanceTypeMissing": "Select at least once instance type.",
         "selectSubnet": "You must select a Subnet.",
+        "selectSubnets": "You must select at least one Subnet.",
         "setRootVolumeSize": "You must set a RootVolume size.",
         "rootVolumeMinimum": "You must use an integer >= 35GB for Root Volume Size.",
         "scriptWithArgs": "You must specify a script path if you specify args.",
@@ -393,7 +394,10 @@
         "label": "Enable Placement Group"
       },
       "subnet": {
-        "label": "Subnet ID"
+        "label": {
+          "single": "Subnet ID",
+          "multiple": "Subnet IDs"
+        }
       },
       "purchaseType": {
         "label": "Purchase Type"

--- a/frontend/src/feature-flags/featureFlagsProvider.ts
+++ b/frontend/src/feature-flags/featureFlagsProvider.ts
@@ -21,7 +21,7 @@ const versionToFeaturesMap: Record<string, AvailableFeature[]> = {
     'slurm_queue_update_strategy',
   ],
   '3.3.0': ['slurm_accounting', 'queues_multiple_instance_types'],
-  '3.4.0': ['on_node_updated'],
+  '3.4.0': ['multi_az', 'on_node_updated']
 }
 
 function composeFlagsListByVersion(currentVersion: string): AvailableFeature[] {

--- a/frontend/src/feature-flags/types.ts
+++ b/frontend/src/feature-flags/types.ts
@@ -17,4 +17,5 @@ export type AvailableFeature =
   | 'slurm_accounting'
   | 'slurm_queue_update_strategy'
   | 'queues_multiple_instance_types'
+  | 'multi_az'
   | 'on_node_updated'

--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -46,6 +46,7 @@ import {
 import {NonCancelableEventHandler} from '@cloudscape-design/components/internal/events'
 import TitleDescriptionHelpPanel from '../../components/help-panel/TitleDescriptionHelpPanel'
 import InfoLink from '../../components/InfoLink'
+import {subnetName} from './util'
 
 // Helper Functions
 function strToOption(str: any) {
@@ -136,18 +137,6 @@ function SubnetSelect({value, onChange, disabled}: any) {
     return <div>No Subnets Found.</div>
   }
 
-  const SubnetName = (subnet: any) => {
-    if (!subnet) return null
-    var tags = subnet.Tags
-    if (!tags) {
-      return null
-    }
-    tags = subnet.Tags.filter((t: any) => {
-      return t.Key === 'Name'
-    })
-    return tags.length > 0 ? tags[0].Value : null
-  }
-
   const itemToOption = (item: any) => {
     return {
       value: item.SubnetId,
@@ -155,7 +144,7 @@ function SubnetSelect({value, onChange, disabled}: any) {
       description:
         item.AvailabilityZone +
         ` - ${item.AvailabilityZoneId}` +
-        (SubnetName(item) ? ` (${SubnetName(item)})` : ''),
+        (subnetName(item) ? ` (${subnetName(item)})` : ''),
     }
   }
 

--- a/frontend/src/old-pages/Configure/Queues/Queues.test.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.test.tsx
@@ -4,6 +4,18 @@ import {
   validateComputeResources,
 } from './MultiInstanceComputeResource'
 
+jest.mock('../../../store', () => {
+  const originalModule = jest.requireActual('../../../store')
+  return {
+    __esModule: true,
+    ...originalModule,
+    setState: jest.fn(),
+  }
+})
+
+import {setState} from '../../../store'
+import {setSubnetsAndValidate} from './Queues'
+
 describe('Given a list of instances', () => {
   const subject = allInstancesSupportEFA
   const efaInstances = new Set<string>(['t2.micro', 't2.medium'])
@@ -42,6 +54,33 @@ describe('Given a list of queues', () => {
   describe('when creating a new compute resource', () => {
     it('should create it with a default instance type', () => {
       expect(subject(0, 0).Instances).toHaveLength(1)
+    })
+  })
+})
+
+describe('Given a queue', () => {
+  const subject = setSubnetsAndValidate
+  describe('when selecting a list of subnets', () => {
+    const detail = {selectedOptions: [{value: 'subnet-1'}, {value: 'subnet-2'}]}
+    const queueIndex = 0
+    const subnetPath = [
+      'app',
+      'wizard',
+      'config',
+      'Scheduling',
+      'SlurmQueues',
+      queueIndex,
+      'Networking',
+      'SubnetIds',
+    ]
+    const queueValidate = jest.fn()
+    it('should set the correspondent state and validate the queue', () => {
+      subject(queueIndex, queueValidate, detail)
+      expect(setState).toHaveBeenCalledWith(subnetPath, [
+        'subnet-1',
+        'subnet-2',
+      ])
+      expect(queueValidate).toHaveBeenCalledWith(queueIndex)
     })
   })
 })

--- a/frontend/src/old-pages/Configure/Queues/SubnetMultiSelect.tsx
+++ b/frontend/src/old-pages/Configure/Queues/SubnetMultiSelect.tsx
@@ -1,0 +1,50 @@
+import {Multiselect, MultiselectProps} from '@cloudscape-design/components'
+import {NonCancelableEventHandler} from '@cloudscape-design/components/internal/events'
+import React from 'react'
+import {useMemo} from 'react'
+import {useState} from '../../../store'
+import {subnetName} from '../util'
+import {Subnet} from './queues.types'
+
+type SubnetMultiSelectProps = {
+  value: string[]
+  onChange: NonCancelableEventHandler<MultiselectProps.MultiselectChangeDetail>
+}
+
+function SubnetMultiSelect({value, onChange}: SubnetMultiSelectProps) {
+  const vpc = useState(['app', 'wizard', 'vpc'])
+  const subnets = useState(['aws', 'subnets'])
+  const filteredSubnets: Subnet[] = useMemo(
+    () =>
+      subnets &&
+      subnets.filter((s: Subnet) => {
+        return vpc ? s.VpcId === vpc : true
+      }),
+    [subnets, vpc],
+  )
+
+  const subnetOptions = useMemo(() => {
+    return filteredSubnets.map((subnet: Subnet) => {
+      return {
+        value: subnet.SubnetId,
+        label: subnet.SubnetId,
+        description:
+          subnet.AvailabilityZone +
+          ` - ${subnet.AvailabilityZoneId}` +
+          (subnetName(subnet) ? ` (${subnetName(subnet)})` : ''),
+      }
+    })
+  }, [filteredSubnets])
+
+  return (
+    <Multiselect
+      selectedOptions={subnetOptions.filter(option => {
+        return value.includes(option.value)
+      })}
+      onChange={onChange}
+      options={subnetOptions}
+    />
+  )
+}
+
+export {SubnetMultiSelect}

--- a/frontend/src/old-pages/Configure/Queues/__tests__/SubnetMultiSelect.test.tsx
+++ b/frontend/src/old-pages/Configure/Queues/__tests__/SubnetMultiSelect.test.tsx
@@ -1,0 +1,81 @@
+import {render} from '@testing-library/react'
+import {Subnet} from '../queues.types'
+import {SubnetMultiSelect} from '../SubnetMultiSelect'
+import wrapper from '@cloudscape-design/components/test-utils/dom'
+import {Provider} from 'react-redux'
+import {mock} from 'jest-mock-extended'
+import {Store} from '@reduxjs/toolkit'
+
+const mockSelectedSubnets: string[] = ['subnet-1']
+const mockSubnets: Subnet[] = [
+  {
+    SubnetId: 'subnet-1',
+    AvailabilityZone: 'AZ-a',
+    AvailabilityZoneId: 'AZ-a-id',
+    VpcId: 'VPC-1',
+  },
+  {
+    SubnetId: 'subnet-2',
+    AvailabilityZone: 'AZ-b',
+    AvailabilityZoneId: 'AZ-b-id',
+    VpcId: 'VPC-1',
+  },
+  {
+    SubnetId: 'subnet-3',
+    AvailabilityZone: 'AZ-c',
+    AvailabilityZoneId: 'AZ-c-id',
+    VpcId: 'VPC-2',
+  },
+]
+
+jest.mock('../../../../store', () => {
+  const originalModule = jest.requireActual('../../../../store')
+
+  return {
+    __esModule: true, // Use it when dealing with esModules
+    ...originalModule,
+    getState: jest.fn(),
+  }
+})
+
+const mockStore = mock<Store>()
+
+describe('given a component to select multiple subnets in a VPC', () => {
+  describe('when a VPC has been specified', () => {
+    beforeEach(() => {
+      mockStore.getState.mockReturnValue({
+        app: {
+          wizard: {
+            vpc: 'VPC-1',
+          },
+        },
+        aws: {
+          subnets: mockSubnets,
+        },
+      })
+    })
+
+    it('should show as options only the subnets in that VPC', () => {
+      const mockedOnChange = jest.fn()
+      const {container} = render(
+        <Provider store={mockStore}>
+          <SubnetMultiSelect
+            value={mockSelectedSubnets}
+            onChange={mockedOnChange}
+          />
+        </Provider>,
+      )
+
+      const multiSelect = wrapper(container).findMultiselect()!
+      expect(multiSelect).toBeDefined()
+      multiSelect.openDropdown()
+      expect(multiSelect.findDropdown()?.findOptions().length).toBe(2)
+      expect(
+        multiSelect.findDropdown()?.findOptionByValue('subnet-1'),
+      ).toBeTruthy()
+      expect(
+        multiSelect.findDropdown()?.findOptionByValue('subnet-2'),
+      ).toBeTruthy()
+    })
+  })
+})

--- a/frontend/src/old-pages/Configure/Queues/queues.types.ts
+++ b/frontend/src/old-pages/Configure/Queues/queues.types.ts
@@ -26,3 +26,16 @@ export type ComputeResourceInstance = {InstanceType: string}
 export type MultiInstanceComputeResource = ComputeResource & {
   Instances: ComputeResourceInstance[]
 }
+
+export type Tag = {
+  Key: string
+  Value: string
+}
+
+export type Subnet = {
+  SubnetId: string
+  AvailabilityZone: string
+  AvailabilityZoneId: string
+  VpcId: string
+  Tags?: Tag[]
+}

--- a/frontend/src/old-pages/Configure/util.tsx
+++ b/frontend/src/old-pages/Configure/util.tsx
@@ -146,4 +146,16 @@ export default function loadTemplate(config: any, callback?: () => void) {
   }
 }
 
-export {loadTemplate}
+function subnetName(subnet: any) {
+  if (!subnet) return null
+  var tags = subnet.Tags
+  if (!tags) {
+    return null
+  }
+  tags = subnet.Tags.filter((t: any) => {
+    return t.Key === 'Name'
+  })
+  return tags.length > 0 ? tags[0].Value : null
+}
+
+export {loadTemplate, subnetName}


### PR DESCRIPTION
## Description
With [ParallelCluster 3.4.0](https://github.com/aws/aws-parallelcluster/releases), customers are able to launch nodes across multiple availability zones, in order to increase capacity availability for their clusters.

This PR aims at adding support for Multi-AZ feature in ParallelCluster Manager.

If the deployed version of PC API is < `3.4.0`, a single `Select` component is displayed in the subnet selection section in the `Queues` page. If PC API version >= `3.4.0` a `MultiSelect` component is displayed instead (see attached images). In this way, users are able to specify multiple subnets in different availability zones.

## Changelog entry
* Added support for Multi-AZ

## How Has This Been Tested?
* Unit tests
* Manual tests with `3.3.0` and `3.4.0` versions

## References
* https://cloudscape.design/components/multiselect/
* https://cloudscape.design/get-started/testing/introduction/

## PR Quality Checklist

- [x] I added tests to new or existing code
- [x] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [x] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
<img width="1725" alt="Screenshot 2022-12-28 at 03 25 00" src="https://user-images.githubusercontent.com/25930133/209784431-4299d4d1-5ca6-43c9-b3d5-7e2152075c72.png">
<img width="1728" alt="Screenshot 2022-12-28 at 03 25 12" src="https://user-images.githubusercontent.com/25930133/209784439-31fc6fe7-4c67-40c9-949e-0955cd7898d9.png">
