### PR TITLE
Added Cognito logout implementation

### DIFF
--- a/api/tests/test_logout.py
+++ b/api/tests/test_logout.py
@@ -1,18 +1,29 @@
 import os
 from unittest import mock
+
+import pytest
+from werkzeug.utils import redirect
+
 from api.PclusterApiHandler import logout
 
+@pytest.fixture
+def mock_cognito_redirect(mocker):
+    mocked_cognito_redirect_url = 'some-url/logout?client_id=client_id&redirect_uri=redirect_uri&response_type=code&scope=scope_list'
+    mocked_redirect = redirect(mocked_cognito_redirect_url, code=302)
+    mocker.patch('api.PclusterApiHandler.__cognito_logout_redirect', return_value=mocked_redirect)
 
-def test_logout_redirect():
+    return mocked_cognito_redirect_url
+
+def test_logout_redirect(mock_cognito_redirect):
     """
-    Given an handler for the /logout endpoint
+    Given a handler for the /logout endpoint
       When user logs out
         Then it should redirect to index.html
     """
     res = logout()
 
     assert res.status_code == 302
-    assert res.location == '/index.html'
+    assert res.location == mock_cognito_redirect
 
 def test_logout_clear_cookies(mocker, app):
     """
@@ -26,3 +37,4 @@ def test_logout_clear_cookies(mocker, app):
     assert "accessToken=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/" in cookie_list
     assert "idToken=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/" in cookie_list
     assert "refreshToken=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/" in cookie_list
+    assert "csrf=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/" in cookie_list


### PR DESCRIPTION
## Description
Added Cognito logout implementation as part of the PCM logout process.
<!-- Summary of what this PR introduces and possibly why -->
This PR refactors the previous logout implementation adding the proper redirection to Cognito logout endpoint to allow a user to logout properly and have the chance to login as a different user if needed.

<!-- A sentence to be added to the next release's changelog that captures the changes in this PR -->

## How Has This Been Tested?
- manually
- unit tests
- e2e tests
<!-- The tests you ran to verify your changes -->

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [x] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
