### PR TITLE
Add HelpPanel to Users page

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -773,6 +773,10 @@
       "delete": "Delete",
       "cancel": "Cancel"
     },
+    "helpPanel": {
+      "title": "Users",
+      "description": "Maintain the list of cognito users with credentials that only permit access to the $t(global.projectName).<p>Enter a user email address and choose <strong>Create user</strong> to add a user.</p><p>Choose <strong>Delete</strong> to remove a user.</p><p>Choose <strong>Refresh</strong> to view changes to the list of users.</p>"
+    },
     "list": {
       "columns": {
         "username": "Username",

--- a/frontend/src/old-pages/Users/Users.tsx
+++ b/frontend/src/old-pages/Users/Users.tsx
@@ -36,10 +36,11 @@ import {
   hideDialog,
 } from '../../components/DeleteDialog'
 import Layout from '../Layout'
-import {DefaultHelpPanel} from '../../components/help-panel/DefaultHelpPanel'
 import {useHelpPanel} from '../../components/help-panel/HelpPanel'
-import {useTranslation} from 'react-i18next'
 import {User} from '../../types/users'
+import {Trans, useTranslation} from 'react-i18next'
+import TitleDescriptionHelpPanel from '../../components/help-panel/TitleDescriptionHelpPanel'
+import InfoLink from '../../components/InfoLink'
 
 // Constants
 const errorsPath = ['app', 'wizard', 'errors', 'user']
@@ -47,8 +48,18 @@ const errorsPath = ['app', 'wizard', 'errors', 'user']
 // selectors
 const selectUserIndex = (state: any) => state.users.index
 
+function UsersHelpPanel() {
+  const {t} = useTranslation()
+  return (
+    <TitleDescriptionHelpPanel
+      title={t('users.helpPanel.title')}
+      description={<Trans i18nKey="users.helpPanel.description" />}
+    />
+  )
+}
+
 const usersSlug = 'users'
-export default function Users(props: any) {
+export default function Users() {
   const {t} = useTranslation()
   const loading = !useSelector(selectUserIndex)
   const user_index = useSelector(selectUserIndex) || {}
@@ -66,7 +77,7 @@ export default function Users(props: any) {
   const usernamePath = ['app', 'users', 'newUser', 'Username']
   const username = useState(usernamePath)
 
-  useHelpPanel(<DefaultHelpPanel />)
+  useHelpPanel(<UsersHelpPanel />)
 
   React.useEffect(() => {
     ListUsers()
@@ -168,6 +179,7 @@ export default function Users(props: any) {
             variant="awsui-h1-sticky"
             counter={users && `(${Object.keys(users).length})`}
             description={t('users.header.description')}
+            info={<InfoLink helpPanel={<UsersHelpPanel />} />}
             actions={
               <SpaceBetween direction="horizontal" size="xs">
                 <Button


### PR DESCRIPTION
## Description

This PR adds the help panel content for the Users page

It builds on #521 

## Changes

<img width="302" alt="image" src="https://user-images.githubusercontent.com/11457067/215530891-34531137-e2d7-474f-9760-9e820ff9164b.png">

## How Has This Been Tested?

- manually

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
