### PR TITLE
Adjust copywriting for clusters list page

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -50,12 +50,23 @@
         "help": "Copy the SSH command.",
         "tooltiptext": "Copy the command to SSH into the head node. If the key pair you use to create the head node isn't the default, you must specify the path to the key pair. See <0>Connect to your Linux instance using an SSH Client</0> for more information."
       },
+      "configurationLabel": "Cluster configuration",
+      "statusLabel": "Cluster status",
+      "computeFleetStatusLabel": "Compute fleet status",
+      "creationTimeLabel": "Created time",
+      "lastUpdatedTimeLabel": "Latest update time",
+      "regionLabel": "Region",
+      "versionLabel": "Version",
       "ec2InstanceConnect": {
         "label": "EC2 Instance Connect",
         "help": "Copy the command to connect to the head node using <0>EC2 Instance Connect</0>. You must <1>install mSSH helper</1> locally before running this command."
       }
     },
     "list": {
+      "header": {
+        "title": "Clusters",
+        "description": "The list of your clusters."
+      },
       "dialogs": {
         "delete": "Are you sure you want to delete cluster {{clusterName}}?"
       },
@@ -89,6 +100,7 @@
       "loadingText": "Loading clusters...",
       "countText": "Results:",
       "filteringAriaLabel": "Filter cluster",
+      "filteringPlaceholder": "Enter search text",
       "splitPanel": {
         "preferencesTitle": "Split panel preferences",
         "preferencesPositionLabel": "Split panel position",

--- a/frontend/src/old-pages/Clusters/Clusters.tsx
+++ b/frontend/src/old-pages/Clusters/Clusters.tsx
@@ -135,6 +135,7 @@ function ClusterList({clusters}: {clusters: ClusterInfoSummary[]}) {
       header={
         <Header
           variant="awsui-h1-sticky"
+          description={t('cluster.list.header.description')}
           counter={items && `(${items.length})`}
           actions={
             <SpaceBetween direction="horizontal" size="xs">
@@ -147,7 +148,7 @@ function ClusterList({clusters}: {clusters: ClusterInfoSummary[]}) {
             </SpaceBetween>
           }
         >
-          Clusters
+          {t('cluster.list.header.title')}
         </Header>
       }
       trackBy="clusterName"
@@ -180,6 +181,7 @@ function ClusterList({clusters}: {clusters: ClusterInfoSummary[]}) {
           {...filterProps}
           countText={`${t('cluster.list.countText')} ${filteredItemsCount}`}
           filteringAriaLabel={t('cluster.list.filteringAriaLabel')}
+          filteringPlaceholder={t('cluster.list.filteringPlaceholder')}
         />
       }
       selectedItems={(items || []).filter(

--- a/frontend/src/old-pages/Clusters/Properties.tsx
+++ b/frontend/src/old-pages/Clusters/Properties.tsx
@@ -142,7 +142,7 @@ export default function ClusterProperties() {
                 </div>
               </ValueWithLabel>
             )}
-            <ValueWithLabel label="clusterConfiguration">
+            <ValueWithLabel label={t('cluster.properties.configurationLabel')}>
               <Button
                 disabled={cluster.clusterStatus === ClusterStatus.CreateFailed}
                 iconName="external"
@@ -155,24 +155,32 @@ export default function ClusterProperties() {
             </ValueWithLabel>
           </SpaceBetween>
           <SpaceBetween size="l">
-            <ValueWithLabel label="clusterStatus">
+            <ValueWithLabel label={t('cluster.properties.statusLabel')}>
               <ClusterStatusIndicator cluster={cluster} />
             </ValueWithLabel>
-            <ValueWithLabel label="computeFleetStatus">
+            <ValueWithLabel
+              label={t('cluster.properties.computeFleetStatusLabel')}
+            >
               <ComputeFleetStatusIndicator
                 status={cluster.computeFleetStatus}
               />
             </ValueWithLabel>
-            <ValueWithLabel label="creationTime">
+            <ValueWithLabel label={t('cluster.properties.creationTimeLabel')}>
               <DateView date={cluster.creationTime} />
             </ValueWithLabel>
           </SpaceBetween>
           <SpaceBetween size="l">
-            <ValueWithLabel label="lastUpdatedTime">
+            <ValueWithLabel
+              label={t('cluster.properties.lastUpdatedTimeLabel')}
+            >
               <DateView date={cluster.lastUpdatedTime} />
             </ValueWithLabel>
-            <ValueWithLabel label="region">{cluster.region}</ValueWithLabel>
-            <ValueWithLabel label="version">{cluster.version}</ValueWithLabel>
+            <ValueWithLabel label={t('cluster.properties.regionLabel')}>
+              {cluster.region}
+            </ValueWithLabel>
+            <ValueWithLabel label={t('cluster.properties.versionLabel')}>
+              {cluster.version}
+            </ValueWithLabel>
             {headNode &&
               headNode.publicIpAddress &&
               headNode.publicIpAddress !== '' &&


### PR DESCRIPTION
## Description
This PR removes hardcoded strings and adjust copywriting for clusters list page following the suggestions of our copywriter.

## How Has This Been Tested?

* Manually tested locally

<img width="1717" alt="Screenshot 2023-01-24 at 18 00 26" src="https://user-images.githubusercontent.com/25930133/214358464-ca3aea5f-7123-416f-a541-191c50e2b98a.png">


## PR Quality Checklist

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
