### PR TITLE
Add HelpPanel to Custom Images page

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -717,6 +717,18 @@
         "selectedAriaLabel": "Selected"
       }
     },
+    "helpPanel": {
+      "title": "Custom images",
+      "description": "Choose <strong>Build image</strong> to create your custom image.<p>You can only <strong>Create images</strong> with the same AWS ParallelCluster version that was used to create the $t(global.projectName).</p><p>If you choose <strong>Build image</strong>, you proceed to create a custom image by uploading a configuration, by entering the ID of an existing image, or by manually entering the configuration.</p><p>After you have provided the configuration, you choose <strong>Build image</strong>.</p><p>Choose <strong>Refresh</strong> to view recently changed or added AWS resources.",
+      "amiCustomizationlink": {
+        "title": "AWS ParallelCluster AMI customization",
+        "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/custom-ami-v3.html?icmpid=docs_parallelcluster_hp_custom_images_v1"
+      },
+      "buildImagePropertieslink": {
+        "title": "Build image configuration properties",
+        "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/image-builder-configuration-file-v3.html?icmpid=docs_parallelcluster_hp_custom_images_v1"
+      }
+    },
     "list": {
       "columns": {
         "name": "Name",

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -719,7 +719,7 @@
     },
     "helpPanel": {
       "title": "Custom images",
-      "description": "Choose <strong>Build image</strong> to create your custom image.<p>You can only <strong>Create images</strong> with the same AWS ParallelCluster version that was used to create the $t(global.projectName).</p><p>If you choose <strong>Build image</strong>, you proceed to create a custom image by uploading a configuration, by entering the ID of an existing image, or by manually entering the configuration.</p><p>After you have provided the configuration, you choose <strong>Build image</strong>.</p><p>Choose <strong>Refresh</strong> to view recently changed or added AWS resources.",
+      "description": "Choose <strong>Build image</strong> to create your custom image.<p>You can only <strong>Create images</strong> with the same AWS ParallelCluster version that was used to create the $t(global.projectName).</p><p>If you choose <strong>Build image</strong>, you proceed to create a custom image by uploading a configuration, by entering the ID of an existing image, or by manually entering the configuration.</p><p>You can only <strong>Create images</strong> with the same AWS ParallelCluster version that was used to create the $t(global.projectName).</p><p>After you have provided the configuration, you choose <strong>Build image</strong>.</p><p>Choose <strong>Refresh</strong> to view recently changed or added AWS resources.",
       "amiCustomizationlink": {
         "title": "AWS ParallelCluster AMI customization",
         "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/custom-ami-v3.html?icmpid=docs_parallelcluster_hp_custom_images_v1"

--- a/frontend/src/components/help-panel/TitleDescriptionHelpPanel.tsx
+++ b/frontend/src/components/help-panel/TitleDescriptionHelpPanel.tsx
@@ -10,19 +10,31 @@
 // limitations under the License.
 
 import {HelpPanel, Icon, Link} from '@cloudscape-design/components'
-import {ReactElement} from 'react'
+import {ReactElement, useMemo} from 'react'
 import {useTranslation} from 'react-i18next'
 
 interface TitleDescriptionHelpPanelProps {
   title: string | ReactElement
   description: string | ReactElement
+  footerLinks?: {title: string; href: string}[]
 }
 
 function TitleDescriptionHelpPanel({
   title,
   description,
+  footerLinks,
 }: TitleDescriptionHelpPanelProps) {
   const {t} = useTranslation()
+
+  const DEFAULT_FOOTER_LINKS = useMemo(
+    () => [
+      {
+        title: t('global.docs.title'),
+        href: t('global.docs.link'),
+      },
+    ],
+    [t],
+  )
 
   return (
     <HelpPanel
@@ -33,15 +45,17 @@ function TitleDescriptionHelpPanel({
             {t('helpPanel.footer.learnMore')} <Icon name="external" />
           </h3>
           <ul>
-            <li>
-              <Link
-                external
-                externalIconAriaLabel={t('global.openNewTab')}
-                href={t('global.docs.link')}
-              >
-                {t('global.docs.title')}
-              </Link>
-            </li>
+            {(footerLinks || DEFAULT_FOOTER_LINKS).map(link => (
+              <li key={link.href}>
+                <Link
+                  external
+                  externalIconAriaLabel={t('global.openNewTab')}
+                  href={link.href}
+                >
+                  {link.title}
+                </Link>
+              </li>
+            ))}
           </ul>
         </div>
       }

--- a/frontend/src/old-pages/CustomImages/CustomImages.tsx
+++ b/frontend/src/old-pages/CustomImages/CustomImages.tsx
@@ -9,7 +9,7 @@
 // OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 import {Ec2AmiState, ImageInfoSummary} from '../../types/images'
-import React from 'react'
+import React, {useMemo} from 'react'
 import {useSelector} from 'react-redux'
 
 import {ListCustomImages, DescribeCustomImage} from '../../model'
@@ -36,9 +36,10 @@ import {
   TextFilter,
 } from '@cloudscape-design/components'
 import Layout from '../Layout'
-import {DefaultHelpPanel} from '../../components/help-panel/DefaultHelpPanel'
 import {useHelpPanel} from '../../components/help-panel/HelpPanel'
 import {TFunction, Trans, useTranslation} from 'react-i18next'
+import InfoLink from '../../components/InfoLink'
+import TitleDescriptionHelpPanel from '../../components/help-panel/TitleDescriptionHelpPanel'
 
 const imageBuildPath = ['app', 'customImages', 'imageBuild']
 
@@ -117,6 +118,7 @@ function CustomImagesList() {
       header={
         <Header
           variant="awsui-h1-sticky"
+          info={<InfoLink helpPanel={<CustomImagesHelpPanel />} />}
           description={
             <Trans i18nKey="customImages.header.description">
               <Link
@@ -253,6 +255,30 @@ function StatusSelect() {
   )
 }
 
+function CustomImagesHelpPanel() {
+  const {t} = useTranslation()
+  const footerLinks = useMemo(
+    () => [
+      {
+        title: t('customImages.helpPanel.amiCustomizationlink.title'),
+        href: t('customImages.helpPanel.amiCustomizationlink.href'),
+      },
+      {
+        title: t('customImages.helpPanel.buildImagePropertieslink.title'),
+        href: t('customImages.helpPanel.buildImagePropertieslink.href'),
+      },
+    ],
+    [t],
+  )
+  return (
+    <TitleDescriptionHelpPanel
+      title={t('customImages.helpPanel.title')}
+      description={<Trans i18nKey="customImages.helpPanel.description" />}
+      footerLinks={footerLinks}
+    />
+  )
+}
+
 const customImageSlug = 'customImages'
 
 export default function CustomImages() {
@@ -261,7 +287,7 @@ export default function CustomImages() {
 
   const [splitOpen, setSplitOpen] = React.useState(true)
 
-  useHelpPanel(<DefaultHelpPanel />)
+  useHelpPanel(<CustomImagesHelpPanel />)
 
   React.useEffect(() => {
     const imageStatus = getState(['app', 'customImages', 'selectedImageStatus'])


### PR DESCRIPTION
## Description

This PR adds the help panel content for the Custom Images page

It builds on #521 

## Changes

<img width="289" alt="image" src="https://user-images.githubusercontent.com/11457067/215538888-d1b98ed0-b27c-4861-abb8-963f4a919f6b.png">


## How Has This Been Tested?

- manually

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
