### PR TITLE
Display error page in case an unmatched route is hit

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -103,7 +103,7 @@ def build_flask_app(name):
     return app
 
 
-def serve_frontend(app, path):
+def serve_frontend(app, path=""):
     if running_local():
         return proxy_to("http://localhost:3000/" + path)
 

--- a/app.py
+++ b/app.py
@@ -77,6 +77,10 @@ def run():
         return Response(
             "You are not authorized to perform this action.", 401
         )
+    
+    @app.errorhandler(404)
+    def page_not_found(_error):
+        return utils.serve_frontend(app)
 
     @app.route("/", defaults={"path": ""})
     @app.route('/<path:path>')

--- a/e2e/specs/noMatch.spec.ts
+++ b/e2e/specs/noMatch.spec.ts
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { expect, test } from '@playwright/test';
+import { visitAndLogin } from '../test-utils/login';
+import { ENVIRONMENT_CONFIG } from "../configs/environment";
+
+test.describe('Given an endpoint where AWS ParallelCluster UI is deployed', () => {
+  test.describe('when a user is logged in, and navigates to an unmatched route', () => {
+    test('an error page should be displayed', async ({ page }) => {
+      await visitAndLogin(page)
+      await page.goto(`${ENVIRONMENT_CONFIG.URL}/noMatch`) 
+      await expect(page.getByRole('heading', { name: 'Page not found' })).toBeVisible()
+    });
+  })
+})

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -9,6 +9,10 @@
       "users": "Users",
       "viewLicense": "View License"
     },
+    "docs": {
+      "title": "$t(global.projectName) documentation",
+      "link": "https://pcluster.cloud/"
+    },
     "errors": {
       "csrfError": "An unexpected error occurred. Please reload the page and try again"
     },
@@ -22,13 +26,15 @@
       "button": "Go to Homepage"   
     }
   },
