### PR TITLE
Log stacktraces in ErrorBoundary

### DIFF
--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import React, {Component, ReactNode} from 'react'
+import React, {Component, ErrorInfo, ReactNode} from 'react'
 import {
   Modal,
   Box,
@@ -29,8 +29,9 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, State> {
   private promiseRejectionHandler = (event: PromiseRejectionEvent) => {
     this.props.logger.error(event.reason)
   }
+
   private errorHandler = (event: ErrorEvent) => {
-    this.props.logger.error(event.message)
+    this.props.logger.error(event.message, {trace: event.error?.stack})
   }
 
   private redirectToHomepage = () => {
@@ -41,8 +42,11 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, State> {
     return {error: true}
   }
 
-  public componentDidCatch(error: Error) {
-    this.props.logger.error(error.message)
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    this.props.logger.error(error.message, {
+      trace: error.stack,
+      componentStack: errorInfo.componentStack,
+    })
   }
 
   public componentDidMount() {


### PR DESCRIPTION
## Description

This PR adds stacktraces to the log entries coming off the `ErrorBoundary`

## Changes

- log `stacktrace` and `componentStack` for errors occurring during component rendering
- log `stacktrace` for uncaught errors occurring elsewhere

### Screenshots

<details>
<summary>Logs for errors occurring during component rendering</summary>
<img width="861" alt="image" src="https://user-images.githubusercontent.com/11457067/212340756-9387b05e-4cde-4756-b18a-c73b6ad93630.png">
</details>

<details>
<summary>Logs for uncaught errors occurring elsewhere</summary>
<img width="861" alt="image" src="https://user-images.githubusercontent.com/11457067/212340733-7f743a19-aaff-4410-8030-4c0751517aaf.png">
</details>

## How Has This Been Tested?

- manually
- unit tests
- deployed and checked on CloudWatch (see screenshots above)

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [x] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
