### PR TITLE
Adopt CloudScape Wizard component

### DIFF
--- a/e2e/specs/wizard.spec.ts
+++ b/e2e/specs/wizard.spec.ts
@@ -20,15 +20,15 @@ test.describe('Given an endpoint where ParallelCluster Manager is deployed', () 
     await page.getByRole('textbox', { name: 'Enter your cluster name' }).fill("testcluster");
     await page.getByRole('button', { name: 'Next' }).click();
     
-    await expect(page.getByRole('heading', { name: 'Cluster Properties' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Cluster' })).toBeVisible()
     await page.getByRole('button', { name: 'Select a VPC' }).click();
     await page.getByText(/vpc-.*/).first().click();
     await page.getByRole('button', { name: 'Next' }).click();
     
-    await expect(page.getByRole('heading', { name: 'Head Node Properties' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Head Node' })).toBeVisible()
     await page.getByRole('button', { name: 'Next' }).click();
   
-    await expect(page.getByRole('heading', { name: 'Storage Properties' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Storage' })).toBeVisible()
     await page.getByRole('button', { name: 'Next' }).click();
   
     await expect(page.getByRole('heading', { name: 'Queues' })).toBeVisible()

--- a/e2e/specs/wizard.template.spec.ts
+++ b/e2e/specs/wizard.template.spec.ts
@@ -28,13 +28,13 @@ test.describe('environment: @demo', () => {
         await page.getByRole('radio', { name: 'Template' }).click();
         await page.getByRole('button', { name: 'Next' }).click();
 
-        await expect(page.getByRole('heading', { name: 'Cluster Properties' })).toBeVisible()
+        await expect(page.getByRole('heading', { name: 'Cluster' })).toBeVisible()
         await page.getByRole('button', { name: 'Next' }).click();
 
-        await expect(page.getByRole('heading', { name: 'Head Node Properties' })).toBeVisible()
+        await expect(page.getByRole('heading', { name: 'Head Node' })).toBeVisible()
         await page.getByRole('button', { name: 'Next' }).click();
 
-        await expect(page.getByRole('heading', { name: 'Storage Properties' })).toBeVisible()
+        await expect(page.getByRole('heading', { name: 'Storage' })).toBeVisible()
         await page.getByRole('button', { name: 'Next' }).click();
 
         await expect(page.getByRole('heading', { name: 'Queues' })).toBeVisible()

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -119,7 +119,15 @@
       "create": "Create",
       "dryRun": "Dry Run"
     },
+    "navigation": {
+      "optional": "optional",
+      "stepNumberLabel": "Step {{stepNumber}}",
+      "collapsedStepsLabel": "Step {{stepNumber}} of {{stepsCount}}",
+      "steps": "Steps"
+    },
     "source" : {
+      "title": "Source",
+      "description": "Choose cluster name and specify the source of the configuration.",
       "validation": {
         "cannotBeBlank": "Cluster name must not be blank.",
         "alreadyExists": "Cluster with name {{clusterName}} already exists. Please choose a unique name.",
@@ -159,11 +167,12 @@
       }
     },
     "cluster": {
+      "title": "Cluster",
+      "description": "Select the region and the VPC where the cluster will be deployed.",
       "validation": {
         "VpcSelect": "You must select a VPC.",
         "customAmiSelect": "You must select an AMI ID if you enable Custom AMI."
       },
-      "title": "Cluster Properties",
       "region": {
         "label": "Region",
         "description": "Region where the cluster will be created.",
@@ -179,14 +188,15 @@
         "description": "VPC where the cluster instances will reside.",
         "selectedAriaLabel": "Selected"
       },
-      "multiuser": {
+      "multiUser": {
         "title": "Multi User",
         "label": "Multi User Cluster",
         "description": "Enable Multi-User cluster through Active Directory integration."
       }
     },
     "headNode": {
-      "title": "HeadNode",
+      "title": "Head Node",
+      "description": "Specify Head Node properties. Optionally define custom actions and additional IAM policies.",
       "validation": {
         "selectSubnet": "You must select a Subnet.",
         "selectInstanceType": "You must select an instance type.",
@@ -263,6 +273,7 @@
     },
     "storage": {
       "title": "Storage",
+      "description": "Select between multiple storage options including EBS, EFS and FSx.",
       "validation": {
         "volumeSize": "You must specify a valid Volume Size."
       },
@@ -344,6 +355,8 @@
       }
     },
     "queues": {
+      "title": "Queues",
+      "description": "Specify queues and compute resources of the cluster",
       "validation": {
         "instanceTypeUnique": "Instance types must be unique within a Queue.",
         "instanceTypeMissing": "Select at least once instance type.",
@@ -410,7 +423,9 @@
         "label": "IAM Policies"
       }
     },
-    "multiuser": {
+    "multiUser": {
+      "title": "Multi User",
+      "description": "Specify existing Active Directory parameters to integrate it with the cluster.",
       "domainName": {
         "name": "Domain Name",
         "description": "The Active Directory (AD) domain that you use for identity information.",
@@ -453,11 +468,15 @@
       }
     },
     "create": {
-      "title": "Cluster Configuration",
-      "description": "This is the cluster configuration that will be used to {{action}} your cluster.",
-      "pending": "{{action}} request pending...",
-      "forceUpdate": "Force Update: Enable this to perform an update while the ComputeFleet is still running.",
-      "disableRollback": "Disable Rollback: Enable this to retain resources in the event of creation failure."
+      "title": "{{action}}",
+      "description": "Shows the generated cluster configuration template.",
+      "configuration": {
+        "title": "Cluster Configuration",
+        "description": "This is the cluster configuration that will be used to {{action}} your cluster.",
+        "pending": "{{action}} request pending...",
+        "forceUpdate": "Force Update: Enable this to perform an update while the ComputeFleet is still running.",
+        "disableRollback": "Disable Rollback: Enable this to retain resources in the event of creation failure."
+      }
     },
     "components": {
       "customAmi": {

--- a/frontend/src/old-pages/Configure/Cluster.tsx
+++ b/frontend/src/old-pages/Configure/Cluster.tsx
@@ -395,16 +395,17 @@ function Cluster() {
         setState(headNodeKPPath, awsConfig.keypairs[0].KeyName)
       }
     }
-  }, [region, config, awsConfig, clusterConfig, wizardLoaded])
+  }, [
+    region,
+    config,
+    awsConfig,
+    clusterConfig,
+    wizardLoaded,
+    isMultipleInstanceTypesActive,
+  ])
 
   return (
-    <Container
-      header={
-        <Header variant="h2">
-          <Trans i18nKey="wizard.cluster.title" />
-        </Header>
-      }
-    >
+    <Container>
       <SpaceBetween direction="vertical" size="s">
         <RegionSelect />
         <OsSelect />
@@ -414,9 +415,9 @@ function Cluster() {
             <Header
               // @ts-expect-error TS(2322) FIXME: Type '"h4"' is not assignable to type 'Variant | u... Remove this comment to see the full error message
               variant="h4"
-              description={t('wizard.cluster.multiuser.description')}
+              description={t('wizard.cluster.multiUser.description')}
             >
-              <Trans i18nKey="wizard.cluster.multiuser.title" />
+              <Trans i18nKey="wizard.cluster.multiUser.title" />
             </Header>
             <Toggle
               disabled={editing}
@@ -425,7 +426,7 @@ function Cluster() {
                 setState(['app', 'wizard', 'multiUser'], !multiUserEnabled)
               }
             >
-              <Trans i18nKey="wizard.cluster.multiuser.label" />
+              <Trans i18nKey="wizard.cluster.multiUser.label" />
             </Toggle>
           </FormField>
         )}

--- a/frontend/src/old-pages/Configure/Create.tsx
+++ b/frontend/src/old-pages/Configure/Create.tsx
@@ -154,11 +154,11 @@ function Create() {
     <Container
       header={
         <Header
-          description={t('wizard.create.description', {
+          description={t('wizard.create.configuration.description', {
             action: editing ? 'update' : 'create',
           })}
         >
-          <Trans i18nKey="wizard.create.title" />
+          <Trans i18nKey="wizard.create.configuration.title" />
         </Header>
       }
     >
@@ -173,7 +173,7 @@ function Create() {
       {pending && (
         <div>
           <Spinner size="normal" />{' '}
-          {t('wizard.create.pending', {action: pending})}
+          {t('wizard.create.configuration.pending', {action: pending})}
         </div>
       )}
       {editing && (
@@ -183,7 +183,7 @@ function Create() {
             setState(['app', 'wizard', 'forceUpdate'], !forceUpdate)
           }
         >
-          {t('wizard.create.forceUpdate')}
+          {t('wizard.create.configuration.forceUpdate')}
         </Toggle>
       )}
       {!editing && (
@@ -193,7 +193,7 @@ function Create() {
             setState(['app', 'wizard', 'disableRollback'], !disableRollback)
           }
         >
-          {t('wizard.create.disableRollback')}
+          {t('wizard.create.configuration.disableRollback')}
         </Toggle>
       )}
     </Container>

--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -416,7 +416,7 @@ function HeadNode() {
 
   return (
     <ColumnLayout columns={1}>
-      <Container header={<Header variant="h2">Head Node Properties</Header>}>
+      <Container>
         <SpaceBetween direction="vertical" size="s">
           <Box>
             <FormField

--- a/frontend/src/old-pages/Configure/MultiUser.tsx
+++ b/frontend/src/old-pages/Configure/MultiUser.tsx
@@ -178,10 +178,10 @@ function AdditionalSssdOptions() {
 function MultiUser() {
   const {t} = useTranslation()
   return (
-    <Container header={<Header variant="h2">Multi User Properties</Header>}>
+    <Container>
       <SpaceBetween direction="vertical" size="xs">
         <span>
-          If you don’t have an exisitng Active Directory you can create an AWS
+          If you don’t have an existing Active Directory you can create an AWS
           managed one following &nbsp;
           <Link
             external
@@ -195,56 +195,56 @@ function MultiUser() {
           .
         </span>
         <HelpTextInput
-          name={t('wizard.multiuser.domainName.name')}
+          name={t('wizard.multiUser.domainName.name')}
           path={dsPath}
           errorsPath={errorsPath}
           configKey={'DomainName'}
-          description={t('wizard.multiuser.domainName.description')}
+          description={t('wizard.multiUser.domainName.description')}
           placeholder={'dc=corp,dc=pcluster,dc=com'}
-          help={t('wizard.multiuser.domainName.help')}
+          help={t('wizard.multiUser.domainName.help')}
           onChange={({detail}) => {
             setState([...dsPath, 'DomainName'], detail.value)
             multiUserValidate()
           }}
         />
         <HelpTextInput
-          name={t('wizard.multiuser.domainAddress.name')}
+          name={t('wizard.multiUser.domainAddress.name')}
           path={dsPath}
           errorsPath={errorsPath}
           configKey={'DomainAddr'}
-          description={t('wizard.multiuser.domainAddress.description')}
+          description={t('wizard.multiUser.domainAddress.description')}
           placeholder={'ldaps://corp.pcluster.com'}
-          help={t('wizard.multiuser.domainAddress.help')}
+          help={t('wizard.multiUser.domainAddress.help')}
           onChange={({detail}) => {
             setState([...dsPath, 'DomainAddr'], detail.value)
             multiUserValidate()
           }}
         />
         <HelpTextInput
-          name={t('wizard.multiuser.passwordSecretArn.name')}
+          name={t('wizard.multiUser.passwordSecretArn.name')}
           path={dsPath}
           errorsPath={errorsPath}
           configKey={'PasswordSecretArn'}
-          description={t('wizard.multiuser.passwordSecretArn.description')}
+          description={t('wizard.multiUser.passwordSecretArn.description')}
           placeholder={
             'arn:aws:secretsmanager:region:000000000000:secret:secret_name'
           }
-          help={t('wizard.multiuser.passwordSecretArn.help')}
+          help={t('wizard.multiUser.passwordSecretArn.help')}
           onChange={({detail}) => {
             setState([...dsPath, 'PasswordSecretArn'], detail.value)
             multiUserValidate()
           }}
         />
         <HelpTextInput
-          name={t('wizard.multiuser.domainReadOnlyUser.name')}
+          name={t('wizard.multiUser.domainReadOnlyUser.name')}
           path={dsPath}
           errorsPath={errorsPath}
           configKey={'DomainReadOnlyUser'}
-          description={t('wizard.multiuser.domainReadOnlyUser.description')}
+          description={t('wizard.multiUser.domainReadOnlyUser.description')}
           placeholder={
             'cn=ReadOnlyUser,ou=Users,ou=CORP,dc=corp,dc=pcluster,dc=com'
           }
-          help={t('wizard.multiuser.domainReadOnlyUser.help')}
+          help={t('wizard.multiUser.domainReadOnlyUser.help')}
           onChange={({detail}) => {
             setState([...dsPath, 'DomainReadOnlyUser'], detail.value)
             multiUserValidate()
@@ -253,51 +253,51 @@ function MultiUser() {
         <ExpandableSection header="Advanced options">
           <SpaceBetween direction="vertical" size="xs">
             <HelpTextInput
-              name={t('wizard.multiuser.caCertificate.name')}
+              name={t('wizard.multiUser.caCertificate.name')}
               path={dsPath}
               errorsPath={errorsPath}
               configKey={'LdapTlsCaCert'}
-              description={t('wizard.multiuser.caCertificate.description')}
+              description={t('wizard.multiUser.caCertificate.description')}
               placeholder={'/path/to/certificate.pem'}
-              help={t('wizard.multiuser.caCertificate.help')}
+              help={t('wizard.multiUser.caCertificate.help')}
               onChange={({detail}) => {
                 setState([...dsPath, 'LdapTlsCaCert'], detail.value)
                 multiUserValidate()
               }}
             />
             <HelpTextInput
-              name={t('wizard.multiuser.requireCertificate.name')}
+              name={t('wizard.multiUser.requireCertificate.name')}
               path={dsPath}
               errorsPath={errorsPath}
               configKey={'LdapTlsReqCert'}
-              description={t('wizard.multiuser.requireCertificate.description')}
+              description={t('wizard.multiUser.requireCertificate.description')}
               placeholder={'hard'}
-              help={t('wizard.multiuser.requireCertificate.help')}
+              help={t('wizard.multiUser.requireCertificate.help')}
               onChange={({detail}) => {
                 setState([...dsPath, 'LdapTlsReqCert'], detail.value)
                 multiUserValidate()
               }}
             />
             <HelpTextInput
-              name={t('wizard.multiuser.LDAPAccessFilter.name')}
+              name={t('wizard.multiUser.LDAPAccessFilter.name')}
               path={dsPath}
               errorsPath={errorsPath}
               configKey={'LdapAccessFilter'}
-              description={t('wizard.multiuser.LDAPAccessFilter.description')}
+              description={t('wizard.multiUser.LDAPAccessFilter.description')}
               placeholder={
                 'memberOf=cn=TeamOne,ou=Users,ou=CORP,dc=corp,dc=pcluster,dc=com'
               }
-              help={t('wizard.multiuser.LDAPAccessFilter.help')}
+              help={t('wizard.multiUser.LDAPAccessFilter.help')}
               onChange={({detail}) => {
                 setState([...dsPath, 'LdapAccessFilter'], detail.value)
                 multiUserValidate()
               }}
             />
             <HelpToggle
-              name={t('wizard.multiuser.generateSSHKeys.name')}
+              name={t('wizard.multiUser.generateSSHKeys.name')}
               configKey={'GenerateSshKeysForUsers'}
-              description={t('wizard.multiuser.generateSSHKeys.description')}
-              help={t('wizard.multiuser.generateSSHKeys.help')}
+              description={t('wizard.multiUser.generateSSHKeys.description')}
+              help={t('wizard.multiUser.generateSSHKeys.help')}
               defaultValue={true}
             />
             <AdditionalSssdOptions />

--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -1072,7 +1072,7 @@ function Storage() {
   }
 
   return (
-    <Container header={<Header variant="h2">Storage Properties</Header>}>
+    <Container>
       <div style={{display: 'flex', flexDirection: 'column', gap: '20px'}}>
         {storages ? (
           storages.map((_: any, i: any) => (

--- a/frontend/src/old-pages/Configure/__tests__/useWizardNavigation.test.tsx
+++ b/frontend/src/old-pages/Configure/__tests__/useWizardNavigation.test.tsx
@@ -1,0 +1,314 @@
+import {Store} from '@reduxjs/toolkit'
+import {renderHook} from '@testing-library/react-hooks'
+import {mock} from 'jest-mock-extended'
+import {Provider} from 'react-redux'
+import {useWizardNavigation} from '../useWizardNavigation'
+import {pages} from '../useWizardNavigation'
+
+jest.mock('../../../store', () => {
+  const originalModule = jest.requireActual('../../../store')
+  return {
+    __esModule: true,
+    ...originalModule,
+    setState: jest.fn(),
+  }
+})
+import {setState} from '../../../store'
+
+const mockStore = mock<Store>()
+mockStore.dispatch.mockImplementation(jest.fn())
+const validate = jest.fn()
+
+describe('Given a hook to navigate through the wizard', () => {
+  describe('when on a page different from create page', () => {
+    beforeEach(() => {
+      mockStore.getState.mockReturnValue({
+        app: {
+          wizard: {
+            page: 'source',
+          },
+        },
+      })
+    })
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+    describe('if page is validated, when clicking next button', () => {
+      beforeEach(() => {
+        validate.mockReturnValue(true)
+      })
+
+      it('should navigate to the next page', () => {
+        const {result} = renderHook(() => useWizardNavigation(validate), {
+          wrapper: ({children}) => {
+            return <Provider store={mockStore}>{children}</Provider>
+          },
+        })
+
+        const pageIdx = pages.indexOf('source')
+        result.current('next', pageIdx + 1)
+        expect(setState).toHaveBeenCalledWith(
+          ['app', 'wizard', 'page'],
+          pages[pageIdx + 1],
+        )
+      })
+    }),
+      describe('if page is not validated, when clicking next button', () => {
+        beforeEach(() => {
+          validate.mockReturnValue(false)
+        })
+
+        it('should remain on the same page', () => {
+          const {result} = renderHook(() => useWizardNavigation(validate), {
+            wrapper: ({children}) => {
+              return <Provider store={mockStore}>{children}</Provider>
+            },
+          })
+
+          result.current('next', 1)
+          expect(setState).not.toHaveBeenCalled()
+        })
+      })
+  })
+
+  describe('when on a page different from source page', () => {
+    const page = 'storage'
+    beforeEach(() => {
+      mockStore.getState.mockReturnValue({
+        app: {
+          wizard: {
+            page: page,
+          },
+        },
+      })
+    })
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+    describe('if page is not validated, when clicking back button', () => {
+      beforeEach(() => {
+        validate.mockReturnValue(false)
+      })
+
+      it('should navigate to the previous page', () => {
+        const {result} = renderHook(() => useWizardNavigation(validate), {
+          wrapper: ({children}) => {
+            return <Provider store={mockStore}>{children}</Provider>
+          },
+        })
+
+        const pageIdx = pages.indexOf(page)
+        result.current('previous', pageIdx - 1)
+        expect(setState).toHaveBeenCalledWith(
+          ['app', 'wizard', 'page'],
+          pages[pageIdx - 1],
+        )
+      })
+    })
+    describe('if page is validated, when clicking back button', () => {
+      beforeEach(() => {
+        validate.mockReturnValue(true)
+      })
+
+      it('should navigate to the previous page', () => {
+        const {result} = renderHook(() => useWizardNavigation(validate), {
+          wrapper: ({children}) => {
+            return <Provider store={mockStore}>{children}</Provider>
+          },
+        })
+
+        const pageIdx = pages.indexOf(page)
+        result.current('previous', pageIdx - 1)
+        expect(setState).toHaveBeenCalledWith(
+          ['app', 'wizard', 'page'],
+          pages[pageIdx - 1],
+        )
+      })
+    })
+  })
+
+  describe('when on cluster page', () => {
+    const page = 'cluster'
+    describe('if multiUser is enabled, and the page is validated, when clicking next button', () => {
+      beforeEach(() => {
+        mockStore.getState.mockReturnValue({
+          app: {
+            wizard: {
+              page: page,
+              multiUser: true,
+            },
+          },
+        })
+        validate.mockReturnValue(true)
+      })
+
+      it('should navigate to multiUser page', () => {
+        const {result} = renderHook(() => useWizardNavigation(validate), {
+          wrapper: ({children}) => {
+            return <Provider store={mockStore}>{children}</Provider>
+          },
+        })
+        const pageIdx = pages.indexOf(page)
+        result.current('next', pageIdx + 1)
+        expect(setState).toHaveBeenCalledWith(
+          ['app', 'wizard', 'page'],
+          pages[pageIdx + 1],
+        )
+      })
+    })
+    describe('if multiUser is not enabled, and the page is validated, when clicking next button', () => {
+      beforeEach(() => {
+        mockStore.getState.mockReturnValue({
+          app: {
+            wizard: {
+              page: 'cluster',
+              multiUser: false,
+            },
+          },
+        })
+        validate.mockReturnValue(true)
+      })
+
+      it('should skip multiUser page and navigate to headNode page', () => {
+        const {result} = renderHook(() => useWizardNavigation(validate), {
+          wrapper: ({children}) => {
+            return <Provider store={mockStore}>{children}</Provider>
+          },
+        })
+        const pageIdx = pages.indexOf(page)
+        result.current('next', pageIdx + 2)
+        expect(setState).toHaveBeenCalledWith(
+          ['app', 'wizard', 'page'],
+          pages[pageIdx + 2],
+        )
+      })
+    })
+  })
+
+  describe('when on headNode page', () => {
+    const page = 'headNode'
+    describe('if multiUser is enabled, when clicking back button', () => {
+      beforeEach(() => {
+        mockStore.getState.mockReturnValue({
+          app: {
+            wizard: {
+              page: page,
+              multiUser: true,
+            },
+          },
+        })
+        validate.mockReturnValue(true)
+      })
+
+      it('should navigate to multiUser page', () => {
+        const {result} = renderHook(() => useWizardNavigation(validate), {
+          wrapper: ({children}) => {
+            return <Provider store={mockStore}>{children}</Provider>
+          },
+        })
+        const pageIdx = pages.indexOf(page)
+        result.current('previous', pageIdx - 1)
+        expect(setState).toHaveBeenCalledWith(
+          ['app', 'wizard', 'page'],
+          pages[pageIdx - 1],
+        )
+      })
+    })
+    describe('if multiUser is not enabled, when clicking back button', () => {
+      beforeEach(() => {
+        mockStore.getState.mockReturnValue({
+          app: {
+            wizard: {
+              page: 'headNode',
+              multiUser: false,
+            },
+          },
+        })
+        validate.mockReturnValue(true)
+      })
+
+      it('should skip multiUser page and navigate back to cluster page', () => {
+        const {result} = renderHook(() => useWizardNavigation(validate), {
+          wrapper: ({children}) => {
+            return <Provider store={mockStore}>{children}</Provider>
+          },
+        })
+        const pageIdx = pages.indexOf(page)
+        result.current('previous', pageIdx - 2)
+        expect(setState).toHaveBeenCalledWith(
+          ['app', 'wizard', 'page'],
+          pages[pageIdx - 2],
+        )
+      })
+    })
+  })
+
+  describe('when on a page', () => {
+    const page = 'queues'
+    beforeEach(() => {
+      mockStore.getState.mockReturnValue({
+        app: {
+          wizard: {
+            page: page,
+          },
+        },
+      })
+    })
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+    describe('when selecting a previous page through the wizard navigation pane', () => {
+      beforeEach(() => {
+        validate.mockReturnValue(false)
+      })
+      it('should navigate to the selected page, despite the fact that the page is validated or not', () => {
+        const {result} = renderHook(() => useWizardNavigation(validate), {
+          wrapper: ({children}) => {
+            return <Provider store={mockStore}>{children}</Provider>
+          },
+        })
+        const clusterIdx = pages.indexOf('cluster')
+        result.current('step', clusterIdx)
+        expect(setState).toHaveBeenCalledWith(
+          ['app', 'wizard', 'page'],
+          'cluster',
+        )
+      })
+    })
+    describe('when selecting a following page through the wizard navigation pane', () => {
+      describe('if the page is validated', () => {
+        beforeEach(() => {
+          validate.mockReturnValue(true)
+        })
+        it('should navigate to the selected page', () => {
+          const {result} = renderHook(() => useWizardNavigation(validate), {
+            wrapper: ({children}) => {
+              return <Provider store={mockStore}>{children}</Provider>
+            },
+          })
+          const createIdx = pages.indexOf('create')
+          result.current('step', createIdx)
+          expect(setState).toHaveBeenCalledWith(
+            ['app', 'wizard', 'page'],
+            'create',
+          )
+        })
+      })
+      describe('if the page is not validated', () => {
+        beforeEach(() => {
+          validate.mockReturnValue(false)
+        })
+        it('should remain on the same page', () => {
+          const {result} = renderHook(() => useWizardNavigation(validate), {
+            wrapper: ({children}) => {
+              return <Provider store={mockStore}>{children}</Provider>
+            },
+          })
+          const createIdx = pages.indexOf('create')
+          result.current('step', createIdx)
+          expect(setState).not.toHaveBeenCalled()
+        })
+      })
+    })
+  })
+})

--- a/frontend/src/old-pages/Configure/__tests__/useWizardNavigation.test.tsx
+++ b/frontend/src/old-pages/Configure/__tests__/useWizardNavigation.test.tsx
@@ -127,6 +127,36 @@ describe('Given a hook to navigate through the wizard', () => {
     })
   })
 
+  describe('when on create page', () => {
+    const page = 'create'
+    describe('if the user has uploaded a file, when clicking back button', () => {
+      beforeEach(() => {
+        mockStore.getState.mockReturnValue({
+          app: {
+            wizard: {
+              page: page,
+              source: {
+                type: 'upload',
+              },
+            },
+          },
+        })
+      })
+      it('should navigate back to source page', () => {
+        const {result} = renderHook(() => useWizardNavigation(validate), {
+          wrapper: ({children}) => {
+            return <Provider store={mockStore}>{children}</Provider>
+          },
+        })
+        result.current('previous', 0)
+        expect(setState).toHaveBeenCalledWith(
+          ['app', 'wizard', 'page'],
+          'source',
+        )
+      })
+    })
+  })
+
   describe('when on cluster page', () => {
     const page = 'cluster'
     describe('if multiUser is enabled, and the page is validated, when clicking next button', () => {

--- a/frontend/src/old-pages/Configure/useWizardNavigation.ts
+++ b/frontend/src/old-pages/Configure/useWizardNavigation.ts
@@ -1,0 +1,109 @@
+import {getState, setState, updateState, useState} from '../../store'
+// @ts-expect-error TS(7016) FIXME: Could not find a declaration file for module 'js-y... Remove this comment to see the full error message
+import jsyaml from 'js-yaml'
+
+const pages = [
+  'source',
+  'cluster',
+  'multiUser',
+  'headNode',
+  'storage',
+  'queues',
+  'create',
+]
+
+export const useWizardNavigation = (validate: (page: string) => boolean) => {
+  const currentPage = useState(['app', 'wizard', 'page']) || 'source'
+  const isMultiUserEnabled = useState(['app', 'wizard', 'multiUser'])
+  const source = useState(['app', 'wizard', 'source', 'type'])
+
+  return (reason: string, requestedStepIndex: number) => {
+    switch (reason) {
+      case 'next':
+        handleNext(currentPage, isMultiUserEnabled, validate)
+        break
+      case 'previous':
+        handlePrev(currentPage, source, isMultiUserEnabled)
+        break
+      case 'step':
+        handleStep(currentPage, pages[requestedStepIndex], validate)
+        break
+      default:
+        setPage('source')
+    }
+  }
+}
+
+const handleNext = (
+  currentPage: string,
+  isMultiUserEnabled: boolean,
+  validate: (page: string) => boolean,
+) => {
+  if (validate(currentPage))
+    updateState(['app', 'wizard', 'validated'], (existing: any) =>
+      (existing || new Set()).add(currentPage),
+    )
+  else return
+
+  if (currentPage === 'cluster') {
+    if (isMultiUserEnabled) {
+      setPage('multiUser')
+      return
+    } else {
+      setPage('headNode')
+      return
+    }
+  }
+  const nextPage = pages[pages.indexOf(currentPage) + 1]
+  setPage(nextPage)
+}
+
+const handlePrev = (
+  currentPage: string,
+  source: string,
+  isMultiUserEnabled: boolean,
+) => {
+  setState(['app', 'wizard', 'errors'], null)
+
+  // Special case where the user uploaded a file, hitting "back"
+  // goes back to the upload screen rather than through the wizard
+  if (currentPage === 'create' && source === 'upload') {
+    setPage('source')
+    return
+  }
+  if (currentPage === 'headNode') {
+    if (isMultiUserEnabled) {
+      setPage('multiUser')
+      return
+    } else {
+      setPage('cluster')
+      return
+    }
+  }
+  const prevPage = pages[pages.indexOf(currentPage) - 1]
+  setPage(prevPage)
+}
+
+const handleStep = (
+  currentPage: string,
+  requestedPage: string,
+  validate: (page: string) => boolean,
+) => {
+  if (
+    pages.indexOf(requestedPage) < pages.indexOf(currentPage) ||
+    validate(currentPage)
+  ) {
+    setPage(requestedPage)
+  }
+}
+
+function setPage(page: string) {
+  const config = getState(['app', 'wizard', 'config'])
+  if (page === 'create') {
+    console.log(jsyaml.dump(config))
+    setState(['app', 'wizard', 'clusterConfigYaml'], jsyaml.dump(config))
+  }
+  setState(['app', 'wizard', 'page'], page)
+}
+
+export {pages}


### PR DESCRIPTION
## Description
This PR introduces the CloudScape [Wizard](https://cloudscape.design/components/wizard/?tabId=playground) component in the create cluster wizard.

## Changelog entry

* Adopted CloudScape Wizard component in the create cluster wizard

## How Has This Been Tested?
* Created new cluster
   * Navigated through wizard (next, back, select step)
   * Enable/disable MultiUser and verified that navigation works as expected
   * Dry-run successful
   
* Updated existing cluster
   * Verified options are loaded and validated correctly 
   * Dry-run successful

## References

* https://cloudscape.design/components/wizard/

## PR Quality Checklist

- [x] I added tests to new or existing code
- [x] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<img width="1725" alt="Screenshot 2023-01-09 at 09 53 44" src="https://user-images.githubusercontent.com/25930133/211270841-87bb1182-144e-485b-90ec-b5ece03d8ced.png">
