### PR TITLE
Add HelpPanel to Official Images page

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -936,6 +936,14 @@
       "title": "Official images",
       "description": "The official list of tested Amazon Machine Images (AMIs) that are automatically used to create AWS ParallelClusters."
     },
+    "helpPanel": {
+      "title": "Official images",
+      "description": "<p>Refer to this list of AMI images when configuring your cluster.</p><p>This version-coupled instance of the $t(global.projectName) automatically uses these tested AMIs to create clusters based on the operating system and architecture that you choose.</p>",
+      "link": {
+        "title": "AWS ParallelCluster support policy",
+        "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/support-policy.html"
+      }
+    },
     "list": {
       "columns": {
         "id": "ID",

--- a/frontend/src/old-pages/OfficialImages/OfficialImages.tsx
+++ b/frontend/src/old-pages/OfficialImages/OfficialImages.tsx
@@ -8,7 +8,7 @@
 // or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 // OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
-import React from 'react'
+import React, {useMemo} from 'react'
 
 import {ListOfficialImages} from '../../model'
 import {useCollection} from '@cloudscape-design/collection-hooks'
@@ -27,15 +27,36 @@ import EmptyState from '../../components/EmptyState'
 import {useQuery} from 'react-query'
 import {useState} from '../../store'
 import Layout from '../Layout'
-import {DefaultHelpPanel} from '../../components/help-panel/DefaultHelpPanel'
 import {useHelpPanel} from '../../components/help-panel/HelpPanel'
-import {useTranslation} from 'react-i18next'
+import {Trans, useTranslation} from 'react-i18next'
+import TitleDescriptionHelpPanel from '../../components/help-panel/TitleDescriptionHelpPanel'
+import InfoLink from '../../components/InfoLink'
 
 type Image = {
   amiId: string
   os: string
   architecture: string
   version: string
+}
+
+function OfficialImagesHelpPanel() {
+  const {t} = useTranslation()
+  const footerLinks = useMemo(
+    () => [
+      {
+        title: t('officialImages.helpPanel.link.title'),
+        href: t('officialImages.helpPanel.link.href'),
+      },
+    ],
+    [t],
+  )
+  return (
+    <TitleDescriptionHelpPanel
+      title={t('officialImages.helpPanel.title')}
+      description={<Trans i18nKey="officialImages.helpPanel.description" />}
+      footerLinks={footerLinks}
+    />
+  )
 }
 
 function OfficialImagesList({images}: {images: Image[]}) {
@@ -85,6 +106,7 @@ function OfficialImagesList({images}: {images: Image[]}) {
           variant="awsui-h1-sticky"
           counter={items && `(${items.length})`}
           description={t('officialImages.header.description')}
+          info={<InfoLink helpPanel={<OfficialImagesHelpPanel />} />}
         >
           {t('officialImages.header.title')}
         </Header>
@@ -142,7 +164,7 @@ export default function OfficialImages() {
   const region = useState(['app', 'selectedRegion']) || defaultRegion
   const {data} = useQuery('OFFICIAL_IMAGES', () => ListOfficialImages(region))
 
-  useHelpPanel(<DefaultHelpPanel />)
+  useHelpPanel(<OfficialImagesHelpPanel />)
 
   return (
     <Layout pageSlug={officialImagesSlug}>


### PR DESCRIPTION
## Description

This PR adds the help panel content for the Official Images page

It builds on #521 

## Changes

<img width="307" alt="image" src="https://user-images.githubusercontent.com/11457067/215531152-745c3480-80a3-41ab-97c7-92b2b62d57b4.png">

## How Has This Been Tested?

- manually

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
