### PR TITLE
Remove SMS and MFA Parameters

### DIFF
--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -38,7 +38,6 @@ OIDC_PROVIDER = os.getenv("OIDC_PROVIDER")
 CLIENT_ID = os.getenv("CLIENT_ID")
 CLIENT_SECRET = os.getenv("CLIENT_SECRET")
 SECRET_ID = os.getenv("SECRET_ID")
-ENABLE_MFA = os.getenv("ENABLE_MFA")
 SITE_URL = os.getenv("SITE_URL", API_BASE_URL)
 SCOPES_LIST = os.getenv("SCOPES_LIST")
 REGION = os.getenv("AWS_DEFAULT_REGION")
@@ -193,7 +192,7 @@ def get_redirect_uri():
 
 
 def get_version():
-    return {"version": API_VERSION, "enable_mfa": ENABLE_MFA == "true"}
+    return {"version": API_VERSION}
 
 def get_app_config():
   return {

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -693,7 +693,6 @@ function GetVersion() {
           minor: minor_int,
           patch: patch,
         })
-        setState(['app', 'enableMfa'], response.data.enable_mfa)
       }
     })
     .catch((error: any) => {

--- a/frontend/src/old-pages/Users/Users.tsx
+++ b/frontend/src/old-pages/Users/Users.tsx
@@ -66,16 +66,12 @@ export default function Users(props: any) {
   const usernamePath = ['app', 'users', 'newUser', 'Username']
   const username = useState(usernamePath)
 
-  const userphonePath = ['app', 'users', 'newUser', 'Phonenumber']
-  const userphone = useState(userphonePath)
-
   useHelpPanel(<DefaultHelpPanel />)
 
   React.useEffect(() => {
     ListUsers()
   }, [])
 
-  const enableMfa = useState(['app', 'enableMfa'])
   const refreshUsers = () => {
     ListUsers()
   }
@@ -189,18 +185,6 @@ export default function Users(props: any) {
                 >
                   {t('users.actions.delete')}
                 </Button>
-                {enableMfa && (
-                  <Input
-                    inputMode="tel"
-                    onChange={({detail}) =>
-                      setState(userphonePath, detail.value)
-                    }
-                    value={userphone}
-                    placeholder={t(
-                      'users.list.createForm.phoneNumberPlaceholder',
-                    )}
-                  ></Input>
-                )}
                 <div onKeyPress={e => e.key === 'Enter' && createUser()}>
                   <Input
                     onChange={onCreateUserChangeCallback}

--- a/infrastructure/parallelcluster-ui-cognito.yaml
+++ b/infrastructure/parallelcluster-ui-cognito.yaml
@@ -7,19 +7,9 @@ Parameters:
     Description: Email address of administrative user setup by default.
     Type: String
     MinLength: 1
-  AdminUserPhone:
-    Description: (Optional) Phone number of administrative user setup by default. This is required if MFA is enabled.
-    Type: String
-    Default: '+10000000000'
-  EnableMFA:
-    AllowedValues: [true, false]
-    Default: false
-    Description: Whether or not to enable MFA through SMS.
-    Type: String
 
 Conditions:
   GovCloud: !Equals [!Ref AWS::Region, 'us-gov-west-1']
-  MFA: !Equals [!Ref EnableMFA, true]
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -28,19 +18,9 @@ Metadata:
           default: Admin info
         Parameters:
           - AdminUserEmail
-          - AdminUserPhone
-      - Label:
-          default: Multi Factor Auth Config
-        Parameters:
-          - EnableMFA
     ParameterLabels:
       AdminUserEmail:
         default: Initial Admin's Email
-      AdminUserPhone:
-        default: Initial Admin's Phone Number
-      EnableMFA:
-        default: Require Multi-Factor Authentication for all Users
-
 
 
 Resources:
@@ -77,19 +57,7 @@ Resources:
     Properties:
       AutoVerifiedAttributes:
         - email
-        - !If [MFA, phone_number, !Ref AWS::NoValue]
-      EnabledMfas: !If [MFA, [SMS_MFA], !Ref AWS::NoValue]
-      MfaConfiguration: !If [MFA, 'ON', 'OFF']
-      SmsConfiguration:
-        Fn::If:
-          - MFA
-          - ExternalId: !Sub ${AWS::StackName}-external
-            SnsCallerArn: !GetAtt SNSRole.Arn
-          - !Ref AWS::NoValue
-      Schema: !If
-        - MFA
-        - [{Name: email, AttributeDataType: String, Mutable: true, Required: true}, {Name: phone_number, AttributeDataType: String, Mutable: false, Required: true}]
-        - [{Name: email, AttributeDataType: String, Mutable: true, Required: true}]
+      Schema: [{Name: email, AttributeDataType: String, Mutable: true, Required: true}]
       UserPoolName: !Sub ${AWS::StackName}-userpool
       UsernameConfiguration:
         CaseSensitive: false
@@ -118,8 +86,6 @@ Resources:
       UserAttributes:
         - Name: email
           Value: !Ref AdminUserEmail
-        - Name: phone_number
-          Value: !Ref AdminUserPhone
       Username: !Ref AdminUserEmail
       UserPoolId: !Ref CognitoUserPool
 

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -19,15 +19,6 @@ Parameters:
     Description: SNSRole ARN of a previously deployed PCUI Cognito Stack. Leave blank to create a new one.
     Type: String
     Default: ''
-  EnableMFA:
-    AllowedValues: [true, false]
-    Default: false
-    Description: Whether or not to enable MFA through SMS. See https://aws-samples.github.io/pcluster-manager/02-tutorials/01-setup-sms.html
-    Type: String
-  AdminUserPhone:
-    Description: Phone number of administrative user setup by default (only with new Cognito instances, this is required if MFA is enabled).
-    Type: String
-    Default: ''
   Version:
     Description: Version of AWS ParallelCluster to deploy
     Type: String
@@ -41,40 +32,31 @@ Parameters:
     Type: String
     Default: ''
   InfrastructureBucket:
-    Description: S3 bucket where CloudFormation files are stored. Change this parameter only when testing changes made to the infrastructure itself.
+    Description: (Optional) S3 bucket where CloudFormation files are stored. Change this parameter only when testing changes made to the infrastructure itself.
     Type: String
     Default: ''
 
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
-      - Label:
-          default: Authentication
-        Parameters:
-          - EnableMFA
       - Label: 
           default: Admin User (only with new Cognito instances)
         Parameters: 
           - AdminUserEmail
-          - AdminUserPhone
       - Label:
-          default: External PCUI Cognito
+          default: (Optional) External PCUI Cognito
         Parameters:
           - UserPoolId
           - UserPoolAuthDomain
           - SNSRole
       - Label:
-          default: ParallelCluster API
+          default: (Optional) ParallelCluster API
         Parameters:
           - Version
           - PublicEcrImageUri
     ParameterLabels:
-      EnableMFA:
-        default: Require Multi-Factor Authentication for all Users
       AdminUserEmail:
         default: Admin's Email
-      AdminUserPhone:
-        default: Admin's Phone Number
       UserPoolId:
         default: UserPoolId from a previously deployed PCUI
       UserPoolAuthDomain:
@@ -111,8 +93,6 @@ Resources:
     Properties:
       Parameters:
         AdminUserEmail: !Ref AdminUserEmail
-        AdminUserPhone: !Ref AdminUserPhone
-        EnableMFA: !Ref EnableMFA
       TemplateURL: !Sub 
         - '${Bucket}/parallelcluster-ui-cognito.yaml'
         - Bucket: !If 
@@ -177,7 +157,6 @@ Resources:
           SECRET_ID: !GetAtt UserPoolClientSecret.SecretName
           AUDIENCE: !Ref CognitoAppClient
           OIDC_PROVIDER: 'Cognito'
-          ENABLE_MFA: !Ref EnableMFA
       FunctionName: !Sub
         - ParallelClusterUIFunction-${StackIdSuffix}
         - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }


### PR DESCRIPTION
Signed-off-by: Sean Smith <seaam@amazon.com>

## Description

* This commit removes two old parameters `EnableMFA`, and `AdminUserPhone` that were used for SMS based MFA. Instead of this we advise users to setup MFA using an authenticator app following the instructions [here](https://pcluster.cloud/02-tutorials/01-setup-mfa.html).

## Changes

* Remove parameters, `EnableMFA`, and `AdminUserPhone` from CloudFormation stack.

## Changelog entry

* Remove parameters, `EnableMFA`, and `AdminUserPhone` from CloudFormation stack.

## How Has This Been Tested?

TBD - wasn't sure how to test changes to the container image.

## References

* https://pcluster.cloud/02-tutorials/01-setup-mfa.html

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
