### PR TITLE
Avoid returning AWS IAM error as-is

### DIFF
--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -209,9 +209,6 @@ def get_cluster_config_text(cluster_name, region=None):
     else:
         info_resp = sigv4_request("GET", API_BASE_URL, url)
     if info_resp.status_code != 200:
-        if info_resp.status_code == 404:
-            raise ValueError(info_resp.json()['message'])
-
         abort(info_resp.status_code)
 
     cluster_info = info_resp.json()

--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -209,8 +209,11 @@ def get_cluster_config_text(cluster_name, region=None):
     else:
         info_resp = sigv4_request("GET", API_BASE_URL, url)
     if info_resp.status_code != 200:
-        print(info_resp.json())
-        return info_resp.json(), info_resp.status_code
+        if info_resp.status_code == 404:
+            raise ValueError(info_resp.json()['message'])
+
+        abort(info_resp.status_code)
+
     cluster_info = info_resp.json()
     configuration = requests.get(cluster_info["clusterConfiguration"]["url"])
     return configuration.text


### PR DESCRIPTION
## Description

<!-- Summary of what this PR introduces and possibly why -->

## Changes
Switched to exception handler based handling of errors inside `get_cluster_config` operation.
<!-- List of relevant changes introduced -->

## How Has This Been Tested?
- unit tests

<!-- The tests you ran to verify your changes -->

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [x] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
