### PR TITLE
Adjust copywriting for wizard head node page

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -331,6 +331,7 @@
       },
       "Dcv": {
         "label": "Virtual desktop",
+        "add": "Add DCV",
         "description": "Add the DCV virtual desktop option on the head node. Increase your instance size if you add this option.",
         "help": "Use the DCV virtual desktop to access the head node and visualize results."
       },
@@ -357,7 +358,30 @@
       },
       "securityGroups": {
        "label": "Additional security groups",
-       "help": "Select a security group."
+       "help": "Select a security group.",
+       "select": "Select a security group"
+      },
+      "advancedOptions": {
+        "label": "Advanced options",
+        "scripts": {
+          "onStart": {
+            "label": "Run script on node start",
+            "description": "The script runs on head node start, before node configuration."
+          },
+          "onConfigured": {
+            "label": "Run script on node configured",
+            "description": "The script runs after node configuration."
+          },
+          "onUpdated": {
+            "label": "Run script on node updated",
+            "description": "The script runs after an update, after node configuration."
+          }
+        },
+        "iamPolicies": {
+          "label": "IAM Policies",
+          "description": "Add IAM policies, in addition to the set of policies that AWS ParallelCluster provides automatically.",
+          "policyAlreadyAdded": "Policy already added."
+        }
       },
       "slurmSettings": {
         "validation": {
@@ -368,24 +392,30 @@
         },
         "container": {
           "title": "Slurm settings",
+          "description": "Connect with an external Slurm database to monitor and analyze cluster usage.",
           "optional": "optional"
         },
         "database": {
           "label": "Database",
+          "description": "Enter the path to the Slurm database.",
           "placeholder": "DNSName/ip:port"
         },
         "username": {
-          "label": "Username"
+          "label": "Username",
+          "description": "Enter the user ID for access to the database."
         },
         "password": {
-          "label": "Password secret ARN"
+          "label": "Password secret ARN",
+          "description": "The ARN of the AWS secret containing the database password."
         },
         "scaledownIdleTime": {
-          "label": "Scale down idle time (minutes)",
+          "label": "Scale down idle time (in minutes)",
+          "description": "The amount of time (in minutes) that a queue has no jobs before the Slurm node terminates.",
           "placeholder": "10"
         },
         "queueUpdateStrategy": {
           "label": "Queue update strategy",
+          "description": "Specifies the node replacement strategy for a queue.",
           "placeholder": "Select a queue update strategy",
           "selectedAriaLabel": "Selected",
           "options": {

--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -38,6 +38,7 @@ import {
   TokenGroup,
   Select,
   InputProps,
+  TextContent,
 } from '@cloudscape-design/components'
 
 // Components
@@ -342,7 +343,7 @@ function ArgEditor({path, i}: any) {
   )
 }
 
-function ActionEditor({label, actionKey, errorPath, path}: any) {
+function ActionEditor({label, description, actionKey, errorPath, path}: any) {
   const script = useState([...path, 'Script']) || ''
   const args = useState([...path, 'Args']) || []
 
@@ -357,7 +358,7 @@ function ActionEditor({label, actionKey, errorPath, path}: any) {
   }
 
   return (
-    <FormField label={label} errorText={errorPath}>
+    <FormField label={label} errorText={errorPath} description={description}>
       <SpaceBetween direction="vertical" size="xs">
         <div
           key={actionKey}
@@ -416,6 +417,8 @@ function ActionsEditor({basePath, errorsPath}: ActionsEditorProps) {
 }
 
 function HeadNodeActionsEditor({basePath, errorsPath}: ActionsEditorProps) {
+  const {t} = useTranslation()
+
   const actionsPath = [...basePath, 'CustomActions']
   const onStartPath = [...actionsPath, 'OnNodeStart']
   const onConfiguredPath = [...actionsPath, 'OnNodeConfigured']
@@ -428,17 +431,26 @@ function HeadNodeActionsEditor({basePath, errorsPath}: ActionsEditorProps) {
   return (
     <SpaceBetween direction="vertical" size="xs">
       <ActionEditor
-        label="On Start"
+        label={t('wizard.headNode.advancedOptions.scripts.onStart.label')}
+        description={t(
+          'wizard.headNode.advancedOptions.scripts.onStart.description',
+        )}
         errorPath={onStartErrors}
         path={onStartPath}
       />
       <ActionEditor
-        label="On Configured"
+        label={t('wizard.headNode.advancedOptions.scripts.onConfigured.label')}
+        description={t(
+          'wizard.headNode.advancedOptions.scripts.onConfigured.description',
+        )}
         errorPath={onConfiguredErrors}
         path={onConfiguredPath}
       />
       <ActionEditor
-        label="On Updated"
+        label={t('wizard.headNode.advancedOptions.scripts.onUpdated.label')}
+        description={t(
+          'wizard.headNode.advancedOptions.scripts.onConfigured.description',
+        )}
         errorPath={onUpdatedErrors}
         path={onUpdatedPath}
       />
@@ -447,6 +459,7 @@ function HeadNodeActionsEditor({basePath, errorsPath}: ActionsEditorProps) {
 }
 
 function SecurityGroups({basePath}: any) {
+  const {t} = useTranslation()
   const sgPath = [...basePath, 'Networking', 'AdditionalSecurityGroups']
   const selectedSgs = useState(sgPath) || []
   const sgSelected = useState(['app', 'wizard', 'sg-selected'])
@@ -485,7 +498,7 @@ function SecurityGroups({basePath}: any) {
               ? itemToOption(
                   findFirst(sgs, (x: any) => x.GroupId === sgSelected.value),
                 )
-              : {label: 'Please Select A Security Group'}
+              : {label: t('wizard.headNode.securityGroups.select')}
           }
           onChange={({detail}) => {
             setState(['app', 'wizard', 'sg-selected'], detail.selectedOption)
@@ -603,6 +616,7 @@ function RootVolume({basePath, errorsPath}: any) {
 }
 
 function IamPoliciesEditor({basePath}: any) {
+  const {t} = useTranslation()
   const policiesPath = [...basePath, 'Iam', 'AdditionalIamPolicies']
   const policies = useState(policiesPath) || []
   const policyPath = ['app', 'wizard', 'headNode', 'iamPolicy']
@@ -626,10 +640,15 @@ function IamPoliciesEditor({basePath}: any) {
 
   return (
     <SpaceBetween direction="vertical" size="s">
+      <TextContent>
+        {t('wizard.headNode.advancedOptions.iamPolicies.description')}
+      </TextContent>
       <FormField
         errorText={
           findFirst(policies, (x: any) => x.Policy === policy)
-            ? 'Policy already added.'
+            ? t(
+                'wizard.headNode.advancedOptions.iamPolicies.policyAlreadyAdded',
+              )
             : ''
         }
       >

--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -355,7 +355,7 @@ function DcvSettings() {
       >
         <SpaceBetween direction="vertical" size="xxxs">
           <Toggle disabled={editing} checked={dcvEnabled} onChange={toggleDcv}>
-            DCV Enabled
+            {t('wizard.headNode.Dcv.add')}
           </Toggle>
           <SpaceBetween direction="vertical" size="xs">
             {dcvEnabled && (
@@ -481,7 +481,9 @@ function HeadNode() {
           >
             <SecurityGroups basePath={headNodePath} />
           </FormField>
-          <ExpandableSection header="Advanced options">
+          <ExpandableSection
+            header={t('wizard.headNode.advancedOptions.label')}
+          >
             {isOnNodeUpdatedActive ? (
               <HeadNodeActionsEditor
                 basePath={headNodePath}
@@ -490,7 +492,9 @@ function HeadNode() {
             ) : (
               <ActionsEditor basePath={headNodePath} errorsPath={errorsPath} />
             )}
-            <ExpandableSection header="IAM Policies">
+            <ExpandableSection
+              header={t('wizard.headNode.advancedOptions.iamPolicies.label')}
+            >
               <IamPoliciesEditor basePath={headNodePath} />
             </ExpandableSection>
           </ExpandableSection>

--- a/frontend/src/old-pages/Configure/SlurmSettings/QueueUpdateStrategyForm.tsx
+++ b/frontend/src/old-pages/Configure/SlurmSettings/QueueUpdateStrategyForm.tsx
@@ -67,6 +67,9 @@ export const QueueUpdateStrategyForm: React.FC<Props> = ({value, onChange}) => {
   return (
     <FormField
       label={t('wizard.headNode.slurmSettings.queueUpdateStrategy.label')}
+      description={t(
+        'wizard.headNode.slurmSettings.queueUpdateStrategy.description',
+      )}
     >
       <Select
         selectedOption={selectedOption}

--- a/frontend/src/old-pages/Configure/SlurmSettings/ScaledownIdleTimeForm.tsx
+++ b/frontend/src/old-pages/Configure/SlurmSettings/ScaledownIdleTimeForm.tsx
@@ -65,6 +65,9 @@ export const ScaledownIdleTimeForm: React.FC<Props> = ({value, onChange}) => {
   return (
     <FormField
       label={t('wizard.headNode.slurmSettings.scaledownIdleTime.label')}
+      description={t(
+        'wizard.headNode.slurmSettings.scaledownIdleTime.description',
+      )}
       errorText={errorText}
     >
       <Input

--- a/frontend/src/old-pages/Configure/SlurmSettings/SlurmAccountingForm.tsx
+++ b/frontend/src/old-pages/Configure/SlurmSettings/SlurmAccountingForm.tsx
@@ -27,6 +27,7 @@ function DatabaseField({uriPath, uriErrorPath}: DatabaseFieldProps) {
   return (
     <FormField
       label={t('wizard.headNode.slurmSettings.database.label')}
+      description={t('wizard.headNode.slurmSettings.database.description')}
       errorText={uriError}
     >
       <Input
@@ -53,6 +54,7 @@ function UsernameField({usernamePath, usernameErrorPath}: UsernameFieldProps) {
   return (
     <FormField
       label={t('wizard.headNode.slurmSettings.username.label')}
+      description={t('wizard.headNode.slurmSettings.username.description')}
       errorText={usernameError}
     >
       <Input
@@ -79,6 +81,7 @@ function PasswordField({passwordPath, passwordErrorPath}: PasswordFieldProps) {
   return (
     <FormField
       label={t('wizard.headNode.slurmSettings.password.label')}
+      description={t('wizard.headNode.slurmSettings.password.description')}
       errorText={passwordError}
     >
       <Input

--- a/frontend/src/old-pages/Configure/SlurmSettings/SlurmSettings.tsx
+++ b/frontend/src/old-pages/Configure/SlurmSettings/SlurmSettings.tsx
@@ -116,12 +116,15 @@ function SlurmSettings() {
   return (
     <Container
       header={
-        <Header variant="h2">
+        <Header
+          variant="h2"
+          description={t('wizard.headNode.slurmSettings.container.description')}
+        >
           {t('wizard.headNode.slurmSettings.container.title')}{' '}
           <span
             style={{fontWeight: '400', fontStyle: 'italic', fontSize: '14px'}}
           >
-            - {t('wizard.headNode.slurmSettings.container.optional')}
+            ({t('wizard.headNode.slurmSettings.container.optional')})
           </span>
         </Header>
       }


### PR DESCRIPTION
## Description

This PR removes hardcoded strings and adjust copywriting for wizard head node page following the suggestions of our copywriter.

## How Has This Been Tested?

* Manually tested locally

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
