### PR TITLE
Adjust copywriting for wizard queues page

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -381,9 +381,7 @@
           }
         },
         "iamPolicies": {
-          "label": "IAM Policies",
-          "description": "Add IAM policies, in addition to the set of policies that AWS ParallelCluster provides automatically.",
-          "policyAlreadyAdded": "Policy already added."
+          "label": "IAM Policies"
         }
       },
       "slurmSettings": {
@@ -514,7 +512,7 @@
     },
     "queues": {
       "title": "Queues",
-      "description": "Specify queues and compute resources for the cluster",
+      "description": "Configure the cluster queues.",
       "validation": {
         "instanceTypeUnique": "Instance types must be unique within a queue.",
         "instanceTypeMissing": "Select at least one instance type.",
@@ -526,7 +524,8 @@
         "customAmiSelect": "You must select an AMI ID if you use a custom AMI."
       },
       "container": {
-        "title": "Queues"
+        "title": "Queues",
+        "description": "Configure up to 5 queues (Slurm partitions)."
       },
       "slurmMemorySettings": {
         "container": {
@@ -553,13 +552,28 @@
         "help": "The default value is 95 percent of the memory advertised by EC2."
       },
       "computeResource": {
+        "header": {
+          "title": "Compute resources",
+          "description": "Configure up to 3 compute resources."
+        },
+        "addComputeResource": "Add compute resource",
         "staticNodes": "Static nodes",
         "dynamicNodes": "Dynamic nodes",
         "instanceType": "Instance type",
-        "disableHT": "Turn off multithreading",
+        "disableHT": {
+          "label": "Turn off multithreading",
+          "description": "Prevent multiple threads from running on an EC2 instance core."
+        },
         "enableEfa": "Use EFA"
       },
+      "advancedOptions": {
+        "iamPolicies": {
+          "label": "IAM Policies"        }
+      },
       "addQueueButton": {
+        "label": "Add queue"
+      },
+      "removeQueueButton": {
         "label": "Add queue"
       },
       "placementGroup": {
@@ -576,9 +590,6 @@
       },
       "securityGroups": {
         "label": "Additional security groups"
-      },
-      "IamPolicies": {
-        "label": "IAM policies"
       }
     },
     "create": {
@@ -594,10 +605,10 @@
     },
     "components": {
       "customAmi": {
-        "ariaLabel": "Custom AMI",
-        "label": "Custom AMI",
+        "ariaLabel": "Custom Amazon Machine Image (AMI)",
+        "label": "Custom Amazon Machine Image (AMI)",
         "helpPanel": {
-          "title": "Custom AMI",
+          "title": "Custom Amazon Machine Image (AMI)",
           "description": "Custom AMI's provide you a way to customize the cluster. See the <0>Image section</0> of the documentation for more information.",
           "link": "https://docs.aws.amazon.com/parallelcluster/latest/ug/pcluster.build-image-v3.html"
         },
@@ -606,12 +617,28 @@
       "rootVolume": {
         "size": {
           "label": "Root volume size (GB)",
-          "description": "Typically users use a shared storage option for application data so a smaller root volume size is suitable. Leave this blank to use the default from the AMI.",
+          "description": "The compute node local storage.",
           "placeholder": "Enter root volume size."
         },
+        "encrypted": "Encrypt root volume",
         "type": {
           "label": "Volume type",
           "placeholder": "Default ({{defaultRootVolumeType}})"
+        }
+      },
+      "IamPoliciesEditor": {
+        "title": "Add IAM policies, in addition to the set of policies that AWS ParallelCluster provides automatically.",
+        "policyAlreadyAdded": "Policy already added.",
+        "addButtonLabel": "Add"
+      },
+      "actionsEditor": {
+        "onStart": {
+          "label": "Run script on node start",
+          "description": "The script runs on head node start, before node configuration."
+        },
+        "onConfigured": {
+          "label": "Run script on node configured",
+          "description": "The script runs after node configuration."
         }
       }
     }

--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -393,6 +393,8 @@ function ActionEditor({label, description, actionKey, errorPath, path}: any) {
 }
 
 function ActionsEditor({basePath, errorsPath}: ActionsEditorProps) {
+  const {t} = useTranslation()
+
   const actionsPath = [...basePath, 'CustomActions']
   const onStartPath = [...actionsPath, 'OnNodeStart']
   const onConfiguredPath = [...actionsPath, 'OnNodeConfigured']
@@ -403,12 +405,16 @@ function ActionsEditor({basePath, errorsPath}: ActionsEditorProps) {
   return (
     <SpaceBetween direction="vertical" size="xs">
       <ActionEditor
-        label="On Start"
+        label={t('wizard.components.actionsEditor.onStart.label')}
+        description={t('wizard.components.actionsEditor.onStart.description')}
         errorPath={onStartErrors}
         path={onStartPath}
       />
       <ActionEditor
-        label="On Configured"
+        label={t('wizard.components.actionsEditor.onConfigured.label')}
+        description={t(
+          'wizard.components.actionsEditor.onConfigured.description',
+        )}
         errorPath={onConfiguredErrors}
         path={onConfiguredPath}
       />
@@ -587,7 +593,7 @@ function RootVolume({basePath, errorsPath}: any) {
         checked={rootVolumeEncrypted || false}
         onChange={toggleEncrypted}
       >
-        Encrypted Root Volume
+        {t('wizard.components.rootVolume.encrypted')}
       </Toggle>
       <div
         key="volume-type"
@@ -641,14 +647,12 @@ function IamPoliciesEditor({basePath}: any) {
   return (
     <SpaceBetween direction="vertical" size="s">
       <TextContent>
-        {t('wizard.headNode.advancedOptions.iamPolicies.description')}
+        {t('wizard.components.IamPoliciesEditor.title')}
       </TextContent>
       <FormField
         errorText={
           findFirst(policies, (x: any) => x.Policy === policy)
-            ? t(
-                'wizard.headNode.advancedOptions.iamPolicies.policyAlreadyAdded',
-              )
+            ? t('wizard.components.IamPoliciesEditor.policyAlreadyAdded')
             : ''
         }
       >
@@ -667,7 +671,7 @@ function IamPoliciesEditor({basePath}: any) {
               findFirst(policies, (x: any) => x.Policy === policy)
             }
           >
-            Add
+            {t('wizard.components.IamPoliciesEditor.addButtonLabel')}
           </Button>
         </SpaceBetween>
       </FormField>

--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -482,7 +482,7 @@ function HeadNode() {
             <SecurityGroups basePath={headNodePath} />
           </FormField>
           <ExpandableSection
-            header={t('wizard.headNode.advancedOptions.label')}
+            headerText={t('wizard.headNode.advancedOptions.label')}
           >
             {isOnNodeUpdatedActive ? (
               <HeadNodeActionsEditor
@@ -493,7 +493,9 @@ function HeadNode() {
               <ActionsEditor basePath={headNodePath} errorsPath={errorsPath} />
             )}
             <ExpandableSection
-              header={t('wizard.headNode.advancedOptions.iamPolicies.label')}
+              headerText={t(
+                'wizard.headNode.advancedOptions.iamPolicies.label',
+              )}
             >
               <IamPoliciesEditor basePath={headNodePath} />
             </ExpandableSection>

--- a/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
+++ b/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
@@ -244,8 +244,11 @@ export function ComputeResource({
             onChange={_e => {
               setDisableHT(!disableHT)
             }}
+            description={t(
+              'wizard.queues.computeResource.disableHT.description',
+            )}
           >
-            <Trans i18nKey="wizard.queues.computeResource.disableHT" />
+            <Trans i18nKey="wizard.queues.computeResource.disableHT.label" />
           </Toggle>
           <Toggle
             disabled={

--- a/frontend/src/old-pages/Configure/Queues/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.tsx
@@ -53,6 +53,7 @@ import * as MultiInstanceCR from './MultiInstanceComputeResource'
 import {AllocationStrategy, ComputeResource} from './queues.types'
 import {SubnetMultiSelect} from './SubnetMultiSelect'
 import {NonCancelableEventHandler} from '@cloudscape-design/components/internal/events'
+import Head from 'next/head'
 
 // Constants
 const queuesPath = ['app', 'wizard', 'config', 'Scheduling', 'SlurmQueues']
@@ -236,9 +237,16 @@ function queuesValidate() {
 }
 
 function ComputeResources({queue, index, canUseEFA}: any) {
+  const {t} = useTranslation()
   const {ViewComponent} = useComputeResourceAdapter()
   return (
     <Container>
+      <Header
+        variant="h3"
+        description={t('wizard.queues.computeResource.header.description')}
+      >
+        {t('wizard.queues.computeResource.header.title')}
+      </Header>
       {queue.ComputeResources.map((computeResource: any, i: any) => (
         <ViewComponent
           queue={queue}
@@ -392,9 +400,13 @@ function Queue({index}: any) {
                   disabled={queue.ComputeResources.length >= 3}
                   onClick={addComputeResource}
                 >
-                  Add Resource
+                  {t('wizard.queues.computeResource.addComputeResource')}
                 </Button>
-                {index > 0 && <Button onClick={remove}>Remove Queue</Button>}
+                {index > 0 && (
+                  <Button onClick={remove}>
+                    {t('wizard.queues.removeQueueButton.label')}
+                  </Button>
+                )}
               </SpaceBetween>
             }
           >
@@ -412,7 +424,7 @@ function Queue({index}: any) {
                 />
               ) : (
                 <span>
-                  Queue: {queue.Name}{' '}
+                  {queue.Name}{' '}
                   <Button
                     variant="icon"
                     onClick={_e => setEditingName(true)}
@@ -504,7 +516,9 @@ function Queue({index}: any) {
               basePath={[...queuesPath, index, 'ComputeSettings']}
               errorsPath={errorsPath}
             />
-            <ExpandableSection header={t('wizard.queues.IamPolicies.label')}>
+            <ExpandableSection
+              headerText={t('wizard.queues.advancedOptions.iamPolicies.label')}
+            >
               <IamPoliciesEditor basePath={[...queuesPath, index]} />
             </ExpandableSection>
           </SpaceBetween>
@@ -553,7 +567,12 @@ function Queues() {
       {isMemoryBasedSchedulingActive && <SlurmMemorySettings />}
       <Container
         header={
-          <Header variant="h2">{t('wizard.queues.container.title')}</Header>
+          <Header
+            variant="h2"
+            description={t('wizard.queues.container.description')}
+          >
+            {t('wizard.queues.container.title')}
+          </Header>
         }
       >
         <QueuesView />

--- a/frontend/src/old-pages/Configure/Queues/SingleInstanceComputeResource.tsx
+++ b/frontend/src/old-pages/Configure/Queues/SingleInstanceComputeResource.tsx
@@ -208,8 +208,11 @@ export function ComputeResource({index, queueIndex, computeResource}: any) {
             onChange={_e => {
               setDisableHT(!disableHT)
             }}
+            description={t(
+              'wizard.queues.computeResource.disableHT.description',
+            )}
           >
-            <Trans i18nKey="wizard.queues.computeResource.disableHT" />
+            <Trans i18nKey="wizard.queues.computeResource.disableHT.label" />
           </Toggle>
           <Toggle
             disabled={!efaInstances.has(instanceType)}


### PR DESCRIPTION
## Description

This PR removes hardcoded strings and adjust copywriting for wizard queues page following the suggestions of our copywriter.

## How Has This Been Tested?

* Manually tested locally

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
