### PR TITLE
Replace occurrences of 'ParallelCluster Manager' with 'AWS ParallelCluster UI'

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Development
 
-To run AWS ParallelCluster Manager locally, start by setting the following environment variables:
+To run AWS ParallelCluster UI locally, start by setting the following environment variables:
 
 ```bash
 export AWS_ACCESS_KEY_ID=[...]
@@ -17,7 +17,7 @@ pip3 install -r requirements.txt
 ```
 
 ## Backend with Cognito
-From the Cognito service page of the AWS account where pcluster-manager has been deployed, click on the user pool
+From the Cognito service page of the AWS account where PCUI has been deployed, click on the user pool
 and then on the *App Integration* tab. In the App client list at the bottom, make note of the *Client ID*, then
 click on the App client and click *Edit* in the *Hosted UI* section, adding `http://localhost:5001/login` to the
 *Allowed callback URLs*.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-ParallelCluster Manager - Make HPC Easy
+AWS ParallelCluster UI - Make HPC Easy
 ================================
 
 This project is a front-end for [AWS Parallel Cluster](https://github.com/aws/aws-parallelcluster)
 
-Quickly and easily create HPC cluster in AWS using ParallelCluster Manager. This UI uses the AWS ParallelCluster 3.x API to Create, Update and Delete Clusters as well as access, view logs, and build Amazon Machine Images (AMI's).
+Quickly and easily create HPC cluster in AWS using AWS ParallelCluster UI. This UI uses the AWS ParallelCluster 3.x API to Create, Update and Delete Clusters as well as access, view logs, and build Amazon Machine Images (AMI's).
 
 You can get started with your first cluster in as little as 15 minutes using the links below.
 
@@ -46,7 +46,7 @@ For more details see the [Getting Started Guide](https://pcluster.cloud).
 
 ## Costs
 
-ParallelCluster Manager is built on a serverless architecture and falls into the free tier for most uses. I've detailed the dependency services and their free-tier limits below:
+AWS ParallelCluster UI is built on a serverless architecture and falls into the free tier for most uses. I've detailed the dependency services and their free-tier limits below:
 
 | Service       | Free Tier                                                        |
 |---------------|------------------------------------------------------------------|
@@ -60,26 +60,26 @@ Typical usage will likely cost < $1 / month.
 
 ## Reusing a Cognito User Pool
 
-It is possible to reuse a Cognito user pool across multiple PCM instances to avoid having to recreate the user base for each installation. There are two ways to do this:
+It is possible to reuse a Cognito user pool across multiple PCUI instances to avoid having to recreate the user base for each installation. There are two ways to do this:
 
-1. Use an existing PCM installation that utilizes Cognito as a nested stack. This is the default setup when installing PCM through the 1-click links and leaving all Cognito parameters blank.
+1. Use an existing PCUI installation that utilizes Cognito as a nested stack. This is the default setup when installing PCUI through the 1-click links and leaving all Cognito parameters blank.
 
-2. Use a standalone Cognito installation that is deployed before the PCM installation and then linked to it. This has the advantage of being completely separate from PCM and makes CloudFormation updates simpler, as it is not using a nested stack.
+2. Use a standalone Cognito installation that is deployed before the PCUI installation and then linked to it. This has the advantage of being completely separate from PCUI and makes CloudFormation updates simpler, as it is not using a nested stack.
 
-### Reusing an Existing PCM Installation with Cognito as a Nested Stack
+### Reusing an Existing PCUI Installation with Cognito as a Nested Stack
 
-1. From the CloudFormation console, select the PCM stack that contains the Cognito pool that you want to reuse.
+1. From the CloudFormation console, select the PCUI stack that contains the Cognito pool that you want to reuse.
 2. Navigate to the Cognito nested stack.
 3. Select the **Outputs** tab.
 4. Copy the following values:
    - `UserPoolId`
    - `UserPoolAuthDomain`
    - `SNSRole`
-5. Install a new PCM instance using the [Quickstart](#quickstart-15-mins-🚀) and fill in all `External PCM Cognito` parameters with the outputs that you just copied. This will prevent PCM from creating a new pool and will use the linked one instead.
+5. Install a new PCUI instance using the [Quickstart](#quickstart-15-mins-🚀) and fill in all `External PCUI Cognito` parameters with the outputs that you just copied. This will prevent PCUI from creating a new pool and will use the linked one instead.
 
 ### Reusing a Standalone Cognito Installation
 
-1. Launch the Cognito-only stack in the same region as the PCM will be deployed. You can do this by clicking on one of the links below for the desired region (use the alternative launch link if S3 template loading fails).
+1. Launch the Cognito-only stack in the same region as the PCUI will be deployed. You can do this by clicking on one of the links below for the desired region (use the alternative launch link if S3 template loading fails).
 
 
 | Region       | Launch                                                                                                                                                                                                                                                                                                              | Alternative launch link |
@@ -113,13 +113,13 @@ It is possible to reuse a Cognito user pool across multiple PCM instances to avo
    - `UserPoolId`
    - `UserPoolAuthDomain`
    - `SNSRole`
-3. Install a new PCM instance using the [Quickstart](#quickstart-15-mins-🚀) and fill in all `External PCM Cognito` parameters with the outputs that you just copied. This will prevent PCM from creating a new pool and will use the linked one instead.
+3. Install a new PCUI instance using the [Quickstart](#quickstart-15-mins-🚀) and fill in all `External PCUI Cognito` parameters with the outputs that you just copied. This will prevent PCUI from creating a new pool and will use the linked one instead.
 
-## Identify the installed version of ParallelCluster and ParallelCluster Manager
-1. From the CloudFormation console, select a PCM stack.
+## Identify the installed version of AWS ParallelCluster and AWS ParallelCluster UI
+1. From the CloudFormation console, select a PCUI stack.
 2. Select the **Parameters** tab.
-3. The version of ParallelCluster is available under `Version`.
-4. The version of ParallelCluster Manager is the latest part of the `PublicEcrImageUri` parameter. For example if the value is `public.ecr.aws/pcm/pcluster-manager-awslambda:3.3.0` the version is `3.3.0`.
+3. The version of AWS ParallelCluster is available under `Version`.
+4. The version of AWS ParallelCluster UI is the latest part of the `PublicEcrImageUri` parameter. For example if the value is `public.ecr.aws/pcm/pcluster-manager-awslambda:3.3.0` the version is `3.3.0`.
 
 ## Updating
 

--- a/decisions/index.md
+++ b/decisions/index.md
@@ -2,7 +2,7 @@
 
 # Architecture knowledge base
 
-Welcome 👋 to the architecture knowledge base of ParallelCluster Manager (PCM).
+Welcome 👋 to the architecture knowledge base of AWS ParallelCluster UI (PCUI).
 You will find here all the Architecture Decision Records (ADR) of the project.
 
 ## Definition and purpose

--- a/e2e/specs/wizard.spec.ts
+++ b/e2e/specs/wizard.spec.ts
@@ -11,7 +11,7 @@
 import { expect, test } from '@playwright/test';
 import { visitAndLogin } from '../test-utils/login';
 
-test.describe('Given an endpoint where ParallelCluster Manager is deployed', () => {
+test.describe('Given an endpoint where AWS ParallelCluster UI is deployed', () => {
   test('a user should be able to login, navigate till the end of the cluster creation wizard, and perform a dry-run successfully', async ({ page }) => {
     await visitAndLogin(page)
   

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -1,7 +1,8 @@
 {
   "global": {
+    "projectName": "AWS ParallelCluster UI",
     "menu": {
-      "header": "ParallelCluster Manager",
+      "header": "$t(global.projectName)",
       "clusters": "Clusters",
       "customImages": "Custom Images",
       "officialImages": "Official Images",
@@ -25,13 +26,13 @@
     "footer": {
       "learnMore": "Learn more",
       "docs": {
-        "title": "AWS ParallelCluster Manager documentation",
+        "title": "$t(global.projectName) documentation",
         "link": "https://pcluster.cloud/"
       }
     },
     "default": {
-      "title": "ParallelCluster Manager",
-      "description": "Quickly and easily create HPC cluster in AWS using ParallelCluster Manager. This UI uses the AWS ParallelCluster API to Create, Update and Delete Clusters as well as access, view logs, and build Amazon Machine Images (AMI's)."
+      "title": "$t(global.projectName)",
+      "description": "Quickly and easily create HPC cluster in AWS using $t(global.projectName). This UI uses the AWS ParallelCluster API to Create, Update and Delete Clusters as well as access, view logs, and build Amazon Machine Images (AMI's)."
     }
   },
   "infoLink": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "ParallelClusterManager",
+  "name": "aws-parallelcluster-ui",
   "version": "3.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "ParallelClusterManager",
+      "name": "aws-parallelcluster-ui",
       "version": "3.3.0",
       "dependencies": {
         "@cloudscape-design/components": "^3.0.118",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ParallelClusterManager",
+  "name": "aws-parallelcluster-ui",
   "version": "3.3.0",
   "private": true,
   "homepage": "/",

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -131,11 +131,11 @@ export default function Topbar() {
     <div id="top-bar">
       <TopNavigation
         identity={{
-          title: 'AWS ParallelCluster Manager',
+          title: 'AWS ParallelCluster UI',
           href: '/',
           logo: {
             src: '/img/pcluster.svg',
-            alt: 'AWS ParallelCluster Manager Logo',
+            alt: 'AWS ParallelCluster UI Logo',
           },
         }}
         utilities={[

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -51,7 +51,7 @@ function App({Component, pageProps}: AppProps) {
     <>
       <Head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>ParallelCluster Manager</title>
+        <title>AWS ParallelCluster UI</title>
       </Head>
       <QueryClientProvider client={queryClient}>
         <I18nextProvider i18n={i18n}>

--- a/frontend/src/pages/_document.tsx
+++ b/frontend/src/pages/_document.tsx
@@ -16,7 +16,7 @@ export default function Document() {
         <meta charSet="utf-8" />
         <link rel="icon" href="favicon.ico" />
         <meta name="theme-color" content="#000000" />
-        <meta name="description" content="AWS ParallelCluster Manager" />
+        <meta name="description" content="AWS ParallelCluster UI" />
       </Head>
       <body>
         <Main />


### PR DESCRIPTION
## Description

This PR replaces all the customer-facing occurrences of `ParallelCluster Manager`, `pcluster-manager` or `PCM` with the new product name: `AWS ParallelCluster UI`.

Project name in `package.json` and `package-lock.json` has been renamed to `aws-parallelcluster-ui` following npm [naming conventions](https://docs.npmjs.com/creating-a-package-json-file#required-name-and-version-fields).


## Changelog entry

* Rename customer-facing occurrences of `ParallelCluster Manager` with `AWS ParallelCluster UI`

## How Has This Been Tested?

* unit tests
* manually checked that new name is displayed

## References
* https://docs.npmjs.com/creating-a-package-json-file#required-name-and-version-fields


<img width="1727" alt="Screenshot 2023-01-12 at 17 15 02" src="https://user-images.githubusercontent.com/25930133/212121409-c920d444-9626-4647-ad0f-e0a56fa9f19f.png">


## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
