### PR TITLE
Move actions in header section in cluster instances tab

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -95,6 +95,7 @@
       }
     },
     "instances": {
+      "title": "Instances",
       "id": "ID",
       "instance": "Instance",
       "launchedTime": "Launched time",
@@ -108,7 +109,18 @@
         "start": "Start compute fleet",
         "logs": "Logs"
       },
-      "computeFleetInfo": "Compute fleet must be stopped."
+      "computeFleetInfo": "Compute fleet must be stopped.",
+      "filtering": {
+        "empty": {
+          "title": "No instances",
+          "subtitle": "No instances found"
+        },
+        "noMatch": {
+          "title": "No matches",
+          "subtitle": "No instances match the filters."
+        },
+        "clearFilter": "Clear filter"
+      }
     },
     "storage": {
       "id": "ID",

--- a/frontend/src/old-pages/Clusters/Instances.tsx
+++ b/frontend/src/old-pages/Clusters/Instances.tsx
@@ -136,12 +136,19 @@ export default function ClusterInstances() {
     clusterName,
     'instances',
   ])
+  const [selectedInstances, setSelectedInstances] = React.useState<Instance[]>(
+    [],
+  )
 
   const clusterPath = ['clusters', 'index', clusterName]
   const fleetStatus: ComputeFleetStatus = useState([
     ...clusterPath,
     'computeFleetStatus',
   ])
+
+  const onSelectionChangeCallback = React.useCallback(({detail}) => {
+    setSelectedInstances(detail.selectedItems)
+  }, [])
 
   React.useEffect(() => {
     const tick = () => {
@@ -167,18 +174,18 @@ export default function ClusterInstances() {
     filtering: {
       empty: (
         <EmptyState
-          title="No instances"
-          subtitle="No instances found."
+          title={t('cluster.instances.filtering.empty.title')}
+          subtitle={t('cluster.instances.filtering.empty.subtitle')}
           action={<span>:(</span>}
         />
       ),
       noMatch: (
         <EmptyState
-          title="No matches"
-          subtitle="No instances match the filters."
+          title={t('cluster.instances.filtering.noMatch.title')}
+          subtitle={t('cluster.instances.filtering.noMatch.subtitle')}
           action={
             <Button onClick={() => actions.setFiltering('')}>
-              Clear filter
+              {t('cluster.instances.filtering.clearFilter')}
             </Button>
           }
         />
@@ -197,8 +204,16 @@ export default function ClusterInstances() {
           variant="h3"
           description=""
           counter={instances && `(${instances.length})`}
+          actions={
+            selectedInstances.length > 0 && (
+              <InstanceActions
+                fleetStatus={fleetStatus}
+                instance={selectedInstances[0]}
+              />
+            )
+          }
         >
-          Instances
+          {t('cluster.instances.title')}
         </Header>
       }
       trackBy="instanceId"
@@ -257,14 +272,10 @@ export default function ClusterInstances() {
           cell: instance => <InstanceStatusIndicator instance={instance} />,
           sortingField: 'state',
         },
-        {
-          id: 'actions',
-          header: t('cluster.instances.actionsLabel'),
-          cell: instance => (
-            <InstanceActions fleetStatus={fleetStatus} instance={instance} />
-          ),
-        },
       ]}
+      selectionType="single"
+      selectedItems={selectedInstances}
+      onSelectionChange={onSelectionChangeCallback}
       loading={instances === null}
       items={items}
       loadingText="Loading instances..."


### PR DESCRIPTION
## Description

* Moved actions in header section in cluster instances tab
* Added i18n strings

## How Has This Been Tested?

* Manuallt on local environment

## References

* https://cloudscape.design/components/header/?tabId=playground

## Screenshots

<img width="1715" alt="Screenshot 2023-01-30 at 18 41 44" src="https://user-images.githubusercontent.com/25930133/215552947-67f6bbac-f8c6-4bdf-b75b-d655f1ed2e9b.png">


## PR Quality Checklist

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
