### PR TITLE
Use pbkdf2_hmac in fingerprint generation

### DIFF
--- a/api/security/fingerprint.py
+++ b/api/security/fingerprint.py
@@ -1,4 +1,4 @@
-import hashlib
+from hashlib import pbkdf2_hmac
 from abc import ABC
 
 
@@ -7,6 +7,7 @@ class IFingerprintGenerator(ABC):
     def fingerprint(self):
         pass
 
+SALT = 'cognito-fingerprint-salt'.encode()
 
 class CognitoFingerprintGenerator(IFingerprintGenerator):
 
@@ -16,9 +17,5 @@ class CognitoFingerprintGenerator(IFingerprintGenerator):
         self.user_pool_id = user_pool_id
 
     def fingerprint(self):
-        hash = self.__hash('', self.client_id)
-        hash = self.__hash(hash, self.client_secret)
-        return self.__hash(hash, self.user_pool_id)
-
-    def __hash(self, a, b):
-        return hashlib.sha256(f'{a}:{b}'.encode('utf-8')).hexdigest()
+        to_encrypt = self.client_id + self.client_secret + self.user_pool_id
+        return pbkdf2_hmac('sha256', to_encrypt.encode(), SALT, 500_000).hex()

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -4,7 +4,13 @@ import pytest
 
 import api.security
 from app import run
+import app as _app
 
+@pytest.fixture(autouse=True)
+def mock_cognito_variables(mocker):
+    mocker.patch.object(_app, 'CLIENT_ID', 'client-id')
+    mocker.patch.object(_app, 'USER_POOL_ID', 'user-pool')
+    mocker.patch.object(_app, 'CLIENT_SECRET', 'client-secret')
 
 @pytest.fixture()
 def app():
@@ -14,8 +20,6 @@ def app():
     })
 
     yield app
-
-
 
 @pytest.fixture()
 def client(app):
@@ -29,10 +33,13 @@ def runner(app):
 @pytest.fixture()
 def dev_app(monkeypatch):
     monkeypatch.setenv("ENV", "dev")
+
     app = run()
     app.config.update({
         "TESTING": True,
     })
+
+    
 
     yield app
 

--- a/api/tests/security/test_secret_generator.py
+++ b/api/tests/security/test_secret_generator.py
@@ -8,7 +8,7 @@ def test_cognito_fingerprint_generator():
         it should produce the same fingerprint everytime
     """
     client_id, client_secret, user_pool_id = 'client-id', 'client-secret', 'pool-id'
-    expected_fingerprint = '456fe4db680c3be20d9f7d000d5d2fdc5aff08668832760caac765aa2814bdd6'
+    expected_fingerprint = '88056a6f3236e82b05de9bbb01a979b2877563c0c971148bc20aaa9aad8b3b85'
 
     gen = CognitoFingerprintGenerator(client_id, client_secret, user_pool_id)
     fingerprint = gen.fingerprint()


### PR DESCRIPTION
## Description

Replace a custom made hash function with pbkdf2_hmac to generate the fingerprint used in the CSRF token generation.

## How Has This Been Tested?

Tested a local version of the frontend with auth enabled, and verified that mutations work seamlessly.

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
