### PR TITLE
Fix logger pushing non-string payloads to remote logging system

### DIFF
--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -31,7 +31,13 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, State> {
   }
 
   private errorHandler = (event: ErrorEvent) => {
-    this.props.logger.error(event.message, {trace: event.error?.stack})
+    /**
+     * Some ErrorEvents miss the error property
+     * for instance the ResizeObserver loop errors
+     *
+     * We fallback to just logging the message
+     */
+    this.props.logger.error(event.error || event.message)
   }
 
   private redirectToHomepage = () => {
@@ -43,8 +49,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, State> {
   }
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    this.props.logger.error(error.message, {
-      trace: error.stack,
+    this.props.logger.error(error, {
       componentStack: errorInfo.componentStack,
     })
   }

--- a/frontend/src/logger/ConsoleLogger.ts
+++ b/frontend/src/logger/ConsoleLogger.ts
@@ -18,7 +18,7 @@ export class ConsoleLogger implements ILogger {
   }
 
   error(
-    message: string,
+    message: Error | string,
     extra?: Record<string, unknown>,
     source?: string,
   ): void {
@@ -42,7 +42,7 @@ export class ConsoleLogger implements ILogger {
   }
 
   private formatMessage(
-    message: string,
+    message: Error | string,
     extra: Record<string, unknown> | undefined,
     source?: string,
   ) {

--- a/frontend/src/logger/ConsoleLogger.ts
+++ b/frontend/src/logger/ConsoleLogger.ts
@@ -2,7 +2,7 @@ import {ILogger} from './ILogger'
 
 export class ConsoleLogger implements ILogger {
   critical(
-    message: string,
+    message: Error | string,
     extra?: Record<string, unknown>,
     source?: string,
   ): void {

--- a/frontend/src/logger/ILogger.ts
+++ b/frontend/src/logger/ILogger.ts
@@ -9,7 +9,11 @@ export interface ILogger {
 
   debug(message: string, extra?: Record<string, unknown>, source?: string): void
 
-  error(message: string, extra?: Record<string, unknown>, source?: string): void
+  error(
+    message: Error | string,
+    extra?: Record<string, unknown>,
+    source?: string,
+  ): void
 
   critical(
     message: string,

--- a/frontend/src/logger/ILogger.ts
+++ b/frontend/src/logger/ILogger.ts
@@ -16,7 +16,7 @@ export interface ILogger {
   ): void
 
   critical(
-    message: string,
+    message: Error | string,
     extra?: Record<string, unknown>,
     source?: string,
   ): void

--- a/frontend/src/logger/RemoteLogger.ts
+++ b/frontend/src/logger/RemoteLogger.ts
@@ -116,7 +116,7 @@ export class Logger implements ILogger {
     if (payload instanceof Error) {
       extra = {
         ...extra,
-        trace: payload.stack,
+        stackTrace: payload.stack,
       }
 
       return {message: payload.message, level, extra}

--- a/frontend/src/logger/RemoteLogger.ts
+++ b/frontend/src/logger/RemoteLogger.ts
@@ -10,7 +10,7 @@ enum LogLevel {
 }
 
 interface LogEntry {
-  message: string
+  message: Error | string
   level: LogLevel
   extra?: Record<string, unknown>
 }
@@ -43,7 +43,7 @@ export class Logger implements ILogger {
 
   private log(
     logLevel: LogLevel,
-    message: string,
+    message: Error | string,
     extra: Record<string, unknown> = {},
     source?: string,
   ) {
@@ -86,7 +86,11 @@ export class Logger implements ILogger {
     this.log(LogLevel.debug, message, extra, source)
   }
 
-  error(message: string, extra?: Record<string, unknown>, source?: string) {
+  error(
+    message: Error | string,
+    extra?: Record<string, unknown>,
+    source?: string,
+  ) {
     this.log(LogLevel.error, message, extra, source)
   }
 
@@ -96,7 +100,7 @@ export class Logger implements ILogger {
 
   private buildMessage(
     level: LogLevel,
-    message: string,
+    messsage: Error | string,
     extra?: Record<string, unknown>,
   ): LogEntry {
     const stringMessage =

--- a/frontend/src/logger/RemoteLogger.ts
+++ b/frontend/src/logger/RemoteLogger.ts
@@ -20,6 +20,8 @@ type BufferConfig = {
   window: number
 }
 
+const DEAFULT_MESSAGE = 'This log entry has no message.'
+
 export class Logger implements ILogger {
   private readonly executeRequest
   private logsBuffer: LogEntry[] = []
@@ -100,11 +102,27 @@ export class Logger implements ILogger {
 
   private buildMessage(
     level: LogLevel,
-    messsage: Error | string,
+    payload: Error | string,
     extra?: Record<string, unknown>,
   ): LogEntry {
-    const stringMessage =
-      typeof message === 'string' ? message : JSON.stringify(message)
-    return {message: stringMessage, level, extra}
+    if (!payload) {
+      return {message: DEAFULT_MESSAGE, level, extra}
+    }
+
+    if (payload instanceof Error) {
+      extra = {
+        ...extra,
+        trace: payload.stack,
+      }
+
+      return {message: payload.message, level, extra}
+    }
+
+    if (typeof payload !== 'string') {
+      const message = JSON.stringify(payload)
+      return {message, level, extra}
+    }
+
+    return {message: payload, level, extra}
   }
 }

--- a/frontend/src/logger/RemoteLogger.ts
+++ b/frontend/src/logger/RemoteLogger.ts
@@ -20,7 +20,7 @@ type BufferConfig = {
   window: number
 }
 
-const DEAFULT_MESSAGE = 'This log entry has no message.'
+const DEFAULT_MESSAGE = 'This log entry has no message.'
 
 export class Logger implements ILogger {
   private readonly executeRequest
@@ -110,7 +110,7 @@ export class Logger implements ILogger {
     extra?: Record<string, unknown>,
   ): LogEntry {
     if (!payload) {
-      return {message: DEAFULT_MESSAGE, level, extra}
+      return {message: DEFAULT_MESSAGE, level, extra}
     }
 
     if (payload instanceof Error) {

--- a/frontend/src/logger/RemoteLogger.ts
+++ b/frontend/src/logger/RemoteLogger.ts
@@ -99,6 +99,8 @@ export class Logger implements ILogger {
     message: string,
     extra?: Record<string, unknown>,
   ): LogEntry {
-    return {message, level, extra}
+    const stringMessage =
+      typeof message === 'string' ? message : JSON.stringify(message)
+    return {message: stringMessage, level, extra}
   }
 }

--- a/frontend/src/logger/RemoteLogger.ts
+++ b/frontend/src/logger/RemoteLogger.ts
@@ -96,7 +96,11 @@ export class Logger implements ILogger {
     this.log(LogLevel.error, message, extra, source)
   }
 
-  critical(message: string, extra?: Record<string, unknown>, source?: string) {
+  critical(
+    message: Error | string,
+    extra?: Record<string, unknown>,
+    source?: string,
+  ) {
     this.log(LogLevel.critical, message, extra, source)
   }
 

--- a/frontend/src/logger/__tests__/logger.test.ts
+++ b/frontend/src/logger/__tests__/logger.test.ts
@@ -40,6 +40,51 @@ describe('Given a RemoteLogger', () => {
       )
     })
 
+    it('should successfully push the trace when message is an Error', () => {
+      logger.error(new Error('some-message'))
+
+      const expectedLogEntry = {
+        logs: [
+          {
+            message: 'some-message',
+            level: 'ERROR',
+            extra: {
+              source: 'frontend',
+              trace: expect.any(String),
+            },
+          },
+        ],
+      }
+      expect(mockedExecuteRequest).toHaveBeenCalledTimes(1)
+      expect(mockedExecuteRequest).toHaveBeenCalledWith(
+        expectedMethod,
+        expectedPath,
+        expectedLogEntry,
+      )
+    })
+
+    it('should successfully push an undefined message', () => {
+      logger.info(undefined as unknown as string)
+
+      const expectedLogEntry = {
+        logs: [
+          {
+            message: 'This log entry has no message.',
+            level: 'INFO',
+            extra: {
+              source: 'frontend',
+            },
+          },
+        ],
+      }
+      expect(mockedExecuteRequest).toHaveBeenCalledTimes(1)
+      expect(mockedExecuteRequest).toHaveBeenCalledWith(
+        expectedMethod,
+        expectedPath,
+        expectedLogEntry,
+      )
+    })
+
     it('should successfully push a non-string message', () => {
       logger.info({somekey: 'some-value'} as unknown as string)
 

--- a/frontend/src/logger/__tests__/logger.test.ts
+++ b/frontend/src/logger/__tests__/logger.test.ts
@@ -40,6 +40,28 @@ describe('Given a RemoteLogger', () => {
       )
     })
 
+    it('should successfully push a non-string message', () => {
+      logger.info({somekey: 'some-value'} as unknown as string)
+
+      const expectedLogEntry = {
+        logs: [
+          {
+            message: '{"somekey":"some-value"}',
+            level: 'INFO',
+            extra: {
+              source: 'frontend',
+            },
+          },
+        ],
+      }
+      expect(mockedExecuteRequest).toHaveBeenCalledTimes(1)
+      expect(mockedExecuteRequest).toHaveBeenCalledWith(
+        expectedMethod,
+        expectedPath,
+        expectedLogEntry,
+      )
+    })
+
     it('should successfully push a log entry with extra parameters', () => {
       logger.error('error message', {
         extra1: 'value1',

--- a/frontend/src/logger/__tests__/logger.test.ts
+++ b/frontend/src/logger/__tests__/logger.test.ts
@@ -50,7 +50,7 @@ describe('Given a RemoteLogger', () => {
             level: 'ERROR',
             extra: {
               source: 'frontend',
-              trace: expect.any(String),
+              stackTrace: expect.any(String),
             },
           },
         ],


### PR DESCRIPTION
## Description

This PR fixes an issue allowing any payload to be sent as message to the remote logging system. 

This is mostly related to the fact that rejected promises can contain any value, thus by blindly logging the `event.reason` of the `PromiseRejectionEvent` we risk to push non-string values to the remote logging system

This could also occur in the future, by logging values that have been typed as `any` (which would defeat the type checking), therefore the guard is place inside the `RemoteLogger`

## Changes

- log stacktraces when Errors are logged
- stringify non-string messages before pushing them
- handle undefined messages

## How Has This Been Tested?

- manually
- unit tests

Log entry to be sent to the remote logging system, in case of an uncaught axios error:
![image](https://user-images.githubusercontent.com/11457067/212359921-68c41a76-7cf8-4bd3-8993-be7d6e7318a8.png)

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
