### PR TITLE
Add endpoints validators

### DIFF
--- a/api/validation/schemas.py
+++ b/api/validation/schemas.py
@@ -1,6 +1,6 @@
 from marshmallow import Schema, fields, validate, INCLUDE
 
-from api.validation.validators import comma_splittable, aws_region_validator
+from api.validation.validators import comma_splittable, aws_region_validator, is_alphanumeric_with_hyphen
 
 
 class EC2ActionSchema(Schema):
@@ -24,3 +24,28 @@ class DeleteUserSchema(Schema):
     username = fields.UUID(required=True)
 
 DeleteUser = DeleteUserSchema(unknown=INCLUDE)
+
+
+class GetClusterConfigSchema(Schema):
+    region = fields.String(validate=aws_region_validator)
+    cluster_name = fields.String(required=True, validate=is_alphanumeric_with_hyphen)
+
+GetClusterConfig = GetClusterConfigSchema(unknown=INCLUDE)
+
+
+class GetCustomImageConfigSchema(Schema):
+    image_id = fields.String(required=True, validate=is_alphanumeric_with_hyphen)
+
+GetCustomImageConfig = GetCustomImageConfigSchema(unknown=INCLUDE)
+
+
+class GetAwsConfigSchema(Schema):
+    region = fields.String(validate=aws_region_validator)
+
+GetAwsConfig = GetAwsConfigSchema(unknown=INCLUDE)
+
+
+class GetInstanceTypesSchema(Schema):
+    region = fields.String(validate=aws_region_validator)
+
+GetInstanceTypes = GetInstanceTypesSchema(unknown=INCLUDE)

--- a/api/validation/validators.py
+++ b/api/validation/validators.py
@@ -1,4 +1,5 @@
 from marshmallow import validate
+import re
 
 # PC available regions
 PC_REGIONS = [
@@ -18,5 +19,11 @@ def comma_splittable(arg: str):
         return True
     except:
         return False
+
+
+def is_alphanumeric_with_hyphen(arg: str):
+    pattern = re.compile(r"^[a-zA-Z][a-zA-Z0-9-]+$")
+    return bool(re.fullmatch(pattern, arg))
+
 
 aws_region_validator = validate.OneOf(choices=PC_REGIONS)

--- a/app.py
+++ b/app.py
@@ -46,7 +46,7 @@ from api.security.csrf import CSRF
 from api.security.csrf.csrf import csrf_needed
 from api.security.fingerprint import CognitoFingerprintGenerator
 from api.validation import validated, EC2Action
-from api.validation.schemas import CreateUser, DeleteUser
+from api.validation.schemas import CreateUser, DeleteUser, GetClusterConfig, GetCustomImageConfig, GetAwsConfig, GetInstanceTypes
 
 ADMINS_GROUP = { "admin" }
 
@@ -94,21 +94,25 @@ def run():
 
     @app.route("/manager/get_cluster_configuration")
     @authenticated(ADMINS_GROUP)
+    @validated(params=GetClusterConfig)
     def get_cluster_config_():
         return get_cluster_config()
 
     @app.route("/manager/get_custom_image_configuration")
     @authenticated(ADMINS_GROUP)
+    @validated(params=GetCustomImageConfig)
     def get_custom_image_config_():
         return get_custom_image_config()
 
     @app.route("/manager/get_aws_configuration")
     @authenticated(ADMINS_GROUP)
+    @validated(params=GetAwsConfig)
     def get_aws_config_():
         return get_aws_config()
 
     @app.route("/manager/get_instance_types")
     @authenticated(ADMINS_GROUP)
+    @validated(params=GetInstanceTypes)
     def get_instance_types_():
         return get_instance_types()
 


### PR DESCRIPTION
## Description
This PR introduces custom validators for the following endpoints:
* `/manager/get_cluster_configuration`
* `/manager/get_custom_image_configuration`
* `/manager/get_aws_configuration`
* `/manager/get_instance_types`

## Changelog entry
* Added input validators for the following endpoints: get_cluster_configuration, get_custom_image_configuration, get_aws_configuration, get_instance_types

## How Has This Been Tested?
* Manual tests on local environment with Postman

## References
* https://marshmallow.readthedocs.io/en/stable/marshmallow.validate.html

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
