### PR TITLE
Add HelpPanel to Source step of the cluster wizard + fix e2e

### DIFF
--- a/e2e/specs/wizard.template.spec.ts
+++ b/e2e/specs/wizard.template.spec.ts
@@ -28,7 +28,7 @@ test.describe('environment: @demo', () => {
         await page.getByRole('radio', { name: 'Existing template' }).click();
         await page.getByRole('button', { name: 'Next' }).click();
 
-        await expect(page.getByRole('heading', { name: 'Cluster', exact: true })).toBeVisible()
+        await expect(page.getByRole('heading', { name: 'Cluster properties', exact: true })).toBeVisible()
         await page.getByRole('button', { name: 'Next' }).click();
 
         await expect(page.getByRole('heading', { name: 'Head node' })).toBeVisible()

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -269,13 +269,21 @@
         "placeholder": "Select a cluster."
       },
       "clusterName": {
-        "label": "Cluster name",
+        "label": "Set up",
         "description": "The name must start with an alphabetical character and can have up to 60 characters. If Slurm accounting is configured, the name can have up to 40 characters. Valid characters: A-Z, a-z, 0-9, and - (hyphen).",
         "placeholder": "Enter your cluster name"
       },
       "configurationSource": {
         "label": "Source",
         "description": "Choose the source for creating your cluster configuration and cluster. After you choose a source, you step through the $t(global.projectName) configuration options for review and edits, to create your cluster."
+      },
+      "helpPanel": {
+        "title": "Set up",
+        "description": "Name your cluster and choose a method for configuring your cluster.",
+        "link": {
+          "title": "Configuration properties",
+          "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/cluster-configuration-file-v3.html?icmpid=docs_parallelcluster_hp_cluster_source_v1"
+        }
       },
       "sourceOptions": {
         "wizard": {

--- a/frontend/src/old-pages/Configure/Source.tsx
+++ b/frontend/src/old-pages/Configure/Source.tsx
@@ -10,7 +10,7 @@
 // OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React from 'react'
+import React, {useMemo} from 'react'
 import i18next from 'i18next'
 import {Trans, useTranslation} from 'react-i18next'
 import {useState, setState, getState, clearState} from '../../store'
@@ -39,6 +39,9 @@ import Loading from '../../components/Loading'
 
 // Types
 import {ClusterInfoSummary, ClusterStatus} from '../../types/clusters'
+import {useHelpPanel} from '../../components/help-panel/HelpPanel'
+import TitleDescriptionHelpPanel from '../../components/help-panel/TitleDescriptionHelpPanel'
+import InfoLink from '../../components/InfoLink'
 
 // Constants
 const sourcePath = ['app', 'wizard', 'source']
@@ -181,6 +184,26 @@ function ClusterSelect() {
   )
 }
 
+const SourceHelpPanel = () => {
+  const {t} = useTranslation()
+  const footerLinks = useMemo(
+    () => [
+      {
+        title: t('wizard.source.helpPanel.link.title'),
+        href: t('wizard.source.helpPanel.link.href'),
+      },
+    ],
+    [t],
+  )
+  return (
+    <TitleDescriptionHelpPanel
+      title={<Trans i18nKey="wizard.source.helpPanel.title" />}
+      description={<Trans i18nKey="wizard.source.helpPanel.description" />}
+      footerLinks={footerLinks}
+    />
+  )
+}
+
 function Source() {
   const {t} = useTranslation()
   let clusterName = useState(['app', 'wizard', 'clusterName']) || ''
@@ -189,6 +212,8 @@ function Source() {
   let clusterNameError = useState([...sourceErrorsPath, 'clusterName'])
   const loadingPath = ['app', 'wizard', 'source', 'loading']
   const loading = useState(loadingPath)
+
+  useHelpPanel(<SourceHelpPanel />)
 
   React.useEffect(() => {
     if (!getState([...sourcePath, 'type']))
@@ -215,6 +240,7 @@ function Source() {
             <Header
               variant="h2"
               description={t('wizard.source.clusterName.description')}
+              info={<InfoLink helpPanel={<SourceHelpPanel />} />}
             >
               <Trans i18nKey="wizard.source.clusterName.label" />
             </Header>


### PR DESCRIPTION
## Description
This PR adds the help panel content for the Source step of the cluster wizard.
This PR also fixes a small change in a e2e test.

It builds on #521 
<!-- Summary of what this PR introduces and possibly why -->

## Changes 
![Screen Shot 2023-01-31 at 10 42 47](https://user-images.githubusercontent.com/6314859/215745024-51dc21f7-d2ac-417a-a4bf-4651c43987fc.png)
![Screen Shot 2023-01-31 at 10 43 16](https://user-images.githubusercontent.com/6314859/215745051-470b7cb5-cb4a-4276-8480-14092f2d5ed8.png)


## How Has This Been Tested?
- manually
- e2e tests
<!-- The tests you ran to verify your changes -->

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [x] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
