### PR TITLE
Add endpoints validators

### DIFF
--- a/api/validation/schemas.py
+++ b/api/validation/schemas.py
@@ -52,6 +52,49 @@ class GetInstanceTypesSchema(Schema):
 GetInstanceTypes = GetInstanceTypesSchema(unknown=INCLUDE)
 
 
+class GetDcvSessionSchema(Schema):
+    user = fields.String()
+    instance_id = fields.String(required=True)
+    region = fields.String(validate=aws_region_validator)
+
+GetDcvSession = GetDcvSessionSchema(unknown=INCLUDE)
+
+
+class QueueStatusSchema(Schema):
+    user = fields.String()
+    instance_id = fields.String(required=True)
+    region = fields.String(required=True, validate=aws_region_validator)
+
+QueueStatus = QueueStatusSchema(unknown=INCLUDE)
+
+
+class ScontrolJobSchema(Schema):
+    user = fields.String()
+    instance_id = fields.String(required=True)
+    job_id = fields.String(required=True)
+    region = fields.String(required=True, validate=aws_region_validator)
+
+ScontrolJob = ScontrolJobSchema(unknown=INCLUDE)
+
+
+class CancelJobSchema(Schema):
+    user = fields.String()
+    instance_id = fields.String(required=True)
+    job_id = fields.String(required=True)
+    region = fields.String(required=True, validate=aws_region_validator)
+
+CancelJob = CancelJobSchema(unknown=INCLUDE)
+
+
+class SacctSchema(Schema):
+    user = fields.String()
+    instance_id = fields.String(required=True)
+    cluster_name = fields.String(required=True, validate=is_alphanumeric_with_hyphen)
+    region = fields.String(required=True, validate=aws_region_validator)
+
+Sacct = SacctSchema(unknown=INCLUDE)
+
+
 class LoginSchema(Schema):
     code = fields.String(required=True)
 

--- a/app.py
+++ b/app.py
@@ -46,7 +46,8 @@ from api.security.csrf import CSRF
 from api.security.csrf.csrf import csrf_needed
 from api.security.fingerprint import CognitoFingerprintGenerator
 from api.validation import validated, EC2Action
-from api.validation.schemas import CreateUser, DeleteUser, GetClusterConfig, GetCustomImageConfig, GetAwsConfig, GetInstanceTypes, Login, PushLog, PriceEstimate
+from api.validation.schemas import CreateUser, DeleteUser, GetClusterConfig, GetCustomImageConfig, GetAwsConfig, GetInstanceTypes,\
+     Login, PushLog, PriceEstimate, GetDcvSession, QueueStatus, ScontrolJob, CancelJob, Sacct
 
 ADMINS_GROUP = { "admin" }
 
@@ -119,6 +120,7 @@ def run():
     @app.route("/manager/get_dcv_session")
     @authenticated(ADMINS_GROUP)
     @csrf_needed
+    @validated(params=GetDcvSession)
     def get_dcv_session_():
         return get_dcv_session()
 
@@ -156,12 +158,14 @@ def run():
 
     @app.route("/manager/queue_status")
     @authenticated(ADMINS_GROUP)
+    @validated(params=QueueStatus)
     def queue_status_():
         return queue_status()
 
     @app.route("/manager/cancel_job")
     @authenticated(ADMINS_GROUP)
     @csrf_needed
+    @validated(params=CancelJob)
     def cancel_job_():
         return cancel_job()
 
@@ -174,11 +178,13 @@ def run():
     @app.route("/manager/sacct", methods=["POST"])
     @authenticated(ADMINS_GROUP)
     @csrf_needed
+    @validated(params=Sacct)
     def sacct_():
         return sacct()
 
     @app.route("/manager/scontrol_job")
     @authenticated(ADMINS_GROUP)
+    @validated(params=ScontrolJob)
     def scontrol_job_():
         return scontrol_job()
 


### PR DESCRIPTION
## Description
This PR introduces custom validators for the following endpoints:
* `/manager/get_dcv_session`
* `/manager/queue_status`
* `/manager/cancel_job`
* `/manager/scontrol_job`
* `/manager/sacct`

## Changelog entry
* Added input validators for the following endpoints: get_dcv_session, queue_status, cancel_job, scontrol_job, sacct

## How Has This Been Tested?
* Manual tests on local environment with Postman

## References
* https://marshmallow.readthedocs.io/en/stable/marshmallow.validate.html

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
