### PR TITLE
Buffer logs sent from the frontend

### DIFF
--- a/frontend/src/logger/RemoteLogger.ts
+++ b/frontend/src/logger/RemoteLogger.ts
@@ -46,7 +46,7 @@ export class Logger implements ILogger {
     extra['source'] = source || 'frontend'
 
     const logEntry = this.buildMessage(logLevel, message, extra)
-    return this.executeRequest('post', '/logs', logEntry).catch(
+    return this.executeRequest('post', '/logs', {logs: [logEntry]}).catch(
       (err: AxiosError<PostLogError>) =>
         console.warn('Unable to push log entry'),
     )

--- a/frontend/src/logger/__tests__/logger.test.ts
+++ b/frontend/src/logger/__tests__/logger.test.ts
@@ -1,3 +1,4 @@
+import {ILogger} from '../ILogger'
 import {Logger} from '../RemoteLogger'
 
 const mockedExecuteRequest = jest.fn()
@@ -5,19 +6,20 @@ const mockedExecuteRequest = jest.fn()
 describe('Given a RemoteLogger', () => {
   beforeEach(() => {
     mockedExecuteRequest.mockClear()
+    mockedExecuteRequest.mockResolvedValue({status: 200})
   })
 
   describe('when buffering is not enabled', () => {
-    const response = {status: 200}
-    mockedExecuteRequest.mockResolvedValue(response)
-
-    let logger = new Logger(mockedExecuteRequest)
+    let logger: ILogger
+    beforeEach(() => {
+      logger = new Logger(mockedExecuteRequest, {size: 1, window: 0})
+    })
 
     const expectedMethod = 'post'
     const expectedPath = '/logs'
 
-    it('should successfully push a log entry', async () => {
-      const response = await logger.info('info message')
+    it('should successfully push a log entry', () => {
+      logger.info('info message')
 
       const expectedLogEntry = {
         logs: [
@@ -36,11 +38,10 @@ describe('Given a RemoteLogger', () => {
         expectedPath,
         expectedLogEntry,
       )
-      expect(response.status).toBe(200)
     })
 
-    it('should successfully push a log entry with extra parameters', async () => {
-      const response = await logger.error('error message', {
+    it('should successfully push a log entry with extra parameters', () => {
+      logger.error('error message', {
         extra1: 'value1',
         extra2: 'value2',
       })
@@ -65,11 +66,10 @@ describe('Given a RemoteLogger', () => {
         expectedPath,
         expectedLogEntry,
       )
-      expect(response.status).toBe(200)
     })
 
-    it('should successfully push a log entry with a `source` parameter', async () => {
-      await logger.error(
+    it('should successfully push a log entry with a `source` parameter', () => {
+      logger.error(
         'error message',
         {
           extra1: 'value1',
@@ -99,21 +99,82 @@ describe('Given a RemoteLogger', () => {
         expectedLogEntry,
       )
     })
+  })
 
-    it('logs a warning about the impossiblity to push the log entry', async () => {
-      const logSpy = jest.spyOn(console, 'warn')
-      mockedExecuteRequest.mockRejectedValueOnce({
-        Code: 400,
-        Message: 'Error message',
+  describe('when buffering is enabled', () => {
+    let subject: ILogger
+    beforeEach(() => {
+      jest.useFakeTimers()
+      subject = new Logger(mockedExecuteRequest, {size: 2, window: 1 * 1000})
+    })
+    afterEach(() => jest.useRealTimers())
+    describe('when the items logged are less than the buffer size', () => {
+      it('should not send the logs', () => {
+        subject.info('Test log')
+
+        expect(mockedExecuteRequest).not.toHaveBeenCalled()
       })
+    })
 
-      await logger.error('error message', {
-        extra1: 'value1',
-        extra2: 'value2',
-        source: 'frontend',
+    describe('when the items logged are more than the buffer size', () => {
+      it('should flush the buffer', () => {
+        subject.info('Test log')
+        subject.warning('Warning log')
+
+        expect(mockedExecuteRequest).toHaveBeenCalledWith('post', '/logs', {
+          logs: [
+            expect.objectContaining({message: 'Test log'}),
+            expect.objectContaining({message: 'Warning log'}),
+          ],
+        })
       })
+    })
 
-      expect(logSpy).toHaveBeenCalledWith('Unable to push log entry')
+    describe('when the items logged are less than the buffer size but the window time has passed', () => {
+      it('should flush the buffer', () => {
+        subject.info('Test log')
+        jest.advanceTimersByTime(1100)
+
+        expect(mockedExecuteRequest).toHaveBeenCalledWith('post', '/logs', {
+          logs: [expect.objectContaining({message: 'Test log'})],
+        })
+      })
+    })
+
+    describe('when the window time has passed but the buffer is empty', () => {
+      it('should not perform any calls', () => {
+        subject.info('Test log')
+        subject.warning('Warning log')
+        jest.advanceTimersByTime(1100)
+
+        expect(mockedExecuteRequest).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('when the logging call fails', () => {
+      beforeEach(() => {
+        jest.useRealTimers()
+        mockedExecuteRequest.mockReset()
+        mockedExecuteRequest.mockRejectedValue({
+          Code: 400,
+          Message: 'Error message',
+        })
+      })
+      it('should try to send logs at the next log call', async () => {
+        subject.info('Test log')
+        subject.warning('Warning log')
+        await new Promise(resolve => setTimeout(resolve, 1))
+        subject.info('New log')
+
+        expect(mockedExecuteRequest).toHaveBeenCalledTimes(2)
+        expect(mockedExecuteRequest).toHaveBeenCalledWith('post', '/logs', {
+          logs: [
+            expect.objectContaining({message: 'Test log'}),
+            expect.objectContaining({message: 'Warning log'}),
+            expect.objectContaining({message: 'New log'}),
+          ],
+        })
+      })
     })
   })
 })

--- a/frontend/src/logger/__tests__/logger.test.ts
+++ b/frontend/src/logger/__tests__/logger.test.ts
@@ -2,108 +2,118 @@ import {Logger} from '../RemoteLogger'
 
 const mockedExecuteRequest = jest.fn()
 
-describe('given the application config', () => {
+describe('Given a RemoteLogger', () => {
   beforeEach(() => {
     mockedExecuteRequest.mockClear()
   })
 
-  describe('and the executeRequest function', () => {
+  describe('when buffering is not enabled', () => {
     const response = {status: 200}
     mockedExecuteRequest.mockResolvedValue(response)
 
-    describe('and a PCM Logger instance', () => {
-      let logger = new Logger(mockedExecuteRequest)
+    let logger = new Logger(mockedExecuteRequest)
 
-      const expectedMethod = 'post'
-      const expectedPath = '/logs'
+    const expectedMethod = 'post'
+    const expectedPath = '/logs'
 
-      it('should successfully push a log entry', async () => {
-        const response = await logger.info('info message')
+    it('should successfully push a log entry', async () => {
+      const response = await logger.info('info message')
 
-        const expectedLogEntry = {
-          message: 'info message',
-          level: 'INFO',
-          extra: {
-            source: 'frontend',
-          },
-        }
-        expect(mockedExecuteRequest).toHaveBeenCalledTimes(1)
-        expect(mockedExecuteRequest).toHaveBeenCalledWith(
-          expectedMethod,
-          expectedPath,
-          expectedLogEntry,
-        )
-        expect(response.status).toBe(200)
-      })
-
-      it('should successfully push a log entry with extra parameters', async () => {
-        const response = await logger.error('error message', {
-          extra1: 'value1',
-          extra2: 'value2',
-        })
-
-        const expectedLogEntry = {
-          message: 'error message',
-          level: 'ERROR',
-          extra: {
-            extra1: 'value1',
-            extra2: 'value2',
-            source: 'frontend',
-          },
-        }
-
-        expect(mockedExecuteRequest).toHaveBeenCalledTimes(1)
-        expect(mockedExecuteRequest).toHaveBeenCalledWith(
-          expectedMethod,
-          expectedPath,
-          expectedLogEntry,
-        )
-        expect(response.status).toBe(200)
-      })
-
-      it('should successfully push a log entry with a `source` parameter', async () => {
-        const response = await logger.error(
-          'error message',
+      const expectedLogEntry = {
+        logs: [
           {
-            extra1: 'value1',
-            extra2: 'value2',
+            message: 'info message',
+            level: 'INFO',
+            extra: {
+              source: 'frontend',
+            },
           },
-          'different-source',
-        )
+        ],
+      }
+      expect(mockedExecuteRequest).toHaveBeenCalledTimes(1)
+      expect(mockedExecuteRequest).toHaveBeenCalledWith(
+        expectedMethod,
+        expectedPath,
+        expectedLogEntry,
+      )
+      expect(response.status).toBe(200)
+    })
 
-        const expectedLogEntry = {
-          message: 'error message',
-          level: 'ERROR',
-          extra: {
-            extra1: 'value1',
-            extra2: 'value2',
-            source: 'different-source',
-          },
-        }
-
-        expect(mockedExecuteRequest).toHaveBeenCalledTimes(1)
-        expect(mockedExecuteRequest).toHaveBeenCalledWith(
-          expectedMethod,
-          expectedPath,
-          expectedLogEntry,
-        )
+    it('should successfully push a log entry with extra parameters', async () => {
+      const response = await logger.error('error message', {
+        extra1: 'value1',
+        extra2: 'value2',
       })
 
-      it('logs a warning about the impossiblity to push the log entry', async () => {
-        const logSpy = jest.spyOn(console, 'warn')
-        mockedExecuteRequest.mockRejectedValueOnce({
-          Code: 400,
-          Message: 'Error message',
-        })
+      const expectedLogEntry = {
+        logs: [
+          {
+            message: 'error message',
+            level: 'ERROR',
+            extra: {
+              extra1: 'value1',
+              extra2: 'value2',
+              source: 'frontend',
+            },
+          },
+        ],
+      }
 
-        await logger.error('error message', {
+      expect(mockedExecuteRequest).toHaveBeenCalledTimes(1)
+      expect(mockedExecuteRequest).toHaveBeenCalledWith(
+        expectedMethod,
+        expectedPath,
+        expectedLogEntry,
+      )
+      expect(response.status).toBe(200)
+    })
+
+    it('should successfully push a log entry with a `source` parameter', async () => {
+      await logger.error(
+        'error message',
+        {
           extra1: 'value1',
           extra2: 'value2',
-          source: 'frontend',
-        })
+        },
+        'different-source',
+      )
 
-        expect(logSpy).toHaveBeenCalledWith('Unable to push log entry')
+      const expectedLogEntry = {
+        logs: [
+          {
+            message: 'error message',
+            level: 'ERROR',
+            extra: {
+              extra1: 'value1',
+              extra2: 'value2',
+              source: 'different-source',
+            },
+          },
+        ],
+      }
+
+      expect(mockedExecuteRequest).toHaveBeenCalledTimes(1)
+      expect(mockedExecuteRequest).toHaveBeenCalledWith(
+        expectedMethod,
+        expectedPath,
+        expectedLogEntry,
+      )
+    })
+
+    it('logs a warning about the impossiblity to push the log entry', async () => {
+      const logSpy = jest.spyOn(console, 'warn')
+      mockedExecuteRequest.mockRejectedValueOnce({
+        Code: 400,
+        Message: 'Error message',
       })
+
+      await logger.error('error message', {
+        extra1: 'value1',
+        extra2: 'value2',
+        source: 'frontend',
+      })
+
+      expect(logSpy).toHaveBeenCalledWith('Unable to push log entry')
     })
   })
 })


### PR DESCRIPTION
## Description

Introduces a buffering logic when sending logs from the client to the server. Logs are sent to the server when 20 logs have been collected or after 5 seconds.

## How Has This Been Tested?

Locally by using the portal and verified that logs are sent in chunks

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
