### PR TITLE
Fixed get_identity causing full login processes

### DIFF
--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -588,9 +588,6 @@ def get_identity():
     try:
         decoded_access = jwt_decode(access_token)
     except jwt.ExpiredSignatureError:
-        if not auth_cookies:
-            return {}, 401
-
         decoded_access = jwt_decode(auth_cookies['accessToken'])
 
     identity = _get_identity_from_token(decoded=decoded_access, claims=claims)

--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -23,7 +23,7 @@ from flask_restful import Resource, reqparse
 from jose import jwt
 
 from api.exception.exceptions import RefreshTokenError
-from api.pcm_globals import set_auth_cookies_in_context, logger
+from api.pcm_globals import set_auth_cookies_in_context, logger, auth_cookies
 from api.security.csrf.constants import CSRF_COOKIE_NAME
 from api.security.csrf.csrf import csrf_needed
 from api.utils import disable_auth
@@ -582,27 +582,29 @@ def get_identity():
         return {"user_roles": ["user", "admin"], "username": "username", "attributes": {"email": "user@domain.com"}}
 
     access_token = request.cookies.get("accessToken")
-    id_token = request.cookies.get("idToken")
-    if not (access_token and id_token):
-        return {"message": "No access or id token."}, 401
-    try:
-        claims = ["email"]
+    id_token = request.cookies.get("idToken", None)
 
+    claims = ["email"]
+    try:
         decoded_access = jwt_decode(access_token)
-        identity_from_access_token = _get_identity_from_token(decoded=decoded_access, claims=claims)
+    except jwt.ExpiredSignatureError:
+        if not auth_cookies:
+            return {}, 401
+
+        decoded_access = jwt_decode(auth_cookies['accessToken'])
+
+    identity = _get_identity_from_token(decoded=decoded_access, claims=claims)
+
+    if id_token:
         decoded_id = jwt_decode(id_token, audience=AUDIENCE, access_token=access_token)
         identity_from_id_token = _get_identity_from_token(decoded=decoded_id, claims=claims)
+        identity.update(identity_from_id_token)
 
-        identity = {**identity_from_access_token, **identity_from_id_token}
+    if "username" not in identity:
+        raise Exception('No username present in access or id token.')
+    if "user_roles" not in identity:
+        raise Exception('No user_roles present in access or id token.')
 
-        if "username" not in identity:
-            return {"message": "No username present in access or id token."}, 400
-        if "user_roles" not in identity:
-            return {"message": "No user_roles present in access or id token."}, 400
-
-    except jwt.ExpiredSignatureError:
-        return {"message": "Signature expired."}, 401
-    
     return identity
 
 

--- a/api/tests/test_get_identity.py
+++ b/api/tests/test_get_identity.py
@@ -1,3 +1,5 @@
+import pytest
+
 from api.PclusterApiHandler import get_identity
 
 
@@ -71,7 +73,7 @@ def test_get_identity_auth_enabled_no_username_provided(monkeypatch, mocker, app
     Given an handler for the /get-identity endpoint
       When authentication is enabled
       When username could not be retrieved
-        Then it should return a 400
+        Then it should raise Exception
     """
     monkeypatch.setenv("ENABLE_AUTH", "true")
     monkeypatch.setattr('api.PclusterApiHandler.USER_ROLES_CLAIM', 'user_roles_claim')
@@ -82,15 +84,15 @@ def test_get_identity_auth_enabled_no_username_provided(monkeypatch, mocker, app
     }
     with app.test_request_context(headers={'Cookie': 'accessToken=access-token; idToken=identity-token'}):
       mocker.patch('api.PclusterApiHandler.jwt_decode', side_effect=[accessTokenDecoded, identityTokenDecoded])
-
-      assert get_identity() == ({"message": "No username present in access or id token."}, 400)
+      with pytest.raises(Exception):
+          get_identity()
 
 def test_get_identity_auth_enabled_no_user_roles_provided(monkeypatch, mocker, app):
     """
     Given an handler for the /get-identity endpoint
       When authentication is enabled
       When user roles could not be retrieved
-        Then it should return 400
+        Then it should raise Exception
     """
     monkeypatch.setenv("ENABLE_AUTH", "true")
     monkeypatch.setattr('api.PclusterApiHandler.USER_ROLES_CLAIM', 'user_roles_claim')
@@ -102,5 +104,6 @@ def test_get_identity_auth_enabled_no_user_roles_provided(monkeypatch, mocker, a
     with app.test_request_context(headers={'Cookie': 'accessToken=access-token; idToken=identity-token'}):
       mocker.patch('api.PclusterApiHandler.jwt_decode', side_effect=[accessTokenDecoded, identityTokenDecoded])
 
-      assert get_identity() == ({"message": "No user_roles present in access or id token."}, 400)
+      with pytest.raises(Exception):
+          get_identity()
       

--- a/api/tests/test_get_identity.py
+++ b/api/tests/test_get_identity.py
@@ -111,7 +111,7 @@ def test_get_identity_auth_enabled_no_user_roles_provided(monkeypatch, mocker, a
       with pytest.raises(Exception):
           get_identity()
 
-def test_get_identity_auht_enabled_expired_access_token_with_correctly_refreshed_tokens(app, mocker):
+def test_get_identity_auth_enabled_expired_access_token_with_correctly_refreshed_tokens(app, mocker):
     """
     Given a controller method for the get_identity endpoint
       when auth is enabled


### PR DESCRIPTION
## Description
Removed 401 from get_identity + adjusted tests
## Changes

<!-- List of relevant changes introduced -->

## How Has This Been Tested?
- manual
- unit tests
<!-- The tests you ran to verify your changes -->

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [x] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
