### PR TITLE
Support for dynamic filesystems mount

### DIFF
--- a/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
+++ b/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
@@ -53,6 +53,7 @@ describe('given a feature flags provider and a list of rules', () => {
         'slurm_queue_update_strategy',
         'slurm_accounting',
         'queues_multiple_instance_types',
+        'dynamic_fs_mount',
       ])
     })
   })

--- a/frontend/src/feature-flags/featureFlagsProvider.ts
+++ b/frontend/src/feature-flags/featureFlagsProvider.ts
@@ -20,8 +20,12 @@ const versionToFeaturesMap: Record<string, AvailableFeature[]> = {
     'multiuser_cluster',
     'slurm_queue_update_strategy',
   ],
-  '3.3.0': ['slurm_accounting', 'queues_multiple_instance_types'],
-  '3.4.0': ['multi_az', 'on_node_updated']
+  '3.3.0': [
+    'slurm_accounting',
+    'queues_multiple_instance_types',
+    'dynamic_fs_mount',
+  ],
+  '3.4.0': ['multi_az', 'on_node_updated'],
 }
 
 function composeFlagsListByVersion(currentVersion: string): AvailableFeature[] {

--- a/frontend/src/feature-flags/types.ts
+++ b/frontend/src/feature-flags/types.ts
@@ -19,3 +19,4 @@ export type AvailableFeature =
   | 'queues_multiple_instance_types'
   | 'multi_az'
   | 'on_node_updated'
+  | 'dynamic_fs_mount'

--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -146,8 +146,6 @@ export function FsxLustreSettings({index}: any) {
   const exportPath = useState(exportPathPath) || ''
   const compression = useState(compressionPath)
 
-  const editing = useState(['app', 'wizard', 'editing'])
-
   React.useEffect(() => {
     const fsxPath = [...storagePath, index, 'FsxLustreSettings']
     const storageCapacityPath = [...fsxPath, 'StorageCapacity']
@@ -222,7 +220,6 @@ export function FsxLustreSettings({index}: any) {
             setState(storageCapacityPath, clampCapacity(storageCapacity))
           }}
           type="number"
-          disabled={editing}
         />
       </div>
       <FormField
@@ -252,7 +249,6 @@ export function FsxLustreSettings({index}: any) {
         }
       >
         <Select
-          disabled={editing}
           selectedOption={strToOption(lustreType || 'PERSISTENT_1')}
           onChange={({detail}) => {
             setState(lustreTypePath, detail.selectedOption.value)
@@ -290,7 +286,6 @@ export function FsxLustreSettings({index}: any) {
             }
           >
             <Input
-              disabled={editing}
               placeholder={t('wizard.storage.Fsx.import.placeholder')}
               value={importPath}
               onChange={({detail}) => setImportPath(detail.value)}
@@ -318,7 +313,6 @@ export function FsxLustreSettings({index}: any) {
             }
           >
             <Input
-              disabled={editing}
               placeholder={t('wizard.storage.Fsx.export.placeholder')}
               value={exportPath}
               onChange={({detail}) => {
@@ -558,7 +552,6 @@ function EbsSettings({index}: any) {
   const encryptedPath = [...ebsPath, 'Encrypted']
   const kmsPath = [...ebsPath, 'KmsKeyId']
   const snapshotIdPath = [...ebsPath, 'SnapshotId']
-  const editing = useState(['app', 'wizard', 'editing'])
 
   const deletionPolicyPath = [...ebsPath, 'DeletionPolicy']
   const deletionPolicies = ['Delete', 'Retain', 'Snapshot']
@@ -603,7 +596,6 @@ function EbsSettings({index}: any) {
         >
           <Trans i18nKey="wizard.storage.Ebs.volumeType.label" />:
           <Select
-            disabled={editing}
             placeholder={t('wizard.queues.validation.scriptWithArgs', {
               defaultVlumeType: defaultVolumeType,
             })}
@@ -628,7 +620,6 @@ function EbsSettings({index}: any) {
           <div style={{display: 'flex', flexShrink: 1}}>
             <FormField errorText={volumeErrors}>
               <Input
-                disabled={editing}
                 inputMode={'decimal'}
                 type={'number' as InputProps.Type}
                 value={volumeSize}
@@ -839,7 +830,6 @@ function StorageInstance({index}: any) {
             }
           >
             <Input
-              disabled={editing}
               value={mountPoint}
               onChange={({detail}) => {
                 setState([...storagePath, index, 'MountDir'], detail.value)

--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -769,7 +769,8 @@ function StorageInstance({index}: any) {
   const fsxFilesystems = useState(['aws', 'fsxFilesystems'])
   const fsxVolumes = useState(['aws', 'fsxVolumes'])
   const efsFilesystems = useState(['aws', 'efs_filesystems']) || []
-  const editing = useState(['app', 'wizard', 'editing'])
+
+  const canEditFilesystems = useDynamicStorage()
 
   const canToggle =
     (useExisting && canCreateStorage(storageType, storages, uiSettings)) ||
@@ -810,7 +811,7 @@ function StorageInstance({index}: any) {
         <Header
           variant="h3"
           actions={
-            <Button disabled={editing} onClick={removeStorage}>
+            <Button disabled={!canEditFilesystems} onClick={removeStorage}>
               Remove
             </Button>
           }
@@ -987,11 +988,11 @@ function StorageInstance({index}: any) {
 
 function Storage() {
   const storages = useState(storagePath)
-  const editing = useState(['app', 'wizard', 'editing'])
   const uiStorageSettings = useState(['app', 'wizard', 'storage', 'ui'])
   const storageType = useState(['app', 'wizard', 'storage', 'type'])
   const isFsxOnTapActive = useFeatureFlag('fsx_ontap')
   const isFsxOpenZsfActive = useFeatureFlag('fsx_openzsf')
+  const canEditFilesystems = useDynamicStorage()
 
   const storageMaxes: Record<string, number> = {
     FsxLustre: 21,
@@ -1082,7 +1083,7 @@ function Storage() {
           <div>No shared storage options selected.</div>
         )}
 
-        {!editing && storageTypes.length > 0 && (
+        {canEditFilesystems && storageTypes.length > 0 && (
           <div
             style={{
               display: 'flex',
@@ -1101,7 +1102,6 @@ function Storage() {
             >
               Storage Type:
               <Select
-                disabled={editing}
                 placeholder="Please Select a Filesystem Type"
                 selectedOption={
                   storageType &&
@@ -1172,4 +1172,16 @@ function canAttachExistingStorage(
   return existingAlreadyAttached < maxExistingToAttach
 }
 
-export {Storage, storageValidate, canCreateStorage, canAttachExistingStorage}
+function useDynamicStorage() {
+  const editingCluster = useState(['app', 'wizard', 'editing'])
+  const isDynamicFSMountActive = useFeatureFlag('dynamic_fs_mount')
+  return isDynamicFSMountActive || !editingCluster
+}
+
+export {
+  Storage,
+  storageValidate,
+  canCreateStorage,
+  canAttachExistingStorage,
+  useDynamicStorage,
+}

--- a/frontend/src/old-pages/Configure/__tests__/dynamicFS.test.tsx
+++ b/frontend/src/old-pages/Configure/__tests__/dynamicFS.test.tsx
@@ -1,0 +1,76 @@
+import {Store} from '@reduxjs/toolkit'
+import {renderHook} from '@testing-library/react-hooks'
+import {mock} from 'jest-mock-extended'
+import {Provider} from 'react-redux'
+import {useDynamicStorage} from '../Storage'
+
+const mockStore = mock<Store>()
+
+describe('Given a PCluster version', () => {
+  describe("when it's >= 3.3.0", () => {
+    it('should let edit or create new filesystems on an already built cluster', () => {
+      mockStore.getState.mockReturnValue({
+        app: {
+          version: {
+            full: '3.3.0',
+          },
+          wizard: {
+            editing: true,
+          },
+        },
+      })
+      const {result} = renderHook(() => useDynamicStorage(), {
+        wrapper: ({children}) => (
+          <Provider store={mockStore}>{children}</Provider>
+        ),
+      })
+
+      expect(result.current).toBe(true)
+    })
+  })
+  describe("when it's < 3.3.0", () => {
+    describe('when creating a cluster', () => {
+      it('should let the user add or remove filesystems', () => {
+        mockStore.getState.mockReturnValue({
+          app: {
+            version: {
+              full: '3.2.0',
+            },
+            wizard: {
+              editing: false,
+            },
+          },
+        })
+        const {result} = renderHook(() => useDynamicStorage(), {
+          wrapper: ({children}) => (
+            <Provider store={mockStore}>{children}</Provider>
+          ),
+        })
+
+        expect(result.current).toBe(true)
+      })
+    })
+
+    describe('when editing a cluster', () => {
+      it('should block the user from creating or removing filesystems', () => {
+        mockStore.getState.mockReturnValue({
+          app: {
+            version: {
+              full: '3.2.0',
+            },
+            wizard: {
+              editing: true,
+            },
+          },
+        })
+        const {result} = renderHook(() => useDynamicStorage(), {
+          wrapper: ({children}) => (
+            <Provider store={mockStore}>{children}</Provider>
+          ),
+        })
+
+        expect(result.current).toBe(false)
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Description

Add support for PCluster 3.3.0 [filesystems mount during updates](https://docs.aws.amazon.com/parallelcluster/latest/ug/document_history.html#aws-parallelcluster-3.3.0).

## How Has This Been Tested?

- created a cluster
- while editing the newly created cluster a new shared storage has been created
- dry run passes

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
