### PR TITLE
Fix "Stop Compute Fleet" button still spinning after the compute fleet is stopped

### DIFF
--- a/frontend/src/components/__tests__/useClusterPoll.test.tsx
+++ b/frontend/src/components/__tests__/useClusterPoll.test.tsx
@@ -1,0 +1,57 @@
+import {renderHook} from '@testing-library/react-hooks'
+import {useClusterPoll} from '../useClusterPoll'
+
+jest.mock('../../model', () => ({
+  DescribeCluster: jest.fn(),
+}))
+import {DescribeCluster} from '../../model'
+import {act} from 'react-dom/test-utils'
+
+describe('Given a cluster poll', () => {
+  beforeEach(() => jest.useFakeTimers())
+  afterEach(() => {
+    jest.resetAllMocks()
+    jest.useRealTimers()
+  })
+
+  describe('when a cluster name is given', () => {
+    it('should start polling the resource', () => {
+      renderHook(() => useClusterPoll('Test', true))
+
+      jest.advanceTimersByTime(6000)
+      expect(DescribeCluster).toHaveBeenCalledWith('Test')
+    })
+
+    it('can start polling the resource on demand', () => {
+      const {result} = renderHook(() => useClusterPoll('Test', false))
+      jest.advanceTimersByTime(6000)
+      expect(DescribeCluster).not.toHaveBeenCalled()
+      act(() => {
+        result.current.start()
+      })
+      jest.advanceTimersByTime(6000)
+
+      expect(DescribeCluster).toHaveBeenCalledWith('Test')
+    })
+
+    it('can stop polling after it has been started', () => {
+      const {result} = renderHook(() => useClusterPoll('Test', false))
+      act(() => {
+        result.current.start()
+        result.current.stop()
+      })
+      jest.advanceTimersByTime(6000)
+
+      expect(DescribeCluster).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when a cluster name is not given', () => {
+    it('should not poll any resource', () => {
+      renderHook(() => useClusterPoll('', true))
+      jest.advanceTimersByTime(6000)
+
+      expect(DescribeCluster).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/src/components/useClusterPoll.tsx
+++ b/frontend/src/components/useClusterPoll.tsx
@@ -1,0 +1,20 @@
+import {useEffect, useState} from 'react'
+import {DescribeCluster} from '../model'
+
+export const useClusterPoll = (clusterName: string, startOnRender: boolean) => {
+  const [start, setStart] = useState(startOnRender)
+
+  useEffect(() => {
+    if (!start) return
+    const timerId = setInterval(
+      () => clusterName && DescribeCluster(clusterName),
+      5000,
+    )
+    return () => clearInterval(timerId)
+  }, [start, clusterName])
+
+  return {
+    start: () => setStart(true),
+    stop: () => setStart(false),
+  }
+}

--- a/frontend/src/old-pages/Clusters/Properties.tsx
+++ b/frontend/src/old-pages/Clusters/Properties.tsx
@@ -12,8 +12,7 @@ import {ClusterStatus, ClusterDescription} from '../../types/clusters'
 import React, {PropsWithChildren, ReactElement} from 'react'
 import {Trans, useTranslation} from 'react-i18next'
 import {findFirst, clusterDefaultUser} from '../../util'
-import {getState, useState, setState, ssmPolicy} from '../../store'
-import {DescribeCluster} from '../../model'
+import {useState, setState, ssmPolicy} from '../../store'
 
 // UI Elements
 import {
@@ -36,6 +35,7 @@ import {
 } from '../../components/Status'
 import TitleDescriptionHelpPanel from '../../components/help-panel/TitleDescriptionHelpPanel'
 import InfoLink from '../../components/InfoLink'
+import {useClusterPoll} from '../../components/useClusterPoll'
 
 // Key:Value pair (label / children)
 const ValueWithLabel = ({
@@ -79,16 +79,7 @@ export default function ClusterProperties() {
   ])
   const ssmEnabled = iamPolicies && findFirst(iamPolicies, isSsmPolicy)
 
-  React.useEffect(() => {
-    const tick = () => {
-      const clusterName = getState(['app', 'clusters', 'selected'])
-      clusterName && DescribeCluster(clusterName)
-    }
-    const timerId = setInterval(tick, 5000)
-    return () => {
-      clearInterval(timerId)
-    }
-  }, [])
+  useClusterPoll(clusterName, true)
 
   return (
     <>

--- a/frontend/src/old-pages/Configure/Configure.tsx
+++ b/frontend/src/old-pages/Configure/Configure.tsx
@@ -157,17 +157,22 @@ function Configure() {
             {t('wizard.actions.refreshConfig')}
           </Button>
         )}
-        {editing &&
-          (fleetStatus === 'RUNNING' || fleetStatus === 'STOP_REQUESTED') && (
-            <Button
-              className="action"
-              variant="normal"
-              loading={fleetStatus === 'STOP_REQUESTED'}
-              onClick={stopComputeFleet}
-            >
-              {t('wizard.actions.stopComputeFleet')}
-            </Button>
-          )}
+        {editing && (
+          <Button
+            variant="normal"
+            disabled={
+              fleetStatus !== 'RUNNING' &&
+              fleetStatus !== 'STOP_REQUESTED' &&
+              fleetStatus !== 'STOPPING'
+            }
+            loading={
+              fleetStatus === 'STOP_REQUESTED' || fleetStatus === 'STOPPING'
+            }
+            onClick={stopComputeFleet}
+          >
+            {t('wizard.actions.stopComputeFleet')}
+          </Button>
+        )}
         {currentPage === 'create' && (
           <Button onClick={wizardHandleDryRun}>
             {t('wizard.actions.dryRun')}


### PR DESCRIPTION
## Description

Introduces an hook to poll the details of a cluster to fix an erroroneus behavior of the "Stop compute fleet" button inside the wizard.
I choose a plain `setInterval` approach instead of going full `react-query` because its refetch API is tricky to use with this specific case.

Fixes #150.

## How Has This Been Tested?

- stopped a cluster and verified that split panel details are updated correctly
- stopped a cluster while editing its configuration and verified the button stops spinning after shutdown

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
