### PR TITLE
Forward custom headers correctly in DELETE requests

### DIFF
--- a/frontend/src/http/__tests__/executeRequest.test.ts
+++ b/frontend/src/http/__tests__/executeRequest.test.ts
@@ -33,7 +33,7 @@ describe('given the application config', () => {
       internalExecuteRequest('get', '/', {}, {}, mockAppConfig)
 
       expect(mockOperation).toHaveBeenCalledTimes(1)
-      expect(mockOperation).toHaveBeenCalledWith('/', {}, expectedConf)
+      expect(mockOperation).toHaveBeenCalledWith('/', expectedConf)
     })
 
     it('should be correctly invoked with method POST', () => {
@@ -61,7 +61,7 @@ describe('given the application config', () => {
       internalExecuteRequest('delete', '/', {}, {}, mockAppConfig)
 
       expect(mockOperation).toHaveBeenCalledTimes(1)
-      expect(mockOperation).toHaveBeenCalledWith('/', {}, expectedConf)
+      expect(mockOperation).toHaveBeenCalledWith('/', expectedConf)
     })
   })
 })

--- a/frontend/src/http/executeRequest.tsx
+++ b/frontend/src/http/executeRequest.tsx
@@ -27,14 +27,17 @@ export function internalExecuteRequest(...params: RequestParams) {
   const [method, url, body, headers, appConfig] = params
   const requestFunc = axiosInstance[method]
 
-  const defaultHeaders = {'Content-Type': 'application/json'}
+  const headersToSend = {'Content-Type': 'application/json', ...headers}
   const handle401and403 = appConfig
     ? handleNotAuthorizedErrors(appConfig)
     : identityFn<Promise<any>>
 
-  return handle401and403(
-    requestFunc(url, body, {headers: {...defaultHeaders, ...headers}}),
-  )
+  const promise =
+    method === 'get' || method === 'delete'
+      ? requestFunc(url, {headers: headersToSend})
+      : requestFunc(url, body, {headers: headersToSend})
+
+  return handle401and403(promise)
 }
 
 export const executeRequest = (...params: RequestParams) =>


### PR DESCRIPTION
## Description
Sending a customer header to a DELETE request doesn't work after the introduction of #496.

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