+  "noMatch": {
+    "title": "Page not found",
+    "description": "You might have typed the address incorrectly or you might have used an outdated link. Check the link and try again.",
+    "links": "Use the following links:",
+    "home": "Homepage"
+  },
   "helpPanel": {
     "footer": {
-      "learnMore": "Learn more",
-      "docs": {
-        "title": "$t(global.projectName) documentation",
-        "link": "https://pcluster.cloud/"
-      }
+      "learnMore": "Learn more"
     },
     "default": {
       "title": "$t(global.projectName)",

--- a/frontend/public/img/error_pages_illustration.svg
+++ b/frontend/public/img/error_pages_illustration.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 91" width="140" height="91" aria-hidden="true">
+  <path
+    d="M122,62a17,17,0,1,0-17-17A17,17,0,0,0,122,62Zm0-17,6.46-6.46L122,45l-6.46-6.46Zm0,0-6.46,6.46L122,45l6.46,6.46Z"
+    fill="none"
+    stroke="#ef6d00"
+    strokeWidth="2"
+  />
+  <path
+    d="M10,12a3,3,0,1,1,3-3A3,3,0,0,1,10,12Zm10,0a3,3,0,1,1,3-3A3,3,0,0,1,20,12Zm10,0a3,3,0,1,1,3-3A3,3,0,0,1,30,12Z"
+    fill="#aab7b8"
+    fillRule="evenodd"
+  />
+  <path d="M40,31v9h9V31Zm0,17v9h9V48Zm0,19v9h9V67Z" fill="none" stroke="#aab7b8" strokeWidth="2" />
+  <path
+    d="M123,22V3a2,2,0,0,0-2-2H3A2,2,0,0,0,1,3V88a2,2,0,0,0,2,2H121a2,2,0,0,0,2-2V69.89"
+    fill="none"
+    stroke="#aab7b8"
+    strokeWidth="2"
+  />
+  <rect x="23.46" y="17.04" width="2.06" height="72.7" fill="#aab7b8" />
+  <rect x="1.52" y="15.44" width="121.73" height="2.06" fill="#aab7b8" />
+  <rect x="55.81" y="34.51" width="44.51" height="1.99" fill="#aab7b8" />
+  <rect x="55.86" y="53.5" width="44.51" height="1.99" fill="#aab7b8" />
+  <rect x="55.87" y="69.49" width="48.01" height="1.99" fill="#aab7b8" />
+</svg>

--- a/frontend/src/components/NoMatch.tsx
+++ b/frontend/src/components/NoMatch.tsx
@@ -1,0 +1,58 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  Container,
+  ContentLayout,
+  Link,
+  TextContent,
+} from '@cloudscape-design/components'
+import React from 'react'
+import errorPage from './../../public/img/error_pages_illustration.svg'
+import Image from 'next/image'
+import {useTranslation} from 'react-i18next'
+import Layout from '../old-pages/Layout'
+import {DefaultHelpPanel} from './help-panel/DefaultHelpPanel'
+import {useHelpPanel} from './help-panel/HelpPanel'
+
+export function NoMatch() {
+  const {t} = useTranslation()
+  useHelpPanel(<DefaultHelpPanel />)
+
+  return (
+    <Layout contentType="default">
+      <ContentLayout header={<></>}>
+        <Container>
+          <Image src={errorPage} alt="test" height={100} />
+          <TextContent>
+            <h1>{t('noMatch.title')}</h1>
+            <p>{t('noMatch.description')}</p>
+            <p>{t('noMatch.links')}</p>
+            <ul>
+              <li>
+                <Link href="/">{t('noMatch.home')}</Link>
+              </li>
+              <li>
+                <Link
+                  external
+                  externalIconAriaLabel={t('global.openNewTab')}
+                  href={t('global.docs.link')}
+                >
+                  {t('global.docs.title')}
+                </Link>
+              </li>
+            </ul>
+          </TextContent>
+        </Container>
+      </ContentLayout>
+    </Layout>
+  )
+}

--- a/frontend/src/components/NoMatch.tsx
+++ b/frontend/src/components/NoMatch.tsx
@@ -31,7 +31,7 @@ export function NoMatch() {
     <Layout contentType="default">
       <ContentLayout header={<></>}>
         <Container>
-          <Image src={errorPage} alt="test" height={100} />
+          <Image src={errorPage} height={100} />
           <TextContent>
             <h1>{t('noMatch.title')}</h1>
             <p>{t('noMatch.description')}</p>

--- a/frontend/src/components/help-panel/TitleDescriptionHelpPanel.tsx
+++ b/frontend/src/components/help-panel/TitleDescriptionHelpPanel.tsx
@@ -37,9 +37,9 @@ function TitleDescriptionHelpPanel({
               <Link
                 external
                 externalIconAriaLabel={t('global.openNewTab')}
-                href={t('helpPanel.footer.docs.link')}
+                href={t('global.docs.link')}
               >
-                {t('helpPanel.footer.docs.title')}
+                {t('global.docs.title')}
               </Link>
             </li>
           </ul>

--- a/frontend/src/old-pages/Layout.tsx
+++ b/frontend/src/old-pages/Layout.tsx
@@ -39,7 +39,7 @@ type Slug =
   | 'clusterCreate'
   | 'clusterUpdate'
 type BreadcrumbsProps = {
-  pageSlug: Slug
+  pageSlug?: Slug
   slugOnClick?: CancelableEventHandler<BreadcrumbGroupProps.ClickDetail>
 }
 
@@ -126,7 +126,9 @@ export default function Layout({
         content={children}
         contentType="table"
         navigation={<SideBar />}
-        breadcrumbs={<Breadcrumbs slug={pageSlug} onClick={slugOnClick} />}
+        breadcrumbs={
+          pageSlug && <Breadcrumbs slug={pageSlug} onClick={slugOnClick} />
+        }
         notifications={<Flashbar items={messages} />}
         {...props}
         tools={element}

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -25,6 +25,7 @@ import Users from '../old-pages/Users/Users'
 // Components
 import Loading from '../components/Loading'
 import {useLogger} from '../logger/LoggerProvider'
+import {NoMatch} from '../components/NoMatch'
 
 export default function App() {
   const identity = useState(['identity'])
@@ -53,6 +54,7 @@ export default function App() {
             <Route path="custom-images" element={<CustomImages />} />
             <Route path="official-images" element={<OfficialImages />} />
             <Route path="users" element={<Users />} />
+            <Route path="*" element={<NoMatch />} />
           </Routes>
         </BrowserRouter>
       ) : (


### PR DESCRIPTION
## Description

Currently, pointing to a non-existing page in PCUI returns an empty page, which can be confusing for customers.

This PR introduces a new error page template in PCUI that displays a clear message to the user indicating that an error has occurred, along with options for resolving the issue.

## Changelog entry
* Add error page to be displayed if an unmatched route is hit

## How Has This Been Tested?
* Manual tests navigating to unmatched routes, even in the case where the frontend is served by the backend

![Screenshot 2023-01-18 at 23 04 35](https://user-images.githubusercontent.com/25930133/213305537-f7d1fc45-a97c-47cb-8b06-c152be764eba.png)

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
