### PR TITLE
Improved CSRF token handling with TimedSignature

### DIFF
--- a/api/security/csrf/__init__.py
+++ b/api/security/csrf/__init__.py
@@ -10,11 +10,8 @@ csrf_blueprint = Blueprint('csrf', __name__)
 
 @csrf_blueprint.get('/csrf')
 def get_and_set_csrf_token():
-    csrf_token = request.cookies.get(CSRF_COOKIE_NAME)
-    if not csrf_token:
-        csrf_secret_key = current_app.config.get(CSRF_SECRET_KEY)
-        csrf_token = generate_csrf_token(csrf_secret_key, SALT)
-
+    csrf_secret_key = current_app.config.get(CSRF_SECRET_KEY)
+    csrf_token = generate_csrf_token(csrf_secret_key, SALT)
     resp = jsonify(csrf_token=csrf_token)
     set_csrf_cookie(resp, csrf_token)
     return resp

--- a/api/security/csrf/csrf.py
+++ b/api/security/csrf/csrf.py
@@ -1,7 +1,6 @@
 import functools
 import hashlib
 import os
-from datetime import datetime, timedelta
 
 from flask import request, current_app
 from itsdangerous import BadSignature, URLSafeTimedSerializer
@@ -42,8 +41,7 @@ def is_csrf_enabled():
 
 
 def set_csrf_cookie(resp, csrf_token, max_age=CSRF_DEFAULT_MAX_AGE):
-    expiration_date = datetime.now() + timedelta(seconds=max_age)
-    resp.set_cookie(CSRF_COOKIE_NAME, expires=expiration_date, value=csrf_token, httponly=True, secure=True, samesite="Lax")
+    resp.set_cookie(CSRF_COOKIE_NAME, max_age=max_age, value=csrf_token, httponly=True, secure=True, samesite="Lax")
 
 def remove_csrf_cookie(resp):
     resp.delete_cookie(CSRF_COOKIE_NAME)

--- a/api/security/csrf/csrf.py
+++ b/api/security/csrf/csrf.py
@@ -1,27 +1,30 @@
 import functools
 import hashlib
 import os
+from datetime import datetime, timedelta
 
 from flask import request, current_app
-from itsdangerous import URLSafeSerializer, BadSignature
+from itsdangerous import BadSignature, URLSafeTimedSerializer
 
 from api.exception import CSRFError
 from api.security.csrf import CSRF_SECRET_KEY
 from api.security.csrf.constants import CSRF_COOKIE_NAME, SALT, CSRF_TOKEN_HEADER
 
+CSRF_DEFAULT_MAX_AGE = 30
+
 digest_method = hashlib.sha256
 signer_kwargs = {'signer_kwargs': {'digest_method': digest_method}}
 
 def generate_csrf_token(secret_key, salt):
-    serializer = URLSafeSerializer(secret_key, salt, **signer_kwargs)
+    serializer = URLSafeTimedSerializer(secret_key, salt, **signer_kwargs)
     csrf_token_value = hashlib.sha256(os.urandom(64)).hexdigest()
     csrf_token = serializer.dumps(csrf_token_value)
     return csrf_token
 
 
-def parse_csrf_token(secret_key, salt, token):
-    serializer = URLSafeSerializer(secret_key, salt, **signer_kwargs)
-    return serializer.loads(token)
+def parse_csrf_token(secret_key, salt, token, max_age=CSRF_DEFAULT_MAX_AGE):
+    serializer = URLSafeTimedSerializer(secret_key, salt, **signer_kwargs)
+    return serializer.loads(token, max_age=max_age)
 
 
 def validate_csrf(secret_key, csrf_cookie, csrf_header):
@@ -38,8 +41,9 @@ def is_csrf_enabled():
     return True
 
 
-def set_csrf_cookie(resp, csrf_token):
-    resp.set_cookie(CSRF_COOKIE_NAME, value=csrf_token, httponly=True, secure=True, samesite="Lax")
+def set_csrf_cookie(resp, csrf_token, max_age=CSRF_DEFAULT_MAX_AGE):
+    expiration_date = datetime.now() + timedelta(seconds=max_age)
+    resp.set_cookie(CSRF_COOKIE_NAME, expires=expiration_date, value=csrf_token, httponly=True, secure=True, samesite="Lax")
 
 def remove_csrf_cookie(resp):
     resp.delete_cookie(CSRF_COOKIE_NAME)

--- a/api/tests/security/csrf/conftest.py
+++ b/api/tests/security/csrf/conftest.py
@@ -1,7 +1,7 @@
 import hashlib
 
 import pytest
-from itsdangerous import URLSafeSerializer
+from itsdangerous import URLSafeTimedSerializer
 
 from api.tests.security.csrf.test_csrf import MOCK_URANDOM_VALUE, SECRET_KEY, SALT
 
