### PR TITLE
Clear selected cluster when the region is changed

### DIFF
--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -18,6 +18,7 @@ import {LoadInitialState} from '../model'
 import TopNavigation from '@cloudscape-design/components/top-navigation'
 import {useQueryClient} from 'react-query'
 import {useLogger} from '../logger/LoggerProvider'
+import {NavigateFunction, useNavigate} from 'react-router-dom'
 
 function regions(selected: any) {
   let supportedRegions = [
@@ -87,10 +88,20 @@ function regions(selected: any) {
   })
 }
 
+export const clearClusterOnRegionChange = (
+  path: string,
+  navigate: NavigateFunction,
+): void => {
+  if (path.indexOf('/clusters') > -1) {
+    navigate('/clusters')
+  }
+}
+
 export default function Topbar() {
   let username = useState(['identity', 'attributes', 'email'])
   const queryClient = useQueryClient()
   const logger = useLogger()
+  const navigate = useNavigate()
 
   const defaultRegion = useState(['aws', 'region']) || 'DEFAULT'
   const region = useState(['app', 'selectedRegion']) || defaultRegion
@@ -102,6 +113,7 @@ export default function Topbar() {
   const selectRegion = (region: any) => {
     let newRegion = region.detail.id
     setState(['app', 'selectedRegion'], newRegion)
+    clearClusterOnRegionChange(location.pathname, navigate)
     LoadInitialState(logger)
     queryClient.invalidateQueries()
   }

--- a/frontend/src/components/__tests__/TopBar.test.tsx
+++ b/frontend/src/components/__tests__/TopBar.test.tsx
@@ -1,0 +1,26 @@
+import {NavigateFunction} from 'react-router-dom'
+import {clearClusterOnRegionChange} from '../TopBar'
+
+describe('Given a TopBar component', () => {
+  let navigate: NavigateFunction
+  beforeEach(() => {
+    navigate = jest.fn()
+  })
+
+  describe('when changing the region', () => {
+    describe('when inside the clusters section', () => {
+      it('should clear the selected cluster', () => {
+        clearClusterOnRegionChange('/clusters/selected-cluster', navigate)
+
+        expect(navigate).toHaveBeenCalledWith('/clusters')
+      })
+    })
+    describe('when inside another section', () => {
+      it('should not do anything', () => {
+        clearClusterOnRegionChange('/custom-images', navigate)
+
+        expect(navigate).not.toHaveBeenCalled()
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Description

Fixes a bug where an error message was flashed after switching the region.

## How Has This Been Tested?

- Selected a cluster, changed the region and verified to error message appears

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [x] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
