### PR TITLE
Allow multiple tabs by not creating a new csrf token if one is already present

### DIFF
--- a/api/security/csrf/__init__.py
+++ b/api/security/csrf/__init__.py
@@ -1,6 +1,6 @@
-from flask import Flask, Blueprint, current_app, jsonify
+from flask import Flask, Blueprint, current_app, jsonify, request
 
-from api.security.csrf.constants import CSRF_SECRET_KEY, SALT
+from api.security.csrf.constants import CSRF_SECRET_KEY, SALT, CSRF_COOKIE_NAME
 from api.security.csrf.csrf import generate_csrf_token, set_csrf_cookie
 
 from api.security.fingerprint import IFingerprintGenerator
@@ -10,8 +10,10 @@ csrf_blueprint = Blueprint('csrf', __name__)
 
 @csrf_blueprint.get('/csrf')
 def get_and_set_csrf_token():
-    csrf_secret_key = current_app.config.get(CSRF_SECRET_KEY)
-    csrf_token = generate_csrf_token(csrf_secret_key, SALT)
+    csrf_token = request.cookies.get(CSRF_COOKIE_NAME)
+    if not csrf_token:
+        csrf_secret_key = current_app.config.get(CSRF_SECRET_KEY)
+        csrf_token = generate_csrf_token(csrf_secret_key, SALT)
 
     resp = jsonify(csrf_token=csrf_token)
     set_csrf_cookie(resp, csrf_token)

--- a/api/tests/security/csrf/test_csrf.py
+++ b/api/tests/security/csrf/test_csrf.py
@@ -23,8 +23,9 @@ def test_crsf_extension_get_new_csrf(app):
     When an app is built
         and CSRF ext is applied
             it should expose a new endpoint /csrf
-            it should set csrf cookie
-            it should return a csrf_token in a json
+            when a csrf cookie is not set in the incoming request
+              it should set a new csrf cookie
+              it should return the csrf_token in a json
     """
     CSRF(app)
     resp = app.test_client().get('/csrf')
@@ -41,8 +42,8 @@ def test_crsf_extension_get_existing_csrf(app):
     When an app is built
         and CSRF ext is applied
             it should expose a new endpoint /csrf
-            it should set csrf cookie if not already present
-            it should return the aforementioned csrf_token in a json
+            when a csrf cookie is already set in the incoming request
+              it should return the csrf_token in a json
     """
     CSRF(app)
     test_client = app.test_client()

--- a/api/tests/security/csrf/test_csrf.py
+++ b/api/tests/security/csrf/test_csrf.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import ANY, call
 
 import pytest
@@ -17,7 +18,7 @@ def mock_urandom(mocker):
     return mocker.patch('os.urandom', return_value=MOCK_URANDOM_VALUE)
 
 
-def test_crsf_extension(app):
+def test_crsf_extension_get_new_csrf(app):
     """
     When an app is built
         and CSRF ext is applied
@@ -32,6 +33,27 @@ def test_crsf_extension(app):
 
     assert resp.status_code != 405
     assert 'csrf_token' in resp.json
+    assert len(csrf_cookies) > 0
+    assert 'Secure; HttpOnly; Path=/; SameSite=Lax' in csrf_cookies[0]
+
+def test_crsf_extension_get_existing_csrf(app):
+    """
+    When an app is built
+        and CSRF ext is applied
+            it should expose a new endpoint /csrf
+            it should set csrf cookie
+            it should return a csrf_token in a json
+    """
+    CSRF(app)
+    test_client = app.test_client()
+    test_client.set_cookie(os.getenv('SITE_URL'), 'csrf', 'csrf-value', samesite='Lax', httponly=True, secure=True)
+    resp = test_client.get('/csrf')
+    csrf_cookies = list(cookie_value for cookie_header, cookie_value in resp.headers if
+                        'Set-Cookie' in cookie_header and CSRF_COOKIE_NAME in cookie_value)
+
+    assert resp.status_code != 405
+    assert 'csrf_token' in resp.json
+    assert resp.json.get('csrf_token') == 'csrf-value'
     assert len(csrf_cookies) > 0
     assert 'Secure; HttpOnly; Path=/; SameSite=Lax' in csrf_cookies[0]
 

--- a/api/tests/security/csrf/test_csrf.py
+++ b/api/tests/security/csrf/test_csrf.py
@@ -41,8 +41,8 @@ def test_crsf_extension_get_existing_csrf(app):
     When an app is built
         and CSRF ext is applied
             it should expose a new endpoint /csrf
-            it should set csrf cookie
-            it should return a csrf_token in a json
+            it should set csrf cookie if not already present
+            it should return the aforementioned csrf_token in a json
     """
     CSRF(app)
     test_client = app.test_client()


### PR DESCRIPTION
## Description
This PR slightly changes the implementation of the get csrf token endpoint to return the already present csrf token if there's one.
<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [x] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