@@ -14,7 +14,7 @@ def mock_csrf_token_value():
 
 @pytest.fixture
 def mock_csrf_token_string(mock_csrf_token_value):
-    return URLSafeSerializer(SECRET_KEY, SALT, signer_kwargs={'digest_method': hashlib.sha256}).dumps(mock_csrf_token_value)
+    return URLSafeTimedSerializer(SECRET_KEY, SALT, signer_kwargs={'digest_method': hashlib.sha256}).dumps(mock_csrf_token_value)
 
 
 @pytest.fixture(scope='function')

--- a/api/tests/security/csrf/test_csrf.py
+++ b/api/tests/security/csrf/test_csrf.py
@@ -1,3 +1,4 @@
+import datetime
 import time
 from unittest.mock import ANY, call
 
@@ -29,6 +30,8 @@ def test_crsf_extension_get_new_csrf(app):
               it should return the csrf_token in a json
     """
     CSRF(app)
+    now = datetime.datetime.utcnow()
+    expected_expiration = (now + datetime.timedelta(seconds=30)).strftime('%a, %d %b %Y %H:%M:%S')
     resp = app.test_client().get('/csrf')
     csrf_cookies = list(cookie_value for cookie_header, cookie_value in resp.headers if
                         'Set-Cookie' in cookie_header and CSRF_COOKIE_NAME in cookie_value)
@@ -37,7 +40,7 @@ def test_crsf_extension_get_new_csrf(app):
     assert 'csrf_token' in resp.json
     assert len(csrf_cookies) > 0
     assert 'Secure; HttpOnly; Path=/; SameSite=Lax' in csrf_cookies[0]
-    assert 'Expires=' in csrf_cookies[0]
+    assert f'Expires={expected_expiration}' in csrf_cookies[0]
 
 
 def test_csrf_needed_decorator(mocker, capsys, mock_csrf_token_string, app, mock_parse_csrf):

--- a/api/tests/security/csrf/test_csrf.py
+++ b/api/tests/security/csrf/test_csrf.py
@@ -1,8 +1,9 @@
-import os
+import time
 from unittest.mock import ANY, call
 
 import pytest
 from flask import request
+from itsdangerous import BadSignature
 
 from api.exception import CSRFError
 from api.security.csrf import CSRF, generate_csrf_token
@@ -36,27 +37,7 @@ def test_crsf_extension_get_new_csrf(app):
     assert 'csrf_token' in resp.json
     assert len(csrf_cookies) > 0
     assert 'Secure; HttpOnly; Path=/; SameSite=Lax' in csrf_cookies[0]
-
-def test_crsf_extension_get_existing_csrf(app):
-    """
-    When an app is built
-        and CSRF ext is applied
-            it should expose a new endpoint /csrf
-            when a csrf cookie is already set in the incoming request
-              it should return the csrf_token in a json
-    """
-    CSRF(app)
-    test_client = app.test_client()
-    test_client.set_cookie(os.getenv('SITE_URL'), 'csrf', 'csrf-value', samesite='Lax', httponly=True, secure=True)
-    resp = test_client.get('/csrf')
-    csrf_cookies = list(cookie_value for cookie_header, cookie_value in resp.headers if
-                        'Set-Cookie' in cookie_header and CSRF_COOKIE_NAME in cookie_value)
-
-    assert resp.status_code != 405
-    assert 'csrf_token' in resp.json
-    assert resp.json.get('csrf_token') == 'csrf-value'
-    assert len(csrf_cookies) > 0
-    assert 'Secure; HttpOnly; Path=/; SameSite=Lax' in csrf_cookies[0]
+    assert 'Expires=' in csrf_cookies[0]
 
 
 def test_csrf_needed_decorator(mocker, capsys, mock_csrf_token_string, app, mock_parse_csrf):
@@ -117,6 +98,12 @@ def test_parse_csrf_token(mock_urandom, mock_csrf_token_value):
 
     assert actual_token_value == mock_csrf_token_value
 
+def test_parse_csrf_token_expired(mock_urandom):
+    csrf_token = generate_csrf_token(SECRET_KEY,SALT)
+    time.sleep(1)
+
+    with pytest.raises(BadSignature):
+        parse_csrf_token(SECRET_KEY, SALT, csrf_token, max_age=0)
 
 def test_validate_csrf(mock_parse_csrf):
     """


### PR DESCRIPTION
## Description
This PR changes the way CSRF token (and cookie) are generated, moving from a `URLSafeSerializer` to a `URLSafeTimedSerializer`.
Now CSRF tokens are valid for 30 seconds, after that they would throw bad signature exception.
Now invocation of the `/csrf` token always returns (and sets as an expiring cookie) a new token.
<!-- Summary of what this PR introduces and possibly why -->

## How Has This Been Tested?
- unit tests
- e2e
- manual tests
<!-- The tests you ran to verify your changes -->

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [x] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
