### PR TITLE
Limit invocations on API Gateway routes

### DIFF
--- a/infrastructure/pcluster-manager.yaml
+++ b/infrastructure/pcluster-manager.yaml
@@ -237,6 +237,9 @@ Resources:
       ApiId: !Ref ApiGateway
       StageName: $default
       AutoDeploy: True
+      DefaultRouteSettings:
+        ThrottlingBurstLimit: 50 
+        ThrottlingRateLimit: 100
 
   CognitoAppClient:
     Type: AWS::Cognito::UserPoolClient


### PR DESCRIPTION
## Description

By default API Gateway has large throttling limits: this change ensures a reasonable limit is used instead.

## How Has This Been Tested?

- created a new env and verified a user don't get throttled with those limits

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [x] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
