### PR TITLE
Fix scrollbar in lists and use sticky headers

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -578,9 +578,9 @@
       }
     },
     "node_modules/@cloudscape-design/components": {
-      "version": "3.0.118",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.118.tgz",
-      "integrity": "sha512-rV9JnAockpSY44ZKzuYSvC8QY1wCKAEttG1t+QIqmC/7aOdtm+Y/+vW8NxNY5h8IRkryka99kAcZYK5mzQUYRw==",
+      "version": "3.0.158",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.158.tgz",
+      "integrity": "sha512-y2IS8u5hIs4l6g3SmJptndTdB/TSgHjsLYSQd2iblIQ/J0/GwdpSFJ7oEUEwTK7WZJniIiE2aeBJgxjPylinXg==",
       "dependencies": {
         "@cloudscape-design/collection-hooks": "^1.0.0",
         "@cloudscape-design/test-utils-core": "^1.0.0",
@@ -10362,9 +10362,9 @@
       "requires": {}
     },
     "@cloudscape-design/components": {
-      "version": "3.0.118",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.118.tgz",
-      "integrity": "sha512-rV9JnAockpSY44ZKzuYSvC8QY1wCKAEttG1t+QIqmC/7aOdtm+Y/+vW8NxNY5h8IRkryka99kAcZYK5mzQUYRw==",
+      "version": "3.0.158",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.158.tgz",
+      "integrity": "sha512-y2IS8u5hIs4l6g3SmJptndTdB/TSgHjsLYSQd2iblIQ/J0/GwdpSFJ7oEUEwTK7WZJniIiE2aeBJgxjPylinXg==",
       "requires": {
         "@cloudscape-design/collection-hooks": "^1.0.0",
         "@cloudscape-design/test-utils-core": "^1.0.0",

--- a/frontend/src/old-pages/Clusters/Clusters.tsx
+++ b/frontend/src/old-pages/Clusters/Clusters.tsx
@@ -131,6 +131,7 @@ function ClusterList({clusters}: {clusters: ClusterInfoSummary[]}) {
     <Table
       {...collectionProps}
       variant="full-page"
+      stickyHeader
       header={
         <Header
           variant="awsui-h1-sticky"

--- a/frontend/src/old-pages/CustomImages/CustomImages.tsx
+++ b/frontend/src/old-pages/CustomImages/CustomImages.tsx
@@ -110,6 +110,7 @@ function CustomImagesList() {
       resizableColumns
       trackBy="imageId"
       variant="full-page"
+      stickyHeader
       header={
         <Header
           variant="awsui-h1-sticky"

--- a/frontend/src/old-pages/OfficialImages/OfficialImages.tsx
+++ b/frontend/src/old-pages/OfficialImages/OfficialImages.tsx
@@ -77,6 +77,7 @@ function OfficialImagesList({images}: {images: Image[]}) {
       resizableColumns
       trackBy="amiId"
       variant="full-page"
+      stickyHeader
       header={
         <Header
           variant="awsui-h1-sticky"

--- a/frontend/src/old-pages/Users/Users.tsx
+++ b/frontend/src/old-pages/Users/Users.tsx
@@ -158,6 +158,7 @@ export default function Users(props: any) {
         resizableColumns
         trackBy={item => item.Attributes && item.Attributes.email}
         variant="full-page"
+        stickyHeader
         header={
           <Header
             variant="awsui-h1-sticky"


### PR DESCRIPTION
## Description

Updates Cloudscape after fixing the following issue https://github.com/cloudscape-design/components/issues/459

## Changes

- Cloudscape version bump
- introduce sticky headers on the lists, now working after the fix

## How Has This Been Tested?

Tried the clusters list with 4 clusters and the scrollbar is not shown

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
