### PR TITLE
Clusters list help panel

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -91,7 +91,7 @@
       "versionLabel": "Version",
       "ec2InstanceConnect": {
         "label": "EC2 Instance Connect",
-        "help": "Copy the command to connect to the head node using <0>EC2 Instance Connect</0>. You must <1>install mSSH helper</1> locally before running this command."
+        "help": "Locally install mSSH helper and copy the provided command to connect to the head node with EC2 Instance Connect."
       }
     },
     "instances": {

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -13,6 +13,16 @@
       "title": "$t(global.projectName) documentation",
       "link": "https://pcluster.cloud/"
     },
+    "help": {
+      "configurationProperties": {
+        "title": "Configuration properties",
+        "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/cluster-configuration-file-v3.html?icmpid=docs_parallelcluster_hp_clusters_v1"
+      },
+      "ec2ConnectLink": {
+        "title": "EC2 Instance Connect",
+        "href": "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-connect-set-up.html?icmpid=docs_parallelcluster_hp_clusters_v1"
+      }
+    },
     "openNewTab": "Open in a new tab",
     "splitPanel": {
       "preferencesTitle": "Split panel preferences",
@@ -145,6 +155,28 @@
     },
     "logs": {
       "label": "Select a log stream from the left."
+    },
+    "help": {
+      "main": "<p><strong>Create</strong> a new cluster or select a listed cluster to view detailed information. You can also choose <strong>Stop fleet</strong> or <strong>Start fleet</strong> to stop or start the cluster compute fleet, and <strong>Edit</strong> or <strong>Delete</strong> a selected cluster.</p><p>You can only <strong>Create</strong> and <strong>Edit</strong> clusters with the same AWS ParallelCluster version that was used to create the $t(global.projectName).</p><p>Depending on the cluster configuration, you can use an AWS Systems Manager shell session or a DCV virtual desktop to access the head node of the selected cluster. You can also access the file system of the selected cluster.</p><p>Enter text in the search field to find clusters by name, status, or version.</p>Select a listed cluster to view its details.<0></0><p>Choose <strong>Create</strong> to create and configure a cluster.</p>Choose <strong>Edit</strong> to update the cluster configuration. Some configuration updates require that you first stop the compute fleet, and some updates can't be performed.",
+      "details": "<strong>Details</strong> shows a summary of cluster properties, starting with a link to the CloudFormation stack that created your cluster.To connect to the head node instance, use the link provided by the <strong>EC2 Instance Connect</strong> helper.",
+      "instances": "<strong>Instances</strong> shows the list of cluster EC2 instances.",
+      "storage": "<strong>Storage</strong> shows the list of your configured file systems.",
+      "scheduling": "<strong>Job scheduling</strong> shows running jobs.",
+      "accounting": "<strong>Accounting</strong> is a dashboard for your configured Slurm accounting data.",
+      "events": "<strong>Stack events</strong> shows the record of cluster CloudFormation stack create, update, and delete events.",
+      "logs": "<strong>Logs</strong> shows the AWS ParallelCluster logs created for your cluster.",
+      "dcvLink": {
+        "title": "NICE DCV",
+        "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/dcv-v3.html?icmpid=docs_parallelcluster_hp_clusters_v1"
+      },
+      "accountingLink": {
+        "title": "Slurm accounting with AWS ParallelCluster",
+        "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/slurm-accounting-v3.html?icmpid=docs_parallelcluster_hp_headnode_accounting_v1"
+      },
+      "logsLink": {
+        "title": "AWS ParallelCluster logs",
+        "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/cloudwatch-logs-v3.html?icmpid=docs_parallelcluster_hp_clusters_v1"
+      }
     },
     "list": {
       "header": {

--- a/frontend/src/components/help-panel/TitleDescriptionHelpPanel.tsx
+++ b/frontend/src/components/help-panel/TitleDescriptionHelpPanel.tsx
@@ -10,19 +10,31 @@
 // limitations under the License.
 
 import {HelpPanel, Icon, Link} from '@cloudscape-design/components'
-import {ReactElement} from 'react'
+import {ReactElement, useMemo} from 'react'
 import {useTranslation} from 'react-i18next'
 
 interface TitleDescriptionHelpPanelProps {
   title: string | ReactElement
   description: string | ReactElement
+  footerLinks?: {title: string; href: string}[]
 }
 
 function TitleDescriptionHelpPanel({
   title,
   description,
+  footerLinks,
 }: TitleDescriptionHelpPanelProps) {
   const {t} = useTranslation()
+
+  const DEFAULT_FOOTER_LINKS = useMemo(
+    () => [
+      {
+        title: t('global.docs.title'),
+        href: t('global.docs.link'),
+      },
+    ],
+    [t],
+  )
 
   return (
     <HelpPanel
@@ -33,15 +45,17 @@ function TitleDescriptionHelpPanel({
             {t('helpPanel.footer.learnMore')} <Icon name="external" />
           </h3>
           <ul>
-            <li>
-              <Link
-                external
-                externalIconAriaLabel={t('global.openNewTab')}
-                href={t('global.docs.link')}
-              >
-                {t('global.docs.title')}
-              </Link>
-            </li>
+            {(footerLinks || DEFAULT_FOOTER_LINKS).map(link => (
+              <li key={link.href}>
+                <Link
+                  external
+                  externalIconAriaLabel={t('global.openNewTab')}
+                  href={link.href}
+                >
+                  {link.title}
+                </Link>
+              </li>
+            ))}
           </ul>
         </div>
       }

--- a/frontend/src/old-pages/Clusters/Clusters.tsx
+++ b/frontend/src/old-pages/Clusters/Clusters.tsx
@@ -12,13 +12,13 @@ import {
   ClusterName,
   ClusterStatus,
 } from '../../types/clusters'
-import React, {useEffect} from 'react'
+import React, {useEffect, useMemo} from 'react'
 import {NavigateFunction, useNavigate, useParams} from 'react-router-dom'
 import {DescribeCluster, GetConfiguration, ListClusters} from '../../model'
 import {useState, clearState, setState} from '../../store'
 import {selectCluster} from './util'
 import {findFirst} from '../../util'
-import {useTranslation} from 'react-i18next'
+import {Trans, useTranslation} from 'react-i18next'
 
 import {useQuery} from 'react-query'
 import {
@@ -39,7 +39,8 @@ import Details from './Details'
 import {wizardShow} from '../Configure/Configure'
 import Layout from '../Layout'
 import {useHelpPanel} from '../../components/help-panel/HelpPanel'
-import {DefaultHelpPanel} from '../../components/help-panel/DefaultHelpPanel'
+import TitleDescriptionHelpPanel from '../../components/help-panel/TitleDescriptionHelpPanel'
+import InfoLink from '../../components/InfoLink'
 
 export function onClustersUpdate(
   selectedClusterName: ClusterName,
@@ -137,6 +138,7 @@ function ClusterList({clusters}: {clusters: ClusterInfoSummary[]}) {
           variant="awsui-h1-sticky"
           description={t('cluster.list.header.description')}
           counter={items && `(${items.length})`}
+          info={<InfoLink helpPanel={<ClustersHelpPanel />} />}
           actions={
             <SpaceBetween direction="horizontal" size="xs">
               {selectedClusterName && <Actions />}
@@ -205,7 +207,7 @@ export default function Clusters() {
   const oldStatus = useState(['app', 'clusters', 'selectedStatus'])
   let navigate = useNavigate()
 
-  useHelpPanel(<DefaultHelpPanel />)
+  useHelpPanel(<ClustersHelpPanel />)
 
   useEffect(
     () => onClustersUpdate(selectedClusterName, clusters!, oldStatus, navigate),
@@ -257,5 +259,59 @@ export default function Clusters() {
     >
       <ClusterList clusters={clusters!} />
     </Layout>
+  )
+}
+
+const CLUSTERS_HELP_PANEL_LIST = [
+  <Trans key="cluster.help.details" i18nKey="cluster.help.details" />,
+  <Trans key="cluster.help.instances" i18nKey="cluster.help.instances" />,
+  <Trans key="cluster.help.storage" i18nKey="cluster.help.storage" />,
+  <Trans key="cluster.help.scheduling" i18nKey="cluster.help.scheduling" />,
+  <Trans key="cluster.help.accounting" i18nKey="cluster.help.accounting" />,
+  <Trans key="cluster.help.events" i18nKey="cluster.help.events" />,
+  <Trans key="cluster.help.logs" i18nKey="cluster.help.logs" />,
+]
+
+const ClustersHelpPanel = () => {
+  const {t} = useTranslation()
+  const footerLinks = useMemo(
+    () => [
+      {
+        title: t('global.help.configurationProperties.title'),
+        href: t('global.help.configurationProperties.href'),
+      },
+      {
+        title: t('cluster.help.dcvLink.title'),
+        href: t('cluster.help.dcvLink.href'),
+      },
+      {
+        title: t('global.help.ec2ConnectLink.title'),
+        href: t('global.help.ec2ConnectLink.href'),
+      },
+      {
+        title: t('cluster.help.accountingLink.title'),
+        href: t('cluster.help.accountingLink.href'),
+      },
+      {
+        title: t('cluster.help.logsLink.title'),
+        href: t('cluster.help.logsLink.href'),
+      },
+    ],
+    [t],
+  )
+  return (
+    <TitleDescriptionHelpPanel
+      title={<Trans i18nKey="cluster.list.header.title" />}
+      description={
+        <Trans i18nKey="cluster.help.main">
+          <ul>
+            {CLUSTERS_HELP_PANEL_LIST.map(detail => (
+              <li key={detail.key}>{detail}</li>
+            ))}
+          </ul>
+        </Trans>
+      }
+      footerLinks={footerLinks}
+    />
   )
 }

--- a/frontend/src/old-pages/Clusters/Properties.tsx
+++ b/frontend/src/old-pages/Clusters/Properties.tsx
@@ -59,6 +59,13 @@ export default function ClusterProperties() {
   ])
   const ssmEnabled = iamPolicies && findFirst(iamPolicies, isSsmPolicy)
 
+  const footerLinks = [
+    {
+      title: t('global.help.ec2ConnectLink.title'),
+      href: t('global.help.ec2ConnectLink.href'),
+    },
+  ]
+
   useClusterPoll(clusterName, true)
 
   return (
@@ -174,20 +181,10 @@ export default function ClusterProperties() {
                           title={t(
                             'cluster.properties.ec2InstanceConnect.label',
                           )}
-                          description={
-                            <Trans i18nKey="cluster.properties.ec2InstanceConnect.help">
-                              <a
-                                rel="noreferrer"
-                                target="_blank"
-                                href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-connect-set-up.html"
-                              />
-                              <a
-                                rel="noreferrer"
-                                target="_blank"
-                                href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-connect-set-up.html"
-                              />
-                            </Trans>
-                          }
+                          description={t(
+                            'cluster.properties.ec2InstanceConnect.help',
+                          )}
+                          footerLinks={footerLinks}
                         />
                       }
                     />

--- a/frontend/src/old-pages/Clusters/__tests__/Clusters.test.tsx
+++ b/frontend/src/old-pages/Clusters/__tests__/Clusters.test.tsx
@@ -97,7 +97,7 @@ describe('given a component to show the clusters list', () => {
           ),
         )
 
-        await userEvent.click(output.getByText('Create'))
+        await userEvent.click(output.getByRole('button', {name: 'Create'}))
         expect(mockNavigate).toHaveBeenCalledWith('/configure')
       })
     })


### PR DESCRIPTION
## Description

Guide users through the application with the help of Cloudscape Help Panel.


## Changes

- [override Help Panel footer links](https://github.com/aws-samples/pcluster-manager/commit/17bc8a642cb44028fdd3e0fbaced7b0f1283626a)
- add help panel for the clusters list
- slightly modify the EC2 instance connect help panel

## How Has This Been Tested?

![Screenshot 2023-01-30 at 15 06 05](https://user-images.githubusercontent.com/3091286/215499636-08a70595-2d63-45ed-ae27-4397746bca25.png)

## References

https://cloudscape.design/patterns/general/help-system/

## PR Quality Checklist

- [x] I added tests to new or existing code
- [x] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
