### PR TITLE
Add help panel for wizard cluster properties

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -286,8 +286,23 @@
       }
     },
     "cluster": {
-      "title": "Cluster",
+      "title": "Cluster properties",
       "description": "Configure the settings that apply to all cluster resources.",
+      "help": {
+        "main": "<p>Configure your cluster environment by selecting the AWS Region, operating system, and VPC.</p><p>Choose <strong>Multiple users on a cluster</strong> to use your Active Directory for managing multiple cluster users.</p><p>Choose <strong>Custom Amazon Machine Image (AMI)</strong> to use your custom AWS ParallelCluster image.</p><p>Choose <strong>Refresh</strong> to view recently changed or added AWS resources.</p>",
+        "networkLink": {
+          "title": "Network configurations",
+          "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/network-configuration-v3.html?icmpid=docs_parallelcluster_hp_cluster_v1"
+        },
+        "adLink": {
+          "title": "Multiple user access to clusters",
+          "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/multi-user-v3.html?icmpid=docs_parallelcluster_hp_cluster_v1"
+        },
+        "amiLink": {
+          "title": "AWS ParallelCluster AMI customization",
+          "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/custom-ami-v3.html?icmpid=docs_parallelcluster_hp_cluster_v1"
+        }
+      },
       "validation": {
         "VpcSelect": "You must select a VPC.",
         "customAmiSelect": "You must select an AMI ID if you add a custom AMI."

--- a/frontend/src/old-pages/Configure/Cluster.tsx
+++ b/frontend/src/old-pages/Configure/Cluster.tsx
@@ -26,7 +26,6 @@ import {
   Header,
   Select,
   SpaceBetween,
-  Toggle,
 } from '@cloudscape-design/components'
 
 // State / Model
@@ -36,11 +35,12 @@ import {LoadAwsConfig} from '../../model'
 // Components
 import {LabeledIcon, CustomAMISettings} from './Components'
 import {useFeatureFlag} from '../../feature-flags/useFeatureFlag'
-import {useComputeResourceAdapter} from './Queues/Queues'
 import {createComputeResource as singleCreate} from './Queues/SingleInstanceComputeResource'
 import {createComputeResource as multiCreate} from './Queues/MultiInstanceComputeResource'
 import {MultiUser, multiUserValidate} from './MultiUser'
 import {NonCancelableEventHandler} from '@cloudscape-design/components/internal/events'
+import TitleDescriptionHelpPanel from '../../components/help-panel/TitleDescriptionHelpPanel'
+import {useHelpPanel} from '../../components/help-panel/HelpPanel'
 
 // Constants
 const errorsPath = ['app', 'wizard', 'errors', 'cluster']
@@ -360,6 +360,8 @@ function Cluster() {
     'queues_multiple_instance_types',
   )
 
+  useHelpPanel(<ClusterPropertiesHelpPanel />)
+
   React.useEffect(() => {
     const configPath = ['app', 'wizard', 'config']
     // Don't overwrite the config if we go back, still gets overwritten
@@ -456,4 +458,36 @@ function Cluster() {
   )
 }
 
-export {Cluster, clusterValidate}
+const ClusterPropertiesHelpPanel = () => {
+  const {t} = useTranslation()
+  const footerLinks = React.useMemo(
+    () => [
+      {
+        title: t('wizard.cluster.help.networkLink.title'),
+        href: t('wizard.cluster.help.networkLink.href'),
+      },
+      {
+        title: t('wizard.cluster.help.adLink.title'),
+        href: t('wizard.cluster.help.adLink.href'),
+      },
+      {
+        title: t('wizard.cluster.help.amiLink.title'),
+        href: t('wizard.cluster.help.amiLink.href'),
+      },
+      {
+        title: t('global.help.configurationProperties.title'),
+        href: t('global.help.configurationProperties.href'),
+      },
+    ],
+    [t],
+  )
+  return (
+    <TitleDescriptionHelpPanel
+      title={t('wizard.cluster.title')}
+      description={<Trans i18nKey="wizard.cluster.help.main" />}
+      footerLinks={footerLinks}
+    />
+  )
+}
+
+export {Cluster, clusterValidate, ClusterPropertiesHelpPanel}

--- a/frontend/src/old-pages/Configure/Configure.tsx
+++ b/frontend/src/old-pages/Configure/Configure.tsx
@@ -22,7 +22,7 @@ import {
 } from '@cloudscape-design/components'
 
 import {Source, sourceValidate} from './Source'
-import {Cluster, clusterValidate} from './Cluster'
+import {Cluster, ClusterPropertiesHelpPanel, clusterValidate} from './Cluster'
 import {HeadNode, headNodeValidate} from './HeadNode'
 import {Storage, storageValidate} from './Storage'
 import {Queues, queuesValidate} from './Queues/Queues'
@@ -42,6 +42,7 @@ import i18next from 'i18next'
 import {pages, useWizardNavigation} from './useWizardNavigation'
 import {ComputeFleetStatus} from '../../types/clusters'
 import {useClusterPoll} from '../../components/useClusterPoll'
+import InfoLink from '../../components/InfoLink'
 
 const validators: {[key: string]: (...args: any[]) => boolean} = {
   source: sourceValidate,
@@ -239,6 +240,7 @@ function Configure() {
             title: t('wizard.cluster.title'),
             description: t('wizard.cluster.description'),
             content: <Cluster />,
+            info: <InfoLink helpPanel={<ClusterPropertiesHelpPanel />} />,
           },
           {
             title: t('wizard.headNode.title'),


### PR DESCRIPTION
## Description

Add the Cloudscape Help Panel in the cluster properties step of the wizard.

## How Has This Been Tested?
<img width="295" alt="Screenshot 2023-01-31 at 09 46 30" src="https://user-images.githubusercontent.com/3091286/215716683-350bae72-55de-41c2-991c-35b826a868dd.png">



## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
