### PR TITLE
Adjust copywriting for cluster details page

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -43,6 +43,15 @@
     "ariaLabel": "Info"
   },
   "cluster": {
+    "tabs": {
+      "details": "Details",
+      "instances": "Instances",
+      "storage": "Storage",
+      "scheduling": "Job scheduling",
+      "accounting": "Accounting",
+      "stackEvents": "Stack events",
+      "logs": "Logs"
+    },
     "properties": {
       "sshcommand": {
         "label": "SSH command",
@@ -61,6 +70,68 @@
         "label": "EC2 Instance Connect",
         "help": "Copy the command to connect to the head node using <0>EC2 Instance Connect</0>. You must <1>install mSSH helper</1> locally before running this command."
       }
+    },
+    "instances": {
+      "id": "ID",
+      "instance": "Instance",
+      "launchedTime": "Launched time",
+      "type": "Type",
+      "privateIp": "Private IP",
+      "publicIp": "Public IP",
+      "state": "State",
+      "actionsLabel": "Actions",
+      "actions": {
+        "stop": "Stop compute fleet",
+        "start": "Start compute fleet",
+        "logs": "Logs"
+      },
+      "computeFleetInfo": "Compute fleet must be stopped."
+    },
+    "storage": {
+      "id": "ID",
+      "mountPoint": "Mount point",
+      "name": "Name",
+      "type": "Type",
+      "noFilesystems": "No filesystems",
+      "noFilesystemsFound": "No filesystems found.",
+      "noFilesystemsToDisplay": "No filesystems to display.",
+      "filter": {
+        "loading": "Loading Filesystems...",
+        "filteringAriaLabel": "Filter filesystems",
+        "noMatches": "No matches",
+        "noFilesystems": "No filesystems match the filters.",
+        "clear": "Clear filter"
+      }
+    },
+    "accounting": {
+      "id": "ID",
+      "name": "Name",
+      "queue": "Queue",
+      "user": "User",
+      "state": "State",
+      "loadingJobs": "Loading jobs...",
+      "filterJobs": "Filter jobs",
+      "costEstimate": {
+        "title": "Cost estimate",
+        "help": "This cost estimate is based on the time taken for the job to run, the number of nodes, and an estimate of the node cost. The estimate could be inaccurate and is only meant to be an overall estimate."
+      }
+    },
+    "scheduling": {
+      "id": "ID",
+      "name": "Name",
+      "partition": "Partition",
+      "runTime": "Run time",
+      "nodes": "Nodes",
+      "actions": "Actions",
+      "queue": "Queue",
+      "state": "State",
+      "schedulingEnabled": "Scheduling is only available in clusters with version 3.1.x and greater.",
+      "ssmEnabled": "You must enable SSM to monitor jobs.",
+      "filterJobs": "Filter jobs",
+      "loadingJobs": "Loading jobs..."
+    },
+    "logs": {
+      "label": "Select a log stream from the left."
     },
     "list": {
       "header": {
@@ -114,12 +185,6 @@
         "resizeHandleAriaLabel": "Resize split panel",
         "noClusterSelectedText": "No cluster selected",
         "selectClusterText": "Select a cluster to see its details"
-      }
-    },
-    "accounting": {
-      "costEstimate": {
-        "title": "Cost estimate",
-        "help": "This cost estimate is based on the time taken for the job to run, the number of nodes, and an estimate of the node cost. The estimate could be inaccurate and is only meant to be an overall estimate."
       }
     }
   },

