### PR TITLE
Changed versioning strategy for PC UI + ADR

### DIFF
--- a/.github/workflows/production_release.yml
+++ b/.github/workflows/production_release.yml
@@ -74,7 +74,7 @@ jobs:
           role-to-assume: arn:aws:iam::046399108653:role/pcluster-manager-github-prod-ProductionDeploy-1I1HYDA5DH7T3
 
       - name: Build and upload Docker image
-        run: ./scripts/build_and_release_image.sh --release
+        run: ./scripts/build_and_release_image.sh
       
       - name: Upload infrastructure files to S3
         run: ./infrastructure/release_infrastructure.sh

--- a/decisions/20230125-pcui-versioning-strategy.md
+++ b/decisions/20230125-pcui-versioning-strategy.md
@@ -5,7 +5,10 @@
 - Tags: versioning, pcui
 
 ## Context
-We want to avoid confusing for customers using PC UI and Parallel Cluster.
+We want to avoid confusion for customers using PC UI and Parallel Cluster.
+So we need to keep PC UI and PC versioning schemas separated.
+While PC keeps their semver-like schema, PC UI switches do a year.month[.revision] schema.
+
 
 ## Decision
 Using the format YYYY.MM[.REVISION] for PC UI versions, where 

--- a/decisions/20230125-pcui-versioning-strategy.md
+++ b/decisions/20230125-pcui-versioning-strategy.md
@@ -1,0 +1,16 @@
+# PCUI Versioning strategy
+
+- Status: accepted
+- Deciders: Nuraghe Team
+- Tags: versioning, pcui
+
+## Context
+We want to avoid confusing for customers using PC UI and Parallel Cluster.
+
+## Decision
+Using the format YYYY.MM[.REVISION] for PC UI versions, where 
+
+- YYYY is the full year in which PC UI gets released
+- MM is the two digit number for the month in which PC UI gets released
+- REVISION is an optional value to allow separation of patches between the same major version
+

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -6,7 +6,7 @@ Parameters:
   PublicEcrImageUri:
     Description: When specified, the URI of the Docker image for the Lambda of the ParallelCluster UI container
     Type: String
-    Default: public.ecr.aws/pcm/parallelcluster-ui:3.3.0
+    Default: public.ecr.aws/pcm/parallelcluster-ui:2023.02
   UserPoolId:
     Description: UserPoolId of a previously deployed PCUI Cognito User Pool. Leave blank to create a new one.
     Type: String
@@ -99,8 +99,8 @@ Conditions:
 Mappings:
   ParallelClusterUI:
     Constants:
-      Version: 3.3.0
-      ShortVersion: 3.3.0
+      Version: 2023.02
+      ShortVersion: 2023.02
 
 Resources:
 

--- a/scripts/build_and_release_image.sh
+++ b/scripts/build_and_release_image.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-USAGE="$(basename "$0") [-h] [--tag YYYY.MM (defaults to current year and month] [--revision REVISION]"
+USAGE="$(basename "$0") [-h] [--tag YYYY.MM (defaults to current year and month)] [--revision REVISION]"
 
 get_default_pcui_version() {
   date +%Y.%m
@@ -45,8 +45,8 @@ ECR_ENDPOINT="public.ecr.aws/pcm"
 if [ -z $TAG ]; then
   TAG=`get_default_pcui_version`
   echo "Using default versioning strategy, tag: $TAG" 1>&2
-elif ! [[ $TAG =~ [0-9]{4}\\.[0-9]{2} ]]; then
-  echo '`--tag` parameter must be of the following format `YYYY.MM`, exiting' 1>&2
+elif ! [[ $TAG =~ [0-9]{4}\.(0[1-9]|1[0-2]) ]]; then
+  echo '`--tag` parameter must be a valid year and month combo of the following format `YYYY.MM`, exiting' 1>&2
   exit 1
 fi
 


### PR DESCRIPTION
## Description
This PR adopts the new PC UI versioning strategy and removes useless code + adds an ADR about it.

## How Has This Been Tested?
- first I tested the validation on inputs and outcomes of possible valid/not valid inputs without producing images
- then I only changed the ecr public registry to my personal account public registry, and ran the script as is, verifying it works

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
