### PR TITLE
Added OAuth2 refresh token flow implementation + shortened `id` and `access` token lifespans

### DIFF
--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -22,6 +22,8 @@ from flask import abort, redirect, request
 from flask_restful import Resource, reqparse
 from jose import jwt
 
+from api.exception.exceptions import RefreshTokenError
+from api.pcm_globals import set_auth_cookies_in_context
 from api.security.csrf.constants import CSRF_COOKIE_NAME
 from api.security.csrf.csrf import csrf_needed
 from api.utils import disable_auth
@@ -116,8 +118,24 @@ def sigv4_request(method, host, path, params={}, headers={}, body=None):
 
     return req_call(boto_request.url, data=body_data, headers=boto_request.headers, timeout=30)
 
+def refresh_tokens(refresh_token):
+    auth = requests.auth.HTTPBasicAuth(CLIENT_ID, CLIENT_SECRET)
 
-# Wrappers
+    resp = requests.post(
+        TOKEN_URL,
+        data={"grant_type": 'refresh_token', "refresh_token": refresh_token, "client_id": CLIENT_ID},
+        auth=auth,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    if resp.status_code != 200:
+        raise RefreshTokenError(resp.json().get('error'))
+
+    values = resp.json()
+    access_token = values.get("access_token")
+    id_token = values.get("id_token")
+
+    return {'accessToken': access_token, 'idToken': id_token}
 
 def authenticate(groups):
     if disable_auth():
@@ -130,7 +148,13 @@ def authenticate(groups):
     try:
         decoded = jwt_decode(access_token)
     except jwt.ExpiredSignatureError:
-        return abort(401)
+        refresh_token = request.cookies.get('refreshToken', None)
+        if refresh_token is None:
+            return abort(401)
+
+        tokens = refresh_tokens(refresh_token)
+        decoded = jwt_decode(tokens['accessToken'])
+        set_auth_cookies_in_context(tokens)
     except Exception as e:
         return abort(401)
 
@@ -645,13 +669,13 @@ def login():
         return abort(401)
 
     id_token = code_resp.json().get("id_token")
-    refresh_token = code_resp.json().get("refresh_token")
+    refresh_token = code_resp.json().get("refresh_token", None)
 
-    # give the jwt to the client for future requests
     resp = redirect("/index.html", code=302)
     resp.set_cookie("accessToken", access_token, httponly=True, secure=True, samesite="Lax")
     resp.set_cookie("idToken", id_token, httponly=True, secure=True, samesite="Lax")
-    resp.set_cookie("refreshToken", refresh_token, httponly=True, secure=True, samesite="Lax")
+    if refresh_token is not None:
+        resp.set_cookie("refreshToken", refresh_token, httponly=True, secure=True, samesite="Lax")
     return resp
 
 

--- a/api/exception/exceptions.py
+++ b/api/exception/exceptions.py
@@ -12,3 +12,14 @@ class CSRFError(Forbidden):
 
     def __init__(self, description):
         self.description = description
+
+class RefreshTokenError(Exception):
+    ERROR_FMT = 'Refresh token error: {description}'
+    description = 'Refresh token flow failed'
+
+    def __init__(self, description=None):
+        if description:
+            self.description = self.ERROR_FMT.format(description=description)
+
+    def __str__(self):
+        return self.description

--- a/api/exception/handlers.py
+++ b/api/exception/handlers.py
@@ -4,6 +4,7 @@ from flask import jsonify
 from werkzeug.routing import WebsocketMismatch
 
 from api.exception import CSRFError
+from api.exception.exceptions import RefreshTokenError
 from api.pcm_globals import logger
 
 
@@ -28,6 +29,12 @@ def csrf_error_handler(err):
     descr, code = str(err), 403
     logger.error(descr, extra=dict(status=code, exception=type(err)))
     return __handler_response(code, descr)
+
+def unauthenticated_error_handler(err):
+    descr, code = str(err), 401
+    logger.error(descr, extra=dict(status=code, exception=type(err)))
+    return __handler_response(code, descr)
+
 def global_exception_handler(err):
     try:
         code = err.code
@@ -57,6 +64,7 @@ class ExceptionHandler(object):
 
         app.register_error_handler(CSRFError, csrf_error_handler)
         app.register_error_handler(ValueError, value_error_handler)
+        app.register_error_handler(RefreshTokenError, unauthenticated_error_handler)
         app.register_error_handler(Exception, global_exception_handler)
 
         # in local dev, handle specific Exception caused by HMR requests from FE

--- a/api/pcm_globals.py
+++ b/api/pcm_globals.py
@@ -1,5 +1,6 @@
 from contextvars import ContextVar
 
+from flask import g, Response
 from flask.scaffold import Scaffold
 from werkzeug.local import LocalProxy
 
@@ -9,6 +10,21 @@ _logger_ctxvar = ContextVar('pcm_logger')
 
 logger = LocalProxy(_logger_ctxvar)
 
+def set_auth_cookies_in_context(cookies: dict):
+    g.auth_cookies = cookies
+
+def get_auth_cookies():
+    if 'auth_cookies' not in g:
+        g.auth_cookies = {}
+
+    return g.auth_cookies
+
+auth_cookies = LocalProxy(get_auth_cookies)
+
+def add_auth_cookies(response: Response):
+    for name, value in auth_cookies.items():
+        response.set_cookie(name, value, httponly=True, secure=True, samesite='Lax')
+    return response
 
 class PCMGlobals(object):
     def __init__(self, app: Scaffold = None, running_local=False):
@@ -23,6 +39,10 @@ class PCMGlobals(object):
             _logger_ctxvar.set(_logger)
 
         app.before_request(set_global_logger_before_func)
+
+        # required for setting auth cookies in case of a token refresh
+        app.after_request(add_auth_cookies)
+
 
     def __create_logger(self):
         return DefaultLogger(self.running_local)

--- a/api/tests/test_authenticate.py
+++ b/api/tests/test_authenticate.py
@@ -63,7 +63,7 @@ def test_authenticate_with_signature_exception_returns_401(mocker, app):
 
         mock_abort.assert_called_once_with(401)
 
-def test_authenticate_with_valid_refresh_token(mocker, app):
+def test_authenticate_with_expired_access_token(mocker, app):
     refresh_tokens = {'accessToken': 'access-token', 'idToken': 'id-token'}
     mock_decoded = {USER_ROLES_CLAIM: ['any-group']}
 

--- a/infrastructure/pcluster-manager.yaml
+++ b/infrastructure/pcluster-manager.yaml
@@ -259,11 +259,11 @@ Resources:
       UserPoolId: !If [ UseExistingCognito, !Ref UserPoolId, !GetAtt [ PclusterManagerCognito, Outputs.UserPoolId ]]
       PreventUserExistenceErrors: ENABLED
       RefreshTokenValidity: 7
-      AccessTokenValidity: 1
-      IdTokenValidity: 1
+      AccessTokenValidity: 10
+      IdTokenValidity: 10
       TokenValidityUnits:
-        AccessToken: "days"
-        IdToken: "days"
+        AccessToken: "minutes"
+        IdToken: "minutes"
 
   UserPoolClientSecret:
     Type: Custom::UserPoolClientSecret


### PR DESCRIPTION
## Description
This PR introduces the implementation of the refresh token flow for the OAuth2 protocol, enabling us to shorten token lifespans without breaking user experience.
<!-- Summary of what this PR introduces and possibly why -->

## Changes
- the `authenticate` method now checks if it's possible to refresh tokens when an expired accesstoken is used, and if so it performs the refresh setting new cookies values to be added to the response in a request context ( `g.auth_cookies`) to be used in a custom `afterresponse` func (this was done to avoid handling response objects manually since a view function could return either a dict and a code like in `app.py`, or a true `Response` object, like in `handlers.py`)
- added custom refreshtokenerror exception + handler
- tests have been added and existing tests adjusted
- edited the pcluster-manager.yaml to shorten lifespans of id and access token

## How Has This Been Tested?
- unit tests
- manual tests
- manually deployed PCM in cloudformation to verify shortened ilfespans
<!-- The tests you ran to verify your changes -->

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [x] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
