### PR TITLE
Improved /logs endpoint expected json schema

### DIFF
--- a/api/tests/test_push_log.py
+++ b/api/tests/test_push_log.py
@@ -12,7 +12,7 @@ def disable_auth(monkeypatch):
 
 
 def test_push_log_controller_with_valid_json_no_extra(client, caplog, disable_auth, mock_csrf_needed):
-    request_body = [{'message': 'sample-message', 'level': 'info'}]
+    request_body = { 'logs': [{'message': 'sample-message', 'level': 'info'}] }
     expected_log = "INFO     pcluster-manager:logger.py:24 {'message': 'sample-message'}"
 
     caplog.clear()
@@ -23,8 +23,8 @@ def test_push_log_controller_with_valid_json_no_extra(client, caplog, disable_au
 
 
 def test_push_log_controller_with_valid_json_with_extra(client, caplog, disable_auth, mock_csrf_needed):
-    request_body = [{'message': 'sample-message', 'level': 'error',
-                    'extra': {'extra_1': 'value_1', 'extra_2': 'value_2'}}]
+    request_body = { 'logs': [{'message': 'sample-message', 'level': 'error',
+                    'extra': {'extra_1': 'value_1', 'extra_2': 'value_2'}}]}
     expected_log = "ERROR    pcluster-manager:logger.py:30 {'extra_1': 'value_1', 'extra_2': 'value_2', 'message': 'sample-message'}"
 
     caplog.clear()
@@ -35,7 +35,7 @@ def test_push_log_controller_with_valid_json_with_extra(client, caplog, disable_
 
 
 def test_push_log_controller_with_invalid_message_key(client, disable_auth, mock_csrf_needed):
-    request_body = [{'message_wrong': 'sample-message', 'level': 'info'}]
+    request_body = { 'logs': [{'message_wrong': 'sample-message', 'level': 'info'}]}
 
     response = client.post('/logs', json=request_body)
 
@@ -47,7 +47,7 @@ def test_push_log_controller_with_invalid_message_key(client, disable_auth, mock
 
 
 def test_push_log_controller_with_invalid_level_key(client, disable_auth, mock_csrf_needed):
-    request_body = [{'message': 'sample-message', 'level_wrong': 'info'}]
+    request_body = { 'logs': [{'message': 'sample-message', 'level_wrong': 'info'}]}
 
     response = client.post('/logs', json=request_body)
 
@@ -59,7 +59,7 @@ def test_push_log_controller_with_invalid_level_key(client, disable_auth, mock_c
 
 
 def test_push_log_controller_with_invalid_level_value(client, disable_auth, mock_csrf_needed):
-    request_body = [{'message': 'sample-message', 'level': 'wrong-level'}]
+    request_body = { 'logs': [{'message': 'sample-message', 'level': 'wrong-level'}]}
 
     response = client.post('/logs', json=request_body)
 
@@ -70,7 +70,7 @@ def test_push_log_controller_with_invalid_level_value(client, disable_auth, mock
         }
 
 def test_push_log_controller_with_invalid_extra_value(client, disable_auth, mock_csrf_needed):
-    request_body = [{'message': 'sample-message', 'level': 'info', 'extra': 'wrong-value'}]
+    request_body = { 'logs': [{'message': 'sample-message', 'level': 'info', 'extra': 'wrong-value'}]}
 
     response = client.post('/logs', json=request_body)
 

--- a/app.py
+++ b/app.py
@@ -184,10 +184,11 @@ def run():
     @authenticated(ADMINS_GROUP)
     @csrf_needed
     def push_log():
-        if type(request.json) != list:
-            raise ValueError('Body must be a list of log entries')
+        body = request.json
+        if 'logs' not in body:
+            raise ValueError("Request body is missing the mandatory 'logs' key")
 
-        for entry in request.json:
+        for entry in body['logs']:
             level, message, extra = parse_log_entry(logger, entry)
             push_log_entry(logger, level, message, extra)
 


### PR DESCRIPTION
## Description
Improved /logs endpoint expected json schema
<!-- Summary of what this PR introduces and possibly why -->

## Changes
Right now the `/logs` endpoint accepts a json containing a single key `logs` with a list of log entries, like this
```javascript
{
    'logs': [
        { 
            'message': 'sample-message',
            'level': 'info',
            'extra': { ... }
        }
    ]
}
```
<!-- List of relevant changes introduced -->

## Changelog entry

<!-- A sentence to be added to the next release's changelog that captures the changes in this PR -->

## How Has This Been Tested?
- manual
- unit tests

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [x] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
