### PR TITLE
Add support for onNodeUpdated custom action in HeadNode

### DIFF
--- a/frontend/src/feature-flags/featureFlagsProvider.ts
+++ b/frontend/src/feature-flags/featureFlagsProvider.ts
@@ -21,6 +21,7 @@ const versionToFeaturesMap: Record<string, AvailableFeature[]> = {
     'slurm_queue_update_strategy',
   ],
   '3.3.0': ['slurm_accounting', 'queues_multiple_instance_types'],
+  '3.4.0': ['on_node_updated'],
 }
 
 function composeFlagsListByVersion(currentVersion: string): AvailableFeature[] {

--- a/frontend/src/feature-flags/types.ts
+++ b/frontend/src/feature-flags/types.ts
@@ -17,3 +17,4 @@ export type AvailableFeature =
   | 'slurm_accounting'
   | 'slurm_queue_update_strategy'
   | 'queues_multiple_instance_types'
+  | 'on_node_updated'

--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -59,6 +59,11 @@ type Extension = {
   args: {name: string; default?: string}[]
 }
 
+type ActionsEditorProps = {
+  basePath: string[]
+  errorsPath: string[]
+}
+
 const multiRunner =
   'https://raw.githubusercontent.com/aws-samples/pcluster-manager/main/resources/scripts/multi-runner.py'
 const knownExtensions: Extension[] = [
@@ -650,7 +655,7 @@ function ActionEditor({label, actionKey, errorPath, path}: any) {
   )
 }
 
-function ActionsEditor({basePath, errorsPath}: any) {
+function ActionsEditor({basePath, errorsPath}: ActionsEditorProps) {
   const actionsPath = [...basePath, 'CustomActions']
   const onStartPath = [...actionsPath, 'OnNodeStart']
   const onConfiguredPath = [...actionsPath, 'OnNodeConfigured']
@@ -659,20 +664,49 @@ function ActionsEditor({basePath, errorsPath}: any) {
   const onConfiguredErrors = useState([...errorsPath, 'onConfigured'])
 
   return (
-    <>
-      <SpaceBetween direction="vertical" size="xs">
-        <ActionEditor
-          label="On Start"
-          errorPath={onStartErrors}
-          path={onStartPath}
-        />
-        <ActionEditor
-          label="On Configured"
-          errorPath={onConfiguredErrors}
-          path={onConfiguredPath}
-        />
-      </SpaceBetween>
-    </>
+    <SpaceBetween direction="vertical" size="xs">
+      <ActionEditor
+        label="On Start"
+        errorPath={onStartErrors}
+        path={onStartPath}
+      />
+      <ActionEditor
+        label="On Configured"
+        errorPath={onConfiguredErrors}
+        path={onConfiguredPath}
+      />
+    </SpaceBetween>
+  )
+}
+
+function HeadNodeActionsEditor({basePath, errorsPath}: ActionsEditorProps) {
+  const actionsPath = [...basePath, 'CustomActions']
+  const onStartPath = [...actionsPath, 'OnNodeStart']
+  const onConfiguredPath = [...actionsPath, 'OnNodeConfigured']
+  const onUpdatedPath = [...actionsPath, 'OnNodeUpdated']
+
+  const onStartErrors = useState([...errorsPath, 'onStart'])
+  const onConfiguredErrors = useState([...errorsPath, 'onConfigured'])
+  const onUpdatedErrors = useState([...errorsPath, 'onUpdated'])
+
+  return (
+    <SpaceBetween direction="vertical" size="xs">
+      <ActionEditor
+        label="On Start"
+        errorPath={onStartErrors}
+        path={onStartPath}
+      />
+      <ActionEditor
+        label="On Configured"
+        errorPath={onConfiguredErrors}
+        path={onConfiguredPath}
+      />
+      <ActionEditor
+        label="On Updated"
+        errorPath={onUpdatedErrors}
+        path={onUpdatedPath}
+      />
+    </SpaceBetween>
   )
 }
 
@@ -962,6 +996,7 @@ export {
   InstanceSelect,
   LabeledIcon,
   ActionsEditor,
+  HeadNodeActionsEditor,
   CustomAMISettings,
   RootVolume,
   IamPoliciesEditor,

--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -42,12 +42,13 @@ import {
 
 // Components
 import {
-  ActionsEditor,
+  HeadNodeActionsEditor,
   InstanceSelect,
   RootVolume,
   SecurityGroups,
   SubnetSelect,
   IamPoliciesEditor,
+  ActionsEditor,
 } from './Components'
 import {useFeatureFlag} from '../../feature-flags/useFeatureFlag'
 import {
@@ -83,6 +84,9 @@ function headNodeValidate() {
 
   const onConfiguredPath = [...actionsPath, 'OnNodeConfigured']
   const onConfigured = getState(onConfiguredPath)
+
+  const onUpdatedPath = [...actionsPath, 'OnNodeUpdated']
+  const onUpdated = getState(onUpdatedPath)
 
   let valid = true
 
@@ -151,6 +155,20 @@ function headNodeValidate() {
     valid = false
   } else {
     clearState([...errorsPath, 'onConfigured'])
+  }
+
+  if (
+    onUpdated &&
+    getState([...onUpdatedPath, 'Args']) &&
+    !getState([...onUpdatedPath, 'Script'])
+  ) {
+    setState(
+      [...errorsPath, 'onUpdated'],
+      i18next.t('wizard.headNode.validation.scriptWithArgs'),
+    )
+    valid = false
+  } else {
+    clearState([...errorsPath, 'onUpdated'])
   }
 
   valid = validateSlurmSettings()
@@ -384,7 +402,7 @@ function HeadNode() {
   const subnetErrors = useState([...errorsPath, 'subnet'])
   const subnetValue = useState(subnetPath) || ''
   const editing = useState(['app', 'wizard', 'editing'])
-  let isSlurmAccountingActive = useFeatureFlag('slurm_accounting')
+  const isOnNodeUpdatedActive = useFeatureFlag('on_node_updated')
 
   const toggleImdsSecured = () => {
     const setImdsSecured = !imdsSecured
@@ -464,7 +482,14 @@ function HeadNode() {
             <SecurityGroups basePath={headNodePath} />
           </FormField>
           <ExpandableSection header="Advanced options">
-            <ActionsEditor basePath={headNodePath} errorsPath={errorsPath} />
+            {isOnNodeUpdatedActive ? (
+              <HeadNodeActionsEditor
+                basePath={headNodePath}
+                errorsPath={errorsPath}
+              />
+            ) : (
+              <ActionsEditor basePath={headNodePath} errorsPath={errorsPath} />
+            )}
             <ExpandableSection header="IAM Policies">
               <IamPoliciesEditor basePath={headNodePath} />
             </ExpandableSection>


### PR DESCRIPTION
## Description
With [ParallelCluster 3.4.0](https://github.com/aws/aws-parallelcluster/releases/tag/v3.4.0) users are now able to specify a custom script to be executed in the head node during the update of the cluster. The script can be specified with `OnNodeUpdated` parameter when using Slurm as scheduler.

This PR aims at providing support for `OnNodeUpdated` custom action in ParallelCluster Manager, by adding a dedicated component in the advanced options of the HeadNode section of the wizard (see attached image). 

## Changelog entry
* Added support for `onUpdated` custom action in `HeadNode` section

## How Has This Been Tested?

* Manually tested a dry-run locally using PC API 3.4.0
* Verified that with versions < 3.4.0 the option is not displayed

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<img width="1724" alt="Screenshot 2022-12-28 at 17 40 34" src="https://user-images.githubusercontent.com/25930133/209845155-aa680b60-3d20-4dd4-a89e-809e621712cf.png">
