### PR TITLE
Replace view configuration button with a link

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -83,6 +83,7 @@
         "tooltiptext": "Copy the command to SSH into the head node. If the key pair you use to create the head node isn't the default, you must specify the path to the key pair. See <0>Connect to your Linux instance using an SSH Client</0> for more information."
       },
       "configurationLabel": "Cluster configuration",
+      "configurationLink": "VIEW",
       "statusLabel": "Cluster status",
       "computeFleetStatusLabel": "Compute fleet status",
       "creationTimeLabel": "Created time",

--- a/frontend/src/old-pages/Clusters/Properties.tsx
+++ b/frontend/src/old-pages/Clusters/Properties.tsx
@@ -21,6 +21,7 @@ import {
   ColumnLayout,
   Container,
   Header,
+  Link,
   Popover,
   SpaceBetween,
   StatusIndicator,
@@ -129,17 +130,23 @@ export default function ClusterProperties() {
                 </div>
               </ValueWithLabel>
             )}
-            <ValueWithLabel label={t('cluster.properties.configurationLabel')}>
-              <Button
-                disabled={cluster.clusterStatus === ClusterStatus.CreateFailed}
-                iconName="external"
-                onClick={() =>
-                  setState(['app', 'clusters', 'clusterConfig', 'dialog'], true)
-                }
+            {cluster.clusterStatus !== ClusterStatus.CreateFailed && (
+              <ValueWithLabel
+                label={t('cluster.properties.configurationLabel')}
               >
-                View
-              </Button>
-            </ValueWithLabel>
+                <Link
+                  href="#"
+                  onFollow={() =>
+                    setState(
+                      ['app', 'clusters', 'clusterConfig', 'dialog'],
+                      true,
+                    )
+                  }
+                >
+                  {t('cluster.properties.configurationLink')}
+                </Link>
+              </ValueWithLabel>
+            )}
           </SpaceBetween>
           <SpaceBetween size="l">
             <ValueWithLabel label={t('cluster.properties.statusLabel')}>


### PR DESCRIPTION
## Description

Replaced view configuration `<Button>` with a `<Link>`

## How Has This Been Tested?

* Manually on local environment

## References

* https://cloudscape.design/components/link/?tabId=playground&example=secondary-link

## Screenshots

<img width="1712" alt="Screenshot 2023-01-31 at 12 17 04" src="https://user-images.githubusercontent.com/25930133/215745859-2ccbc9f8-e9d1-47a2-8e8a-ca722295dff8.png">


## PR Quality Checklist

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
