### PR TITLE
Adopted sha256 for CSRF token generation and improved CSRFError handler + tests

### DIFF
--- a/api/exception/handlers.py
+++ b/api/exception/handlers.py
@@ -7,6 +7,7 @@ from werkzeug.routing import WebsocketMismatch
 from api.exception import CSRFError
 from api.exception.exceptions import RefreshTokenError
 from api.pcm_globals import logger
+from api.security.csrf.csrf import remove_csrf_cookie
 
 
 def boto3_exception_handler(err):
@@ -29,7 +30,9 @@ def value_error_handler(err):
 def csrf_error_handler(err):
     descr, code = str(err), 403
     logger.error(descr, extra=dict(status=code, exception=type(err)))
-    return __handler_response(code, descr)
+    response, status_code = __handler_response(code, descr)
+    remove_csrf_cookie(response)
+    return response, status_code
 
 def unauthenticated_error_handler(err):
     descr, code = str(err), 401

--- a/api/security/csrf/csrf.py
+++ b/api/security/csrf/csrf.py
@@ -9,16 +9,18 @@ from api.exception import CSRFError
 from api.security.csrf import CSRF_SECRET_KEY
 from api.security.csrf.constants import CSRF_COOKIE_NAME, SALT, CSRF_TOKEN_HEADER
 
+digest_method = staticmethod(hashlib.sha256)
+signer_kwargs = {'signer_kwargs': {'digest_method': digest_method}}
 
 def generate_csrf_token(secret_key, salt):
-    serializer = URLSafeSerializer(secret_key, salt)
+    serializer = URLSafeSerializer(secret_key, salt, **signer_kwargs)
     csrf_token_value = hashlib.sha256(os.urandom(64)).hexdigest()
     csrf_token = serializer.dumps(csrf_token_value)
     return csrf_token
 
 
 def parse_csrf_token(secret_key, salt, token):
-    serializer = URLSafeSerializer(secret_key, salt)
+    serializer = URLSafeSerializer(secret_key, salt, **signer_kwargs)
     return serializer.loads(token)
 
 
@@ -39,6 +41,8 @@ def is_csrf_enabled():
 def set_csrf_cookie(resp, csrf_token):
     resp.set_cookie(CSRF_COOKIE_NAME, value=csrf_token, httponly=True, secure=True, samesite="Lax")
 
+def remove_csrf_cookie(resp):
+    resp.set_cookie(CSRF_COOKIE_NAME, value='', expires=0)
 
 def csrf_needed(func):
     @functools.wraps(func)

--- a/api/security/csrf/csrf.py
+++ b/api/security/csrf/csrf.py
@@ -42,7 +42,7 @@ def set_csrf_cookie(resp, csrf_token):
     resp.set_cookie(CSRF_COOKIE_NAME, value=csrf_token, httponly=True, secure=True, samesite="Lax")
 
 def remove_csrf_cookie(resp):
-    resp.set_cookie(CSRF_COOKIE_NAME, value='', expires=0)
+    resp.delete_cookie(CSRF_COOKIE_NAME)
 
 def csrf_needed(func):
     @functools.wraps(func)

--- a/api/security/csrf/csrf.py
+++ b/api/security/csrf/csrf.py
@@ -9,7 +9,7 @@ from api.exception import CSRFError
 from api.security.csrf import CSRF_SECRET_KEY
 from api.security.csrf.constants import CSRF_COOKIE_NAME, SALT, CSRF_TOKEN_HEADER
 
-digest_method = staticmethod(hashlib.sha256)
+digest_method = hashlib.sha256
 signer_kwargs = {'signer_kwargs': {'digest_method': digest_method}}
 
 def generate_csrf_token(secret_key, salt):

--- a/api/tests/exceptions/test_exception_handlers.py
+++ b/api/tests/exceptions/test_exception_handlers.py
@@ -1,6 +1,7 @@
 from marshmallow import ValidationError
 
 from api.exception.exceptions import RefreshTokenError, CSRFError
+from api.exception.handlers import csrf_error_handler
 from api.security.csrf import CSRF_COOKIE_NAME
 
 
@@ -26,16 +27,14 @@ def test_value_error_exception_handler(client, app, monkeypatch):
 
 def test_csrf_error_exception_handler(client, app, monkeypatch):
 
-    def sacct_raising():
-        raise CSRFError('CSRF Error')
-
-    monkeypatch.setitem(app.view_functions, 'sacct_', sacct_raising)
-    response = client.post('/manager/sacct')
+    with app.test_request_context('/'):
+        app.preprocess_request()
+        response, status_code = csrf_error_handler(CSRFError('CSRF Error'))
 
     csrf_cookies = list(cookie_value for cookie_header, cookie_value in response.headers if
                         'Set-Cookie' in cookie_header and CSRF_COOKIE_NAME in cookie_value)
 
-    assert response.status_code == 403
+    assert status_code == 403
     assert response.json == {'code': 403, 'message': '403 Forbidden: CSRF Error'}
     assert len(csrf_cookies) > 0
     assert 'Expires=Thu, 01 Jan 1970 00:00:00 GMT' in csrf_cookies[0]

--- a/api/tests/security/csrf/conftest.py
+++ b/api/tests/security/csrf/conftest.py
@@ -14,7 +14,7 @@ def mock_csrf_token_value():
 
 @pytest.fixture
 def mock_csrf_token_string(mock_csrf_token_value):
-    return URLSafeSerializer(SECRET_KEY, SALT).dumps(mock_csrf_token_value)
+    return URLSafeSerializer(SECRET_KEY, SALT, signer_kwargs={'digest_method': staticmethod(hashlib.sha256)}).dumps(mock_csrf_token_value)
 
 
 @pytest.fixture(scope='function')

--- a/api/tests/security/csrf/conftest.py
+++ b/api/tests/security/csrf/conftest.py
@@ -14,7 +14,7 @@ def mock_csrf_token_value():
 
 @pytest.fixture
 def mock_csrf_token_string(mock_csrf_token_value):
-    return URLSafeSerializer(SECRET_KEY, SALT, signer_kwargs={'digest_method': staticmethod(hashlib.sha256)}).dumps(mock_csrf_token_value)
+    return URLSafeSerializer(SECRET_KEY, SALT, signer_kwargs={'digest_method': hashlib.sha256}).dumps(mock_csrf_token_value)
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
## Description
This PR takes care of three things:
- switches to sha256 for the strategy used when creating a CSRF token
- in case of a CSRF token error the cookie gets deleted
- tests are adjusted and added for csrf exception handler
<!-- Summary of what this PR introduces and possibly why -->

## How Has This Been Tested?
- unit tests
- e2e
- manual tests running "state changing" requests that trigger the csrf token check
<!-- The tests you ran to verify your changes -->


## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [x] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
