### PR TITLE
Fix e2e tests broken after #465

### DIFF
--- a/e2e/specs/wizard.spec.ts
+++ b/e2e/specs/wizard.spec.ts
@@ -31,7 +31,7 @@ test.describe('Given an endpoint where ParallelCluster Manager is deployed', () 
     await expect(page.getByRole('heading', { name: 'Storage' })).toBeVisible()
     await page.getByRole('button', { name: 'Next' }).click();
   
-    await expect(page.getByRole('heading', { name: 'Queues' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Queues' }).first()).toBeVisible()
     await page.getByRole('button', { name: 'Next' }).click();
   
     await expect(page.getByRole('heading', { name: 'Cluster Configuration' })).toBeVisible()

--- a/e2e/specs/wizard.template.spec.ts
+++ b/e2e/specs/wizard.template.spec.ts
@@ -28,7 +28,7 @@ test.describe('environment: @demo', () => {
         await page.getByRole('radio', { name: 'Template' }).click();
         await page.getByRole('button', { name: 'Next' }).click();
 
-        await expect(page.getByRole('heading', { name: 'Cluster' })).toBeVisible()
+        await expect(page.getByRole('heading', { name: 'Cluster', exact: true })).toBeVisible()
         await page.getByRole('button', { name: 'Next' }).click();
 
         await expect(page.getByRole('heading', { name: 'Head Node' })).toBeVisible()
@@ -37,7 +37,7 @@ test.describe('environment: @demo', () => {
         await expect(page.getByRole('heading', { name: 'Storage' })).toBeVisible()
         await page.getByRole('button', { name: 'Next' }).click();
 
-        await expect(page.getByRole('heading', { name: 'Queues' })).toBeVisible()
+        await expect(page.getByRole('heading', { name: 'Queues' }).first()).toBeVisible()
         await page.getByRole('button', { name: 'Next' }).click();
 
         await expect(page.getByRole('heading', { name: 'Cluster Configuration' })).toBeVisible()


### PR DESCRIPTION
## Description

Fix e2e tests broken due to https://github.com/aws-samples/pcluster-manager/pull/465.

## How Has This Been Tested?

* `npx playwright test` executed successfully against local and demo environment

## References

* https://github.com/aws-samples/pcluster-manager/pull/465

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
