### PR TITLE
Fixed ecr image recipe version after newly introduced versioning strategy for PC UI

### DIFF
--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -101,6 +101,7 @@ Mappings:
     Constants:
       Version: 2023.02
       ShortVersion: 2023.02
+      EcrRecipeVersion: 2023.02.00
 
 Resources:
 
@@ -457,7 +458,7 @@ Resources:
       Name: !Sub
         - 'parallelcluster-ui-${Version}-${StackIdSuffix}'
         - { Version: !Join ['_', !Split ['.', !FindInMap [ParallelClusterUI, Constants, Version]]], StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
-      Version: !FindInMap [ParallelClusterUI, Constants, ShortVersion]
+      Version: !FindInMap [ParallelClusterUI, Constants, EcrRecipeVersion]
       ParentImage: !Ref PublicEcrImageUri
       PlatformOverride: Linux
       TargetRepository:


### PR DESCRIPTION
## Description
Fixed ecr image recipe version after newly introduced versioning strategy for PC UI
<!-- Summary of what this PR introduces and possibly why -->

## Changes
- introduced a new entry in ParallelClusterUI mapping in main CF template, to handle the ecr image recipe version that needs to be a sem ver like value.

## References
- #513 
In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
