### PR TITLE
Rename 'Password' field label in Slurm settings to 'Password Secret Arn'

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -227,7 +227,7 @@
         "validation": {
           "databaseCannotBeEmpty": "Database cannot be empty",
           "usernameCannotBeEmpty": "Username cannot be empty",
-          "passwordCannotBeEmpty": "Password cannot be empty",
+          "passwordCannotBeEmpty": "Password Secret Arn cannot be empty",
           "scaledownIdleTimeLessThanOne": "Scaledown idle time should be at least 1 minute"
         },
         "container": {
@@ -242,7 +242,7 @@
           "label": "Username"
         },
         "password": {
-          "label": "Password"
+          "label": "Password Secret Arn"
         },
         "scaledownIdleTime": {
           "label": "Scaledown Idle Time (minutes)",


### PR DESCRIPTION
## Description

In `Slurm Settings` section of `Head Node` step of the wizard, users need to submit a password arn in the `Password` field.
Labeling it just with `Password` may lead to confusion.

## Changelog entry
* Renamed `Password` field label in Slurm settings to `Password Secret Arn` to avoid confusion

## How Has This Been Tested?

* Manually inspected Slurm settings section (see attached image)

<img width="1722" alt="Screenshot 2023-01-02 at 10 37 20" src="https://user-images.githubusercontent.com/25930133/210215242-f5f417f5-bab3-4bb2-9084-53b6d67dd8c2.png">


## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
