### PR TITLE
Align id and access tokens value in `get_identity` after refresh flow

### DIFF
--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -574,7 +574,9 @@ def get_identity():
     try:
         decoded_access = jwt_decode(access_token)
     except jwt.ExpiredSignatureError:
-        decoded_access = jwt_decode(auth_cookies['accessToken'])
+        access_token = auth_cookies.get('accessToken')
+        id_token = auth_cookies.get('idToken')
+        decoded_access = jwt_decode(access_token)
 
     identity = _get_identity_from_token(decoded=decoded_access, claims=claims)
 


### PR DESCRIPTION
## Description
Small fix to align tokens values with refreshed ones.
Previously this would cause a failure in get_identity function due to an expired id_token.

## How Has This Been Tested?
- manual
- unit
- e2e
<!-- The tests you ran to verify your changes -->

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