--- a/frontend/src/old-pages/Clusters/Accounting.tsx
+++ b/frontend/src/old-pages/Clusters/Accounting.tsx
@@ -366,6 +366,7 @@ function JobModal() {
 }
 
 export default function ClusterAccounting() {
+  const {t} = useTranslation()
   const clusterName = useState(['app', 'clusters', 'selected'])
   //const accounting = useState(['clusters', 'index', clusterName, 'accounting']);
   //const errors = useState(['clusters', 'index', clusterName, 'accounting', 'errors']) || [];
@@ -643,7 +644,7 @@ export default function ClusterAccounting() {
               columnDefinitions={[
                 {
                   id: 'id',
-                  header: 'ID',
+                  header: t('cluster.accounting.id'),
                   cell: job => (
                     <Link onFollow={() => selectJob(job.job_id)}>
                       {job.job_id}
@@ -653,25 +654,25 @@ export default function ClusterAccounting() {
                 },
                 {
                   id: 'name',
-                  header: 'name',
+                  header: t('cluster.accounting.name'),
                   cell: job => job.name,
                   sortingField: 'name',
                 },
                 {
                   id: 'queue',
-                  header: 'queue',
+                  header: t('cluster.accounting.queue'),
                   cell: job => job.partition,
                   sortingField: 'partition',
                 },
                 {
                   id: 'user',
-                  header: 'user',
+                  header: t('cluster.accounting.user'),
                   cell: job => job.user,
                   sortingField: 'user',
                 },
                 {
                   id: 'state',
-                  header: 'state',
+                  header: t('cluster.accounting.state'),
                   cell: job => (
                     <JobStatusIndicator
                       status={getIn(job, ['state', 'current'])}
@@ -681,13 +682,13 @@ export default function ClusterAccounting() {
                 },
               ]}
               items={items}
-              loadingText="Loading jobs..."
+              loadingText={t('cluster.accounting.loadingJobs')}
               pagination={<Pagination {...paginationProps} />}
               filter={
                 <TextFilter
                   {...filterProps}
                   countText={`Results: ${filteredItemsCount}`}
-                  filteringAriaLabel="Filter jobs"
+                  filteringAriaLabel={t('cluster.accounting.filterJobs')}
                 />
               }
             />

--- a/frontend/src/old-pages/Clusters/Details.tsx
+++ b/frontend/src/old-pages/Clusters/Details.tsx
@@ -26,8 +26,10 @@ import Scheduling from './Scheduling'
 import Properties from './Properties'
 import Logs from './Logs'
 import Loading from '../../components/Loading'
+import {useTranslation} from 'react-i18next'
 
 export default function ClusterTabs() {
+  const {t} = useTranslation()
   const clusterName = useState(['app', 'clusters', 'selected'])
   const clusterPath = ['clusters', 'index', clusterName]
   const cluster = useState(clusterPath)
@@ -57,15 +59,41 @@ export default function ClusterTabs() {
   return cluster ? (
     <Tabs
       tabs={[
-        {label: 'Details', id: 'details', content: <Properties />},
-        {label: 'Instances', id: 'instances', content: <Instances />},
-        {label: 'Storage', id: 'storage', content: <Filesystems />},
-        {label: 'Job Scheduling', id: 'scheduling', content: <Scheduling />},
+        {
+          label: t('cluster.tabs.details'),
+          id: 'details',
+          content: <Properties />,
+        },
+        {
+          label: t('cluster.tabs.instances'),
+          id: 'instances',
+          content: <Instances />,
+        },
+        {
+          label: t('cluster.tabs.storage'),
+          id: 'storage',
+          content: <Filesystems />,
+        },
+        {
+          label: t('cluster.tabs.scheduling'),
+          id: 'scheduling',
+          content: <Scheduling />,
+        },
         ...(accountingEnabled
-          ? [{label: 'Accounting', id: 'accounting', content: <Accounting />}]
+          ? [
+              {
+                label: t('cluster.tabs.accounting'),
+                id: 'accounting',
+                content: <Accounting />,
+              },
+            ]
           : []),
-        {label: 'Stack Events', id: 'stack-events', content: <StackEvents />},
-        {label: 'Logs', id: 'logs', content: <Logs />},
+        {
+          label: t('cluster.tabs.stackEvents'),
+          id: 'stack-events',
+          content: <StackEvents />,
+        },
+        {label: t('cluster.tabs.logs'), id: 'logs', content: <Logs />},
       ]}
       onChange={({detail}) => {
         navigate(`/clusters/${selectedClusterName}/${detail.activeTabId}`)

--- a/frontend/src/old-pages/Clusters/Filesystems.tsx
+++ b/frontend/src/old-pages/Clusters/Filesystems.tsx
@@ -29,8 +29,10 @@ import {useFeatureFlag} from '../../feature-flags/useFeatureFlag'
 import {EC2Instance} from '../../types/instances'
 import {Region} from '../../types/base'
 import {Storages} from '../Configure/Storage.types'
+import {useTranslation} from 'react-i18next'
 
 function StorageId({storage}: any) {
+  const {t} = useTranslation()
   const settingsKey = `${storage.StorageType}Settings`
   const canMountFileSystem = ['Efs', 'FsxLustre'].includes(storage.StorageType)
   const idKey = canMountFileSystem ? 'FileSystemId' : 'VolumeId'
@@ -55,7 +57,7 @@ function StorageId({storage}: any) {
       {fsxStorageTypes.includes(storage.StorageType) && (
         <Link
           external
-          externalIconAriaLabel="Opens a new tab"
+          externalIconAriaLabel={t('global.openNewTab')}
           href={`${consoleDomain(
             region,
           )}/fsx/home?region=${region}${detailsFragment}/${id}`}
@@ -66,7 +68,7 @@ function StorageId({storage}: any) {
       {storage.StorageType === 'Efs' && (
         <Link
           external
-          externalIconAriaLabel="Opens a new tab"
+          externalIconAriaLabel={t('global.openNewTab')}
           href={`${consoleDomain(
             region,
           )}/efs/home?region=${region}#/file-systems/${id}`}
@@ -77,7 +79,7 @@ function StorageId({storage}: any) {
       {storage.StorageType === 'Ebs' && (
         <Link
           external
-          externalIconAriaLabel="Opens a new tab"
+          externalIconAriaLabel={t('global.openNewTab')}
           href={`${consoleDomain(
             region,
           )}/ec2/v2/home?region=${region}#VolumeDetails:volumeId=${id}`}
@@ -104,6 +106,7 @@ export function buildFilesystemLink(
 }
 
 export default function Filesystems() {
+  const {t} = useTranslation()
   const clusterName = useState(['app', 'clusters', 'selected'])
   const clusterPath = ['clusters', 'index', clusterName]
   const storage: Storages =
@@ -126,17 +129,17 @@ export default function Filesystems() {
     filtering: {
       empty: (
         <EmptyState
-          title="No filesystems"
-          subtitle="No filesystems to display."
+          title={t('cluster.storage.noFilesystems')}
+          subtitle={t('cluster.storage.noFilesystemsToDisplay')}
         />
       ),
       noMatch: (
         <EmptyState
-          title="No matches"
-          subtitle="No filesystems match the filters."
+          title={t('cluster.storage.filter.noMatches')}
+          subtitle={t('cluster.storage.filter.noFilesystems')}
           action={
             <Button onClick={() => actions.setFiltering('')}>
-              Clear filter
+              {t('cluster.storage.filter.clear')}
             </Button>
           }
         />
@@ -157,7 +160,7 @@ export default function Filesystems() {
             columnDefinitions={[
               {
                 id: 'mount',
-                header: 'Mount Point',
+                header: t('cluster.storage.mountPoint'),
                 cell: item => {
                   const href = buildFilesystemLink(region, headNode, item)
                   const text = (item as any).MountDir
@@ -172,37 +175,39 @@ export default function Filesystems() {
               },
               {
                 id: 'name',
-                header: 'Name',
+                header: t('cluster.storage.name'),
                 cell: item => (item as any).Name,
                 sortingField: 'Name',
               },
               {
                 id: 'type',
-                header: 'Type',
+                header: t('cluster.storage.type'),
                 cell: item => (item as any).StorageType,
                 sortingField: 'StorageType',
               },
               {
                 id: 'id',
-                header: 'id',
+                header: t('cluster.storage.id'),
                 // @ts-expect-error TS(2786) FIXME: 'StorageId' cannot be used as a JSX component.
                 cell: item => <StorageId storage={item} />,
               },
             ]}
             items={items}
-            loadingText="Loading Filesystems..."
+            loadingText={t('cluster.storage.filter.loading')}
             pagination={<Pagination {...paginationProps} />}
             filter={
               <TextFilter
                 {...filterProps}
                 countText={`Results: ${filteredItemsCount}`}
-                filteringAriaLabel="Filter filesystems"
+                filteringAriaLabel={t(
+                  'cluster.storage.filter.filteringAriaLabel',
+                )}
               />
             }
           />
         </div>
       )}
-      {!storage && <div>No Filesystems Found.</div>}
+      {!storage && <div>{t('cluster.storage.noFilesystemsFound')}</div>}
     </>
   )
 }

--- a/frontend/src/old-pages/Clusters/Instances.tsx
+++ b/frontend/src/old-pages/Clusters/Instances.tsx
@@ -53,6 +53,7 @@ function InstanceActions({
   const clusterName = useState(['app', 'clusters', 'selected'])
   const navigate = useNavigate()
   const logHref = `/clusters/${clusterName}/logs?instance=${instance.instanceId}`
+  const {t} = useTranslation()
 
   const refresh = () => {
     const clusterName = getState(['app', 'clusters', 'selected'])
@@ -84,7 +85,7 @@ function InstanceActions({
                   stopInstance(instance)
                 }}
               >
-                Stop
+                {t('cluster.instances.actions.stop')}
               </Button>
             )}
           {instance.nodeType === NodeType.HeadNode &&
@@ -95,16 +96,18 @@ function InstanceActions({
                   startInstance(instance)
                 }}
               >
-                Start
+                {t('cluster.instances.actions.start')}
               </Button>
             )}
         </div>
       )}
       {fleetStatus !== ComputeFleetStatus.Stopped && (
-        <div title="Compute Fleet must be stopped.">
+        <div title={t('cluster.instances.computeFleetInfo')}>
           {instance.nodeType === NodeType.HeadNode &&
             instance.state === InstanceState.Running && (
-              <Button disabled={true}>Stop</Button>
+              <Button disabled={true}>
+                {t('cluster.instances.actions.stop')}
+              </Button>
             )}
         </div>
       )}
@@ -115,7 +118,7 @@ function InstanceActions({
           e.preventDefault()
         }}
       >
-        Logs
+        {t('cluster.instances.actions.logs')}
       </Button>
     </SpaceBetween>
   )
@@ -124,6 +127,7 @@ function InstanceActions({
 export default function ClusterInstances() {
   let defaultRegion = useState(['aws', 'region']) || ''
   const region: Region = useState(['app', 'selectedRegion']) || defaultRegion
+  const {t} = useTranslation()
 
   const clusterName: ClusterName = useState(['app', 'clusters', 'selected'])
   const instances: Instance[] = useState([
@@ -201,11 +205,11 @@ export default function ClusterInstances() {
       columnDefinitions={[
         {
           id: 'id',
-          header: 'Id',
+          header: t('cluster.instances.id'),
           cell: instance => (
             <Link
               external
-              externalIconAriaLabel="Opens in a new tab"
+              externalIconAriaLabel={t('global.openNewTab')}
               href={`${consoleDomain(
                 region,
               )}/ec2/v2/home?region=${region}#InstanceDetails:instanceId=${
@@ -219,43 +223,43 @@ export default function ClusterInstances() {
         },
         {
           id: 'instance-type',
-          header: 'instance',
+          header: t('cluster.instances.instance'),
           cell: instance => instance.instanceType,
           sortingField: 'instanceType',
         },
         {
           id: 'launch-time',
-          header: 'Launch',
+          header: t('cluster.instances.launchedTime'),
           cell: instance => <DateView date={instance.launchTime} />,
           sortingField: 'launchTime',
         },
         {
           id: 'node-type',
-          header: 'Type',
+          header: t('cluster.instances.type'),
           cell: instance => instance.nodeType,
           sortingField: 'nodeType',
         },
         {
           id: 'private-ip',
-          header: 'Private IP',
+          header: t('cluster.instances.privateIp'),
           cell: instance => instance.privateIpAddress,
           sortingField: 'privateIpAddress',
         },
         {
           id: 'public-ip',
-          header: 'Public IP',
+          header: t('cluster.instances.publicIp'),
           cell: instance => instance.publicIpAddress,
           sortingField: 'publicIpAddress',
         },
         {
           id: 'state',
-          header: 'State',
+          header: t('cluster.instances.state'),
           cell: instance => <InstanceStatusIndicator instance={instance} />,
           sortingField: 'state',
         },
         {
           id: 'actions',
-          header: 'Actions',
+          header: t('cluster.instances.actionsLabel'),
           cell: instance => (
             <InstanceActions fleetStatus={fleetStatus} instance={instance} />
           ),

--- a/frontend/src/old-pages/Clusters/Logs.tsx
+++ b/frontend/src/old-pages/Clusters/Logs.tsx
@@ -30,6 +30,7 @@ import {
 
 // Components
 import EmptyState from '../../components/EmptyState'
+import {useTranslation} from 'react-i18next'
 
 function LogEventsTable() {
   const selected = getState(['app', 'clusters', 'selected'])
@@ -302,6 +303,7 @@ function LogStreamList() {
 }
 
 export default function ClusterLogs() {
+  const {t} = useTranslation()
   const selected = getState(['app', 'clusters', 'selected'])
   const logStreamIndexPath = ['app', 'clusters', 'logs', 'index']
   const streams = useState(['clusters', 'index', selected, 'logstreams'])
@@ -339,8 +341,7 @@ export default function ClusterLogs() {
           <div style={{width: 'calc(100% - 165px)', overflowX: 'auto'}}>
             {selectedLogStreamName &&
               (logEvents ? <LogEventsTable /> : <Loading />)}
-            {!selectedLogStreamName &&
-              'Please select a log stream from the left.'}
+            {!selectedLogStreamName && t('cluster.logs.label')}
           </div>
         </div>
       ) : (

--- a/frontend/src/old-pages/Clusters/Scheduling.tsx
+++ b/frontend/src/old-pages/Clusters/Scheduling.tsx
@@ -41,6 +41,7 @@ import {
 import {JobStatusIndicator} from '../../components/Status'
 import EmptyState from '../../components/EmptyState'
 import Loading from '../../components/Loading'
+import {useTranslation} from 'react-i18next'
 
 // Key:Value pair (label / children)
 const ValueWithLabel = ({
@@ -250,6 +251,7 @@ function JobModal() {
 }
 
 export default function ClusterScheduling() {
+  const {t} = useTranslation()
   const clusterName = useState(['app', 'clusters', 'selected'])
   const clusterPath = ['clusters', 'index', clusterName]
   const cluster = useState(clusterPath)
@@ -346,7 +348,7 @@ export default function ClusterScheduling() {
             columnDefinitions={[
               {
                 id: 'id',
-                header: 'ID',
+                header: t('cluster.scheduling.id'),
                 cell: job => (
                   <Link onFollow={() => selectJob(job.job_id)}>
                     {job.job_id}
@@ -356,50 +358,50 @@ export default function ClusterScheduling() {
               },
               {
                 id: 'name',
-                header: 'name',
+                header: t('cluster.scheduling.name'),
                 cell: job => job.name,
                 sortingField: 'name',
               },
               {
                 id: 'partition',
-                header: 'partition',
+                header: t('cluster.scheduling.partition'),
                 cell: job => job.partition,
                 sortingField: 'partition',
               },
               {
                 id: 'nodes',
-                header: 'nodes',
+                header: t('cluster.scheduling.nodes'),
                 cell: job => job.nodes,
                 sortingField: 'nodes',
               },
               {
                 id: 'state',
-                header: 'state',
+                header: t('cluster.scheduling.state'),
                 cell: job => <JobStatusIndicator status={job.job_state} />,
                 sortingField: 'job_state',
               },
               {
                 id: 'time',
-                header: 'time',
+                header: t('cluster.scheduling.runTime'),
                 cell: job => job.time,
                 sortingField: 'time',
               },
               {
                 id: 'actions',
-                header: 'Actions',
+                header: t('cluster.scheduling.actions'),
                 cell: job => (
                   <JobActions disabled={fleetStatus !== 'RUNNING'} job={job} />
                 ),
               },
             ]}
             items={items}
-            loadingText="Loading jobs..."
+            loadingText={t('cluster.scheduling.loadingJobs')}
             pagination={<Pagination {...paginationProps} />}
             filter={
               <TextFilter
                 {...filterProps}
                 countText={`Results: ${filteredItemsCount}`}
-                filteringAriaLabel="Filter jobs"
+                filteringAriaLabel={t('cluster.scheduling.filterJobs')}
               />
             }
           />
@@ -409,12 +411,9 @@ export default function ClusterScheduling() {
           </div>
         ))}
       {clusterMinor === 0 && (
-        <div>
-          Scheduling is only available in clusters with version 3.1.x and
-          greater.
-        </div>
+        <div>{t('cluster.scheduling.schedulingEnabled')}</div>
       )}
-      {!ssmEnabled && <div>You must enable SSM to monitor jobs.</div>}
+      {!ssmEnabled && <div>{t('cluster.scheduling.ssmEnabled')}</div>}
     </SpaceBetween>
   )
 }


### PR DESCRIPTION
## Description

This PR removes hardcoded strings and adjust copywriting for cluster details page following the suggestions of our copywriter.

## How Has This Been Tested?

* Manually tested locally

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
