### PR TITLE
Remove EnableAuth parameter to configure the authentication

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -47,29 +47,6 @@ npm run dev
 
 Lastly, navigate to [http://localhost:5001](http://localhost:5001)
 
-## Frontend
-Disable authentication (*HMR does not work when working on http://localhost:5001*), note that this has to be exported in shell where the backend runs:
-
-```bash
-export ENABLE_AUTH=false
-```
-
-Start the API backend by running:
-
-```bash
-./scripts/run_flask.sh
-```
-
-Start the React frontend by running:
-
-```bash
-cd frontend/
-npm install # if this is your first time starting the frontend
-npm run dev
-```
-
-Navigate to [http://localhost:3000](http://localhost:3000)
-
 ## Typescript
 The project has been converted to Typescript using [ts-migrate](https://github.com/airbnb/ts-migrate/tree/master/packages/ts-migrate)(an in depth explanation can be found [here](https://medium.com/airbnb-engineering/ts-migrate-a-tool-for-migrating-to-typescript-at-scale-cd23bfeb5cc)).
 The tool automatically adds comments similar to `// @ts-expect-error` when typing errors cannot be fixed automatically: if you fix a type error either by adding a missing third party declaration or tweaking the signature of a function, you can adjust automatically the codebase and remove `//@ts-ignore` comments using `npm run ts-reignore`.

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 import api.security
@@ -47,6 +45,6 @@ def mock_csrf_needed(mocker, app):
     mock_csrf_enabled = mocker.patch.object(api.security.csrf.csrf, 'is_csrf_enabled')
     mock_csrf_enabled.return_value = False
 
-@pytest.fixture(scope='function')
-def mock_enable_auth(mocker):
-    return mocker.patch.dict(os.environ, {'ENABLE_AUTH': 'false'})
+@pytest.fixture
+def mock_disable_auth(mocker):
+    mocker.patch.object(api.utils, 'DISABLE_AUTH', True)

--- a/api/tests/test_authenticate.py
+++ b/api/tests/test_authenticate.py
@@ -3,20 +3,16 @@ from unittest import mock
 
 import pytest
 from flask import g
-from api.PclusterApiHandler import authenticate, refresh_tokens, USER_ROLES_CLAIM
+from api.PclusterApiHandler import authenticate, USER_ROLES_CLAIM
 from jose import jwt
 
-from api.exception.exceptions import RefreshTokenError
-
-@mock.patch.dict(os.environ,{"ENABLE_AUTH": "false"})
-def test_authenticate():
+def test_authenticate(mock_disable_auth):
     """
     Given an authentication middleware
       When authentication is disabled
         Then it should do nothing
     """
     assert authenticate({'any-group'}) is None
-
 
 def test_authenticate_with_no_access_token_returns_401(mocker, app):
     with app.test_request_context():

--- a/api/tests/test_get_identity.py
+++ b/api/tests/test_get_identity.py
@@ -1,6 +1,7 @@
 from unittest.mock import call, ANY
 
 import pytest
+
 from jose import ExpiredSignatureError
 
 import api
@@ -9,13 +10,12 @@ from api.PclusterApiHandler import get_identity
 
 MOCK_IDENTITY_OBJECT = {"user_roles": ["user", "admin"], "username": "username", "attributes": {"email": "user@domain.com"}}
 
-def test_get_identity_auth_disabled(monkeypatch):
+def test_get_identity_auth_disabled(mock_disable_auth):
     """
     Given an handler for the /get-identity endpoint
       When authentication is disabled
         Then it should return a static identity object
     """
-    monkeypatch.setenv("ENABLE_AUTH", "false")
     assert get_identity() == MOCK_IDENTITY_OBJECT
 
 def test_get_identity_auth_enabled_both_tokens_provide_attributes(monkeypatch, mocker, app):
@@ -25,7 +25,6 @@ def test_get_identity_auth_enabled_both_tokens_provide_attributes(monkeypatch, m
       When both access token and identity token contain the same user attributes
         Then it should return the attributes contained in the identity token
     """
-    monkeypatch.setenv("ENABLE_AUTH", "true")
     monkeypatch.setattr('api.PclusterApiHandler.USER_ROLES_CLAIM', 'user_roles_claim')
     accessTokenDecoded = {
       'user_roles_claim': ['access-token-group'],
@@ -53,7 +52,6 @@ def test_get_identity_auth_enabled_access_tokens_used_as_fallback(monkeypatch, m
       When identity token is missing some user attributes
         Then it should fallback to the attributes contained in the access token
     """
-    monkeypatch.setenv("ENABLE_AUTH", "true")
     monkeypatch.setattr('api.PclusterApiHandler.USER_ROLES_CLAIM', 'user_roles_claim')
     accessTokenDecoded = {
       'user_roles_claim': ['access-token-group'],
@@ -79,7 +77,6 @@ def test_get_identity_auth_enabled_no_username_provided(monkeypatch, mocker, app
       When username could not be retrieved
         Then it should raise Exception
     """
-    monkeypatch.setenv("ENABLE_AUTH", "true")
     monkeypatch.setattr('api.PclusterApiHandler.USER_ROLES_CLAIM', 'user_roles_claim')
     accessTokenDecoded = {}
     identityTokenDecoded = {
@@ -98,7 +95,6 @@ def test_get_identity_auth_enabled_no_user_roles_provided(monkeypatch, mocker, a
       When user roles could not be retrieved
         Then it should raise Exception
     """
-    monkeypatch.setenv("ENABLE_AUTH", "true")
     monkeypatch.setattr('api.PclusterApiHandler.USER_ROLES_CLAIM', 'user_roles_claim')
     accessTokenDecoded = {}
     identityTokenDecoded = {

--- a/api/tests/test_push_log.py
+++ b/api/tests/test_push_log.py
@@ -1,18 +1,10 @@
-from os import environ
-
 import pytest
-
 
 def trim_log(caplog):
     return caplog.text.replace('\n', '')
 
 
-@pytest.fixture(scope='function')
-def disable_auth(monkeypatch):
-    monkeypatch.setitem(environ, 'ENABLE_AUTH', 'false')
-
-
-def test_push_log_controller_with_valid_json_no_extra(client, caplog, disable_auth, mock_csrf_needed):
+def test_push_log_controller_with_valid_json_no_extra(client, caplog, mock_disable_auth, mock_csrf_needed):
     request_body = { 'logs': [{'message': 'sample-message', 'level': 'info'}] }
     expected_log = "INFO     pcluster-manager:logger.py:24 {'message': 'sample-message'}"
 
@@ -23,7 +15,7 @@ def test_push_log_controller_with_valid_json_no_extra(client, caplog, disable_au
     assert trim_log(caplog) == expected_log
 
 
-def test_push_log_controller_with_valid_json_with_extra(client, caplog, disable_auth, mock_csrf_needed):
+def test_push_log_controller_with_valid_json_with_extra(client, caplog, mock_disable_auth, mock_csrf_needed):
     request_body = { 'logs': [{'message': 'sample-message', 'level': 'error',
                     'extra': {'extra_1': 'value_1', 'extra_2': 'value_2'}}]}
     expected_log = "ERROR    pcluster-manager:logger.py:30 {'extra_1': 'value_1', 'extra_2': 'value_2', 'message': 'sample-message'}"

--- a/api/tests/validation/test_api_validation.py
+++ b/api/tests/validation/test_api_validation.py
@@ -25,14 +25,14 @@ class MockRequestJsonSchema(Schema):
     username = fields.Email(required=True)
 
 
-def test_valid_request_successful(mock_csrf_needed, mock_enable_auth):
+def test_valid_request_successful(mock_csrf_needed, mock_disable_auth):
     request = MockRequest()
     errors = __validate_request(request, body_schema=MockRequestJsonSchema(), params_schema=MockRequestArgsSchema(),
                                 cookies_schema=MockRequestCookiesSchema())
 
     assert errors == {}
 
-def test_invalid_request_successful_with_raise_on_missing_body_enabled(mock_csrf_needed, mock_enable_auth):
+def test_invalid_request_successful_with_raise_on_missing_body_enabled(mock_csrf_needed, mock_disable_auth):
     request = MockRequest()
     mock_json_property = PropertyMock(side_effect=Exception)
     original_json_property = MockRequest.json
@@ -45,7 +45,7 @@ def test_invalid_request_successful_with_raise_on_missing_body_enabled(mock_csrf
     mock_json_property.assert_called_once()
     MockRequest.json = original_json_property
 
-def test_invalid_request_successful_with_raise_on_missing_body_disabled(mock_csrf_needed, mock_enable_auth):
+def test_invalid_request_successful_with_raise_on_missing_body_disabled(mock_csrf_needed, mock_disable_auth):
     request = MockRequest()
     mock_json_property = PropertyMock(side_effect=Exception)
     original_json_property = MockRequest.json
@@ -60,7 +60,7 @@ def test_invalid_request_successful_with_raise_on_missing_body_disabled(mock_csr
     MockRequest.json = original_json_property
 
 
-def test_valid_request_failure(mock_csrf_needed, mock_enable_auth):
+def test_valid_request_failure(mock_csrf_needed, mock_disable_auth):
     request = MockRequest()
     request.cookies['int_value'] = 50
     errors = __validate_request(request, body_schema=MockRequestJsonSchema(), params_schema=MockRequestArgsSchema(),
@@ -69,7 +69,7 @@ def test_valid_request_failure(mock_csrf_needed, mock_enable_auth):
     assert errors == {'int_value': ['Must be greater than or equal to 99 and less than or equal to 101.']}
 
 
-def test_valid_decorator_success(app, mock_csrf_needed, mock_enable_auth):
+def test_valid_decorator_success(app, mock_csrf_needed, mock_disable_auth):
     def func(): pass
     func = validated(body=MockRequestJsonSchema())(func)
 
@@ -77,7 +77,7 @@ def test_valid_decorator_success(app, mock_csrf_needed, mock_enable_auth):
         func()
 
 
-def test_valid_decorator_failure(app, mock_csrf_needed, mock_enable_auth):
+def test_valid_decorator_failure(app, mock_csrf_needed, mock_disable_auth):
     def func(): pass
     func = validated(body=MockRequestJsonSchema())(func)
 

--- a/api/utils.py
+++ b/api/utils.py
@@ -19,6 +19,8 @@ from api.exception import ExceptionHandler
 from api.pcm_globals import PCMGlobals
 from api.security import SecurityHeaders
 
+# needed to only allow tests to disable auth
+DISABLE_AUTH=False
 
 def to_utc_datetime(time_in, default_timezone=datetime.timezone.utc) -> datetime.datetime:
     """
@@ -63,10 +65,8 @@ def to_iso_timestr(time_in: datetime.datetime) -> str:
 def running_local():
     return os.getenv("ENV") == "dev"
 
-
 def disable_auth():
-    return os.getenv("ENABLE_AUTH") == "false"
-
+    return DISABLE_AUTH
 
 def proxy_to(to_url):
     """

--- a/infrastructure/pcluster-manager.yaml
+++ b/infrastructure/pcluster-manager.yaml
@@ -19,11 +19,6 @@ Parameters:
     Description: SNSRole ARN of a previously deployed PCM Cognito Stack. Leave blank to create a new one.
     Type: String
     Default: ''
-  EnableAuth:
-    Description: When false this disables the authentication requirement for PCM users. Only use this value for tutorials or short-lived deployments.
-    Type: String
-    Default: true
-    AllowedValues: [true, false]
   EnableMFA:
     AllowedValues: [true, false]
     Default: false
@@ -56,7 +51,6 @@ Metadata:
       - Label:
           default: Authentication
         Parameters:
-          - EnableAuth
           - EnableMFA
       - Label: 
           default: Admin User (only with new Cognito instances)
@@ -77,8 +71,6 @@ Metadata:
     ParameterLabels:
       EnableMFA:
         default: Require Multi-Factor Authentication for all Users
-      EnableAuth:
-        default: Enable Authentication
       AdminUserEmail:
         default: Admin's Email
       AdminUserPhone:
@@ -182,7 +174,6 @@ Resources:
           SECRET_ID: !GetAtt UserPoolClientSecret.SecretName
           AUDIENCE: !Ref CognitoAppClient
           OIDC_PROVIDER: 'Cognito'
-          ENABLE_AUTH: !Ref EnableAuth
           ENABLE_MFA: !Ref EnableMFA
       FunctionName: !Sub
         - PclusterManagerFunction-${StackIdSuffix}


### PR DESCRIPTION
## Description

This PR removes the possibility of disabling the authentication by changing a CloudFormation parameter.

In order to protect customers from affecting the security of their installation, this PR also removes the possibility of disabling the authentication by changing an environment variable passed to the Lambda

## Changes

- remove `EnableAuth` CloudFormation parameter
- remove `ENABLE_AUTH` environment variable

## How Has This Been Tested?

- ran unit and e2e tests
- set the environment variable and checked that the auth does not get disabled
- tested that you can still disable authentication when developing locally
- verified the Stack Create screen does not allow to configure the EnableAuth anymore (see screenshot below)
- set the environment variable in the Lambda Console and checked that auth does not get disabled

![Screenshot 2023-01-19 at 11 32 42](https://user-images.githubusercontent.com/11457067/213421998-10e96247-89c3-488f-940f-a31ddc732689.png)

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [x] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
