### PR TITLE
Replace Toggle with Checkbox instances everywhere in the wizard

### DIFF
--- a/frontend/src/old-pages/Configure/Cluster.tsx
+++ b/frontend/src/old-pages/Configure/Cluster.tsx
@@ -26,7 +26,6 @@ import {
   Header,
   Select,
   SpaceBetween,
-  Toggle,
 } from '@cloudscape-design/components'
 
 // State / Model

--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -34,7 +34,7 @@ import {
   FormField,
   Input,
   SpaceBetween,
-  Toggle,
+  Checkbox,
   TokenGroup,
   Select,
   InputProps,
@@ -266,13 +266,13 @@ function CustomAMISettings({basePath, appPath, errorsPath, validate}: any) {
   return (
     <>
       <SpaceBetween direction="horizontal" size={'xxs'}>
-        <Toggle
-          disabled={editing}
+        <Checkbox
           checked={customAmiEnabled}
+          disabled={editing}
           onChange={toggleCustomAmi}
         >
           <Trans i18nKey="wizard.components.customAmi.label" />
-        </Toggle>
+        </Checkbox>
         <InfoLink
           ariaLabel={t('wizard.components.customAmi.ariaLabel')}
           helpPanel={
@@ -574,7 +574,7 @@ function RootVolume({basePath, errorsPath}: any) {
   }, [rootVolumeType, rootVolumeTypePath])
 
   return (
-    <>
+    <SpaceBetween direction="vertical" size="xs">
       <FormField
         label={t('wizard.components.rootVolume.size.label')}
         errorText={rootVolumeErrors}
@@ -588,13 +588,13 @@ function RootVolume({basePath, errorsPath}: any) {
           onChange={({detail}) => setRootVolume(detail.value)}
         />
       </FormField>
-      <Toggle
+      <Checkbox
         disabled={editing}
         checked={rootVolumeEncrypted || false}
         onChange={toggleEncrypted}
       >
         {t('wizard.components.rootVolume.encrypted')}
-      </Toggle>
+      </Checkbox>
       <div
         key="volume-type"
         style={{
@@ -617,7 +617,7 @@ function RootVolume({basePath, errorsPath}: any) {
           options={volumeTypes.map(strToOption)}
         />
       </div>
-    </>
+    </SpaceBetween>
   )
 }
 

--- a/frontend/src/old-pages/Configure/Create.tsx
+++ b/frontend/src/old-pages/Configure/Create.tsx
@@ -20,7 +20,12 @@ import {
 } from '../../model'
 
 // UI Elements
-import {Container, Header, Toggle, Spinner} from '@cloudscape-design/components'
+import {
+  Container,
+  Header,
+  Checkbox,
+  Spinner,
+} from '@cloudscape-design/components'
 
 // Components
 import ValidationErrors from '../../components/ValidationErrors'
@@ -177,24 +182,24 @@ function Create() {
         </div>
       )}
       {editing && (
-        <Toggle
+        <Checkbox
           checked={forceUpdate}
           onChange={() =>
             setState(['app', 'wizard', 'forceUpdate'], !forceUpdate)
           }
         >
           {t('wizard.create.configuration.forceUpdate')}
-        </Toggle>
+        </Checkbox>
       )}
       {!editing && (
-        <Toggle
+        <Checkbox
           checked={disableRollback}
           onChange={() =>
             setState(['app', 'wizard', 'disableRollback'], !disableRollback)
           }
         >
           {t('wizard.create.configuration.disableRollback')}
-        </Toggle>
+        </Checkbox>
       )}
     </Container>
   )

--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -19,15 +19,14 @@ import {findFirst, getIn} from '../../util'
 // UI Elements
 import {
   Box,
+  Checkbox,
   ColumnLayout,
   Container,
   ExpandableSection,
   FormField,
-  Header,
   Input,
   Select,
   SpaceBetween,
-  Toggle,
 } from '@cloudscape-design/components'
 
 // State
@@ -296,13 +295,13 @@ function SsmSettings() {
           />
         }
       >
-        <Toggle
+        <Checkbox
           checked={ssmEnabled}
           onChange={({detail}) => enableSsm(!ssmEnabled)}
           disabled={dcvEnabled}
         >
           <Trans i18nKey="wizard.headNode.Ssm.label" />
-        </Toggle>
+        </Checkbox>
       </FormField>
     </div>
   )
@@ -354,9 +353,13 @@ function DcvSettings() {
         }
       >
         <SpaceBetween direction="vertical" size="xxxs">
-          <Toggle disabled={editing} checked={dcvEnabled} onChange={toggleDcv}>
+          <Checkbox
+            disabled={editing}
+            checked={dcvEnabled}
+            onChange={toggleDcv}
+          >
             {t('wizard.headNode.Dcv.add')}
-          </Toggle>
+          </Checkbox>
           <SpaceBetween direction="vertical" size="xs">
             {dcvEnabled && (
               <FormField label="Allowed IPs">
@@ -446,9 +449,12 @@ function HeadNode() {
           <SsmSettings />
           <DcvSettings />
           <SpaceBetween size="xs" direction="horizontal">
-            <Toggle checked={imdsSecured || false} onChange={toggleImdsSecured}>
+            <Checkbox
+              checked={imdsSecured || false}
+              onChange={toggleImdsSecured}
+            >
               <Trans i18nKey="wizard.headNode.imdsSecured.label" />
-            </Toggle>
+            </Checkbox>
             <InfoLink
               helpPanel={
                 <TitleDescriptionHelpPanel

--- a/frontend/src/old-pages/Configure/MultiUser.tsx
+++ b/frontend/src/old-pages/Configure/MultiUser.tsx
@@ -22,7 +22,7 @@ import {
   Input,
   Link,
   SpaceBetween,
-  Toggle,
+  Checkbox,
 } from '@cloudscape-design/components'
 
 // State
@@ -87,7 +87,7 @@ function HelpToggle({name, configKey, description, help, defaultValue}: any) {
         }}
       >
         <div style={{flexGrow: 1}}>
-          <Toggle
+          <Checkbox
             checked={value === null ? defaultValue : value}
             onChange={({detail}) => setState([...dsPath, configKey], !value)}
           />

--- a/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
+++ b/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
@@ -6,7 +6,7 @@ import {
   Input,
   Multiselect,
   MultiselectProps,
-  Toggle,
+  Checkbox,
 } from '@cloudscape-design/components'
 import {NonCancelableEventHandler} from '@cloudscape-design/components/internal/events'
 import {useCallback, useEffect, useMemo} from 'react'
@@ -239,7 +239,7 @@ export function ComputeResource({
           )}
         </ColumnLayout>
         <div style={{display: 'flex', flexDirection: 'row', gap: '20px'}}>
-          <Toggle
+          <Checkbox
             checked={disableHT}
             onChange={_e => {
               setDisableHT(!disableHT)
@@ -249,8 +249,8 @@ export function ComputeResource({
             )}
           >
             <Trans i18nKey="wizard.queues.computeResource.disableHT.label" />
-          </Toggle>
-          <Toggle
+          </Checkbox>
+          <Checkbox
             disabled={
               !allInstancesSupportEFA(instances, efaInstances) || !canUseEFA
             }
@@ -260,7 +260,7 @@ export function ComputeResource({
             }}
           >
             <Trans i18nKey="wizard.queues.computeResource.enableEfa" />
-          </Toggle>
+          </Checkbox>
         </div>
       </div>
     </div>

--- a/frontend/src/old-pages/Configure/Queues/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.tsx
@@ -25,7 +25,7 @@ import {
   Input,
   Select,
   SpaceBetween,
-  Toggle,
+  Checkbox,
   MultiselectProps,
 } from '@cloudscape-design/components'
 
@@ -486,7 +486,7 @@ function Queue({index}: any) {
           ) : null}
         </ColumnLayout>
         <Box variant="div" margin={{vertical: 'xs'}}>
-          <Toggle
+          <Checkbox
             checked={enablePlacementGroup}
             disabled={!canUsePlacementGroup}
             onChange={_e => {
@@ -494,7 +494,7 @@ function Queue({index}: any) {
             }}
           >
             <Trans i18nKey="wizard.queues.placementGroup.label" />
-          </Toggle>
+          </Checkbox>
         </Box>
         <ComputeResources queue={queue} index={index} canUseEFA={canUseEFA} />
         <ExpandableSection header="Advanced options">

--- a/frontend/src/old-pages/Configure/Queues/SingleInstanceComputeResource.tsx
+++ b/frontend/src/old-pages/Configure/Queues/SingleInstanceComputeResource.tsx
@@ -4,7 +4,7 @@ import {
   ColumnLayout,
   FormField,
   Input,
-  Toggle,
+  Checkbox,
 } from '@cloudscape-design/components'
 import {useEffect} from 'react'
 import {Trans, useTranslation} from 'react-i18next'
@@ -199,7 +199,7 @@ export function ComputeResource({index, queueIndex, computeResource}: any) {
           )}
         </ColumnLayout>
         <div style={{display: 'flex', flexDirection: 'row', gap: '20px'}}>
-          <Toggle
+          <Checkbox
             disabled={
               tInstances.has(instanceType) ||
               gravitonInstances.has(instanceType)
@@ -213,8 +213,8 @@ export function ComputeResource({index, queueIndex, computeResource}: any) {
             )}
           >
             <Trans i18nKey="wizard.queues.computeResource.disableHT.label" />
-          </Toggle>
-          <Toggle
+          </Checkbox>
+          <Checkbox
             disabled={!efaInstances.has(instanceType)}
             checked={enableEFA}
             onChange={_e => {
@@ -222,7 +222,7 @@ export function ComputeResource({index, queueIndex, computeResource}: any) {
             }}
           >
             <Trans i18nKey="wizard.queues.computeResource.enableEfa" />
-          </Toggle>
+          </Checkbox>
         </div>
       </div>
     </div>

--- a/frontend/src/old-pages/Configure/Queues/SlurmMemorySettings.tsx
+++ b/frontend/src/old-pages/Configure/Queues/SlurmMemorySettings.tsx
@@ -15,7 +15,7 @@ import {
   Container,
   Header,
   Alert,
-  Toggle,
+  Checkbox,
   SpaceBetween,
 } from '@cloudscape-design/components'
 import {setState, getState, useState, clearState} from '../../../store'
@@ -117,13 +117,13 @@ function SlurmMemorySettings() {
             justifyContent: 'space-between',
           }}
         >
-          <Toggle
+          <Checkbox
             checked={memoryBasedSchedulingEnabled}
             disabled={multipleInstancesTypesSelected}
             onChange={toggleMemoryBasedSchedulingEnabled}
           >
             <Trans i18nKey="wizard.queues.slurmMemorySettings.toggle.label" />
-          </Toggle>
+          </Checkbox>
         </div>
         <Alert
           visible={multipleInstancesTypesSelected}

--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -28,7 +28,7 @@ import {
   Select,
   SpaceBetween,
   TextContent,
-  Toggle,
+  Checkbox,
 } from '@cloudscape-design/components'
 
 // State
@@ -360,9 +360,9 @@ export function FsxLustreSettings({index}: any) {
         </FormField>
       )}
       <SpaceBetween direction="horizontal" size="xs">
-        <Toggle checked={compression !== null} onChange={toggleCompression}>
+        <Checkbox checked={compression !== null} onChange={toggleCompression}>
           <Trans i18nKey="wizard.storage.Fsx.compression.label" />
-        </Toggle>
+        </Checkbox>
         <InfoLink
           helpPanel={
             <TitleDescriptionHelpPanel
@@ -440,9 +440,9 @@ function EfsSettings({index}: any) {
             />
           }
         >
-          <Toggle checked={encrypted} onChange={toggleEncrypted}>
+          <Checkbox checked={encrypted} onChange={toggleEncrypted}>
             {t('wizard.storage.Efs.encrypted.label')}
-          </Toggle>
+          </Checkbox>
 
           {encrypted ? (
             <FormField label={t('wizard.storage.Efs.encrypted.kmsId')}>
@@ -475,7 +475,7 @@ function EfsSettings({index}: any) {
         </div>
         <div style={{display: 'flex', flexDirection: 'column', gap: '10px'}}>
           <SpaceBetween direction="horizontal" size="xs">
-            <Toggle
+            <Checkbox
               checked={throughputMode !== 'bursting'}
               onChange={_event => {
                 setState(
@@ -487,7 +487,7 @@ function EfsSettings({index}: any) {
               }}
             >
               <Trans i18nKey="wizard.storage.Efs.provisioned.label" />
-            </Toggle>
+            </Checkbox>
 
             <InfoLink
               helpPanel={
@@ -653,9 +653,9 @@ function EbsSettings({index}: any) {
             />
           }
         >
-          <Toggle checked={encrypted} onChange={toggleEncrypted}>
+          <Checkbox checked={encrypted} onChange={toggleEncrypted}>
             {t('wizard.storage.Ebs.encrypted.label')}
-          </Toggle>
+          </Checkbox>
 
           {encrypted ? (
             <FormField label={t('wizard.storage.Ebs.encrypted.kmsId')}>
@@ -689,14 +689,14 @@ function EbsSettings({index}: any) {
             />
           }
         >
-          <Toggle
+          <Checkbox
             checked={snapshotId !== null}
             onChange={_event => {
               setState(snapshotIdPath, snapshotId === null ? '' : null)
             }}
           >
             {t('wizard.storage.Ebs.snapshotId.label')}
-          </Toggle>
+          </Checkbox>
           {snapshotId !== null && (
             <Input
               value={snapshotId}
@@ -837,13 +837,13 @@ function StorageInstance({index}: any) {
           <div style={{display: 'flex', flexDirection: 'column'}}>
             {STORAGE_TYPE_PROPS[storageType].maxToCreate > 0 ? (
               <SpaceBetween direction="horizontal" size="xs">
-                <Toggle
+                <Checkbox
                   disabled={!canToggle}
                   checked={useExisting}
                   onChange={toggleUseExisting}
                 >
                   <Trans i18nKey="wizard.storage.instance.useExisting.label" />
-                </Toggle>
+                </Checkbox>
                 <InfoLink
                   helpPanel={
                     <TitleDescriptionHelpPanel


### PR DESCRIPTION
## Description

Replaced Toggle with Checkbox instances everywhere in the wizard

## How Has This Been Tested?

* Manually on local environment

## References

* https://cloudscape.design/components/checkbox/

## Screenshots

<img width="1715" alt="Screenshot 2023-01-30 at 18 08 08" src="https://user-images.githubusercontent.com/25930133/215545557-d29a555a-07c1-436a-ac27-3fff8c5d63f9.png">


## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
