### PR TITLE
Fix storage tab crashing when headnode is not available yet

### DIFF
--- a/frontend/src/old-pages/Clusters/__tests__/Filesystems.test.ts
+++ b/frontend/src/old-pages/Clusters/__tests__/Filesystems.test.ts
@@ -1,0 +1,36 @@
+import {mock, MockProxy} from 'jest-mock-extended'
+import {EC2Instance} from '../../../types/instances'
+import {Storages} from '../../Configure/Storage.types'
+import {buildFilesystemLink} from '../Filesystems'
+
+describe('given a function to build the link to the filesystem in the AWS console', () => {
+  let mockHeadNode: MockProxy<EC2Instance | undefined>
+  const mockFileSystem = mock<Storages[0]>({MountDir: 'some-mount-dir'})
+  const mockRegion = 'some-region'
+
+  describe('when the headnode configuration is available', () => {
+    beforeEach(() => {
+      mockHeadNode = mock<EC2Instance>({instanceId: 'some-instance-id'})
+    })
+
+    it('should return the link to the filsystem', () => {
+      expect(
+        buildFilesystemLink(mockRegion, mockHeadNode, mockFileSystem),
+      ).toBe(
+        'https://some-region.console.aws.amazon.com/systems-manager/managed-instances/some-instance-id/file-system?region=some-region&osplatform=Linux#%7B%22path%22%3A%22some-mount-dir%22%7D',
+      )
+    })
+  })
+
+  describe('when the headnode configuration is not available', () => {
+    beforeEach(() => {
+      mockHeadNode = undefined
+    })
+
+    it('should return null', () => {
+      expect(
+        buildFilesystemLink(mockRegion, mockHeadNode, mockFileSystem),
+      ).toBe(null)
+    })
+  })
+})


### PR DESCRIPTION
## Description

This PR fixes an issue causing the Storage tab to crash the app when the filesystem is not ready yet. 

The root cause was the construction of link to the filesystem, which depends on the head node information to be available. More precisely, the `headNode.instanceId` property access cases an error due to the `headNode` being undefined. 

The fix is as follows:
- until the headnode is not available, the filesystem is listed without the link to the console
- when the headnode is available, the link is correctly shown

See screenshots below:

Link not available due to missing information:
<img width="861" alt="image" src="https://user-images.githubusercontent.com/11457067/211874269-0dcf10e2-4183-4372-9686-e3884e7b99d7.png">

Link available:
<img width="870" alt="image" src="https://user-images.githubusercontent.com/11457067/211874153-32287110-e65e-46c6-93ee-f7383f6e5648.png">


## Changes

- add `buildFilesystemLink` function to create the link
- avoid displaying a `<Link/>`, when the href is missing

## Changelog entry

Fix storage tab crashing when headnode is not available yet

## How Has This Been Tested?

- manually
- unit tests

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
