### PR TITLE
Head node help panels

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -387,6 +387,42 @@
     "headNode": {
       "title": "Head node",
       "description": "Configure the head node.",
+      "help": {
+        "main": "<p>Configure the head node of your cluster.</p><p>Choose <strong>Refresh</strong> to view recently changed or added AWS resources.</p>",
+        "instanceSelectionLink": {
+          "title": "Head node instance type selection",
+          "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/best-practices-v3.html?icmpid=docs_parallelcluster_hp_headnode_v1#best-practices-head-node-instance-type"
+        },
+        "headNodePropertiesLink": {
+          "title": "Head node properties",
+          "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/HeadNode-v3.html?icmpid=docs_parallelcluster_hp_headnode_v1"
+        },
+        "ssmLink": {
+          "title": "What is an SSM session?",
+          "href": "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager.html#what-is-a-session?icmpid=docs_parallelcluster_hp_headnode_v1"
+        },
+        "dcvLink": {
+          "title": "What is NICE DCV virtual desktop?",
+          "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/dcv-v3.html?icmpid=docs_parallelcluster_hp_headnode_v1"
+        },
+        "customActionsLink": {
+          "title": "What are custom actions?",
+          "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/custom-bootstrap-actions-v3.html?icmpid=docs_parallelcluster_hp_headnode_v1"
+        },
+        "slurmSettings": "<p>Configure Slurm accounting settings and queue update strategy settings for your cluster.</p><p>Choose <strong>Refresh</strong> to view recently changed or added AWS resources.</p>",
+        "accountingLink": {
+          "title": "How Slurm accounting works with AWS ParallelCluster",
+          "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/slurm-accounting-v3.html?icmpid=docs_parallelcluster_hp_headnode_accounting_v1"
+        },
+        "databaseLink": {
+          "title": "Slurm accounting database setting",
+          "href": "https://alpha.www.docs.aws.a2z.com/parallelcluster/latest/ug/Scheduling-v3.html#Scheduling-v3-SlurmSettings-Database"
+        },
+        "queueLink": {
+          "title": "Queue update strategy setting",
+          "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/Scheduling-v3.html#yaml-Scheduling-SlurmSettings-QueueUpdateStrategy"
+        }
+      },
       "validation": {
         "selectSubnet": "You must select a subnet.",
         "selectInstanceType": "You must select an instance type.",

--- a/frontend/src/components/InfoLink.tsx
+++ b/frontend/src/components/InfoLink.tsx
@@ -1,5 +1,5 @@
 import {Link} from '@cloudscape-design/components'
-import {ReactElement} from 'react'
+import {ReactElement, useCallback} from 'react'
 import {useTranslation} from 'react-i18next'
 import {useHelpPanel} from './help-panel/HelpPanel'
 
@@ -9,13 +9,12 @@ type InfoLinkProps = {
 }
 
 function InfoLink({ariaLabel, helpPanel}: InfoLinkProps) {
-  const {setContent, setVisible} = useHelpPanel()
+  const {updateHelpPanel} = useHelpPanel()
   const {t} = useTranslation()
 
-  const setHelpPanel = () => {
-    setContent(helpPanel)
-    setVisible(true)
-  }
+  const setHelpPanel = useCallback(() => {
+    updateHelpPanel({element: helpPanel, open: true})
+  }, [updateHelpPanel, helpPanel])
 
   return (
     <Link

--- a/frontend/src/components/help-panel/HelpPanel.tsx
+++ b/frontend/src/components/help-panel/HelpPanel.tsx
@@ -7,7 +7,6 @@ import {
   useCallback,
   useContext,
   useEffect,
-  useRef,
   useState,
 } from 'react'
 
@@ -47,34 +46,22 @@ export const HelpPanelProvider: FunctionComponent = ({children}) => {
  *
  * Update and show the help panel when tapping on an Info link
  * ```
- * const { setContent, setVisible } = useHelpPanel()
- * setContent(<HelpPanel .../>)
- * setVisible(true)
+ * const { updateHelpPanel } = useHelpPanel()
+ * updateHelpPanel({ element: <HelpPanel .../>, open: true})
  * ```
  */
 
 export const useHelpPanel = (initialPanel?: ReactElement) => {
   const [helpPanel, setHelpPanel] = useContext(HelpPanelContext)
-  // The ref is used to keep track of local changes made to the help panel properties,
-  // otherwise triggering both a content and a visibility change will result in a partial object update,
-  // meaning that if you call setContent() and setVisible(true) sequentially you can end up
-  // with a visible help panel, but with the old panel content
-  const panelRef = useRef(helpPanel)
 
-  const setContent = useCallback(
-    (panel: ReactElement) => {
-      panelRef.current.element = panel
-      setHelpPanel({...panelRef.current})
+  const updateHelpPanel = useCallback(
+    ({element, open}: {element?: ReactElement; open?: boolean}) => {
+      setHelpPanel({
+        element: element || helpPanel.element,
+        open: typeof open !== 'undefined' ? open : helpPanel.open,
+      })
     },
-    [setHelpPanel],
-  )
-
-  const setVisible = useCallback(
-    (visible: boolean) => {
-      panelRef.current.open = visible
-      setHelpPanel({...panelRef.current})
-    },
-    [setHelpPanel],
+    [setHelpPanel, helpPanel],
   )
 
   // This useEffect simplify the usage of the component
@@ -82,10 +69,10 @@ export const useHelpPanel = (initialPanel?: ReactElement) => {
   // and avoid placing effects in the main page component
   useEffect(() => {
     if (initialPanel) {
-      setContent(initialPanel)
+      updateHelpPanel({element: initialPanel})
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  return {...helpPanel, setContent, setVisible}
+  return {...helpPanel, updateHelpPanel}
 }

--- a/frontend/src/components/help-panel/TitleDescriptionHelpPanel.tsx
+++ b/frontend/src/components/help-panel/TitleDescriptionHelpPanel.tsx
@@ -60,9 +60,7 @@ function TitleDescriptionHelpPanel({
         </div>
       }
     >
-      <div>
-        <p>{description}</p>
-      </div>
+      <div>{description}</div>
     </HelpPanel>
   )
 }

--- a/frontend/src/old-pages/Configure/Configure.tsx
+++ b/frontend/src/old-pages/Configure/Configure.tsx
@@ -23,7 +23,11 @@ import {
 
 import {Source, sourceValidate} from './Source'
 import {Cluster, ClusterPropertiesHelpPanel, clusterValidate} from './Cluster'
-import {HeadNode, headNodeValidate} from './HeadNode'
+import {
+  HeadNode,
+  HeadNodePropertiesHelpPanel,
+  headNodeValidate,
+} from './HeadNode'
 import {Storage, storageValidate} from './Storage'
 import {Queues, queuesValidate} from './Queues/Queues'
 import {
@@ -246,6 +250,7 @@ function Configure() {
             title: t('wizard.headNode.title'),
             description: t('wizard.headNode.description'),
             content: <HeadNode />,
+            info: <InfoLink helpPanel={<HeadNodePropertiesHelpPanel />} />,
           },
           {
             title: t('wizard.storage.title'),

--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -56,6 +56,7 @@ import {
 } from './SlurmSettings/SlurmSettings'
 import InfoLink from '../../components/InfoLink'
 import TitleDescriptionHelpPanel from '../../components/help-panel/TitleDescriptionHelpPanel'
+import {useHelpPanel} from '../../components/help-panel/HelpPanel'
 
 // Constants
 const headNodePath = ['app', 'wizard', 'config', 'HeadNode']
@@ -407,6 +408,8 @@ function HeadNode() {
   const editing = useState(['app', 'wizard', 'editing'])
   const isOnNodeUpdatedActive = useFeatureFlag('on_node_updated')
 
+  useHelpPanel(<HeadNodePropertiesHelpPanel />)
+
   const toggleImdsSecured = () => {
     const setImdsSecured = !imdsSecured
     if (setImdsSecured) setState(imdsSecuredPath, setImdsSecured)
@@ -513,4 +516,40 @@ function HeadNode() {
   )
 }
 
-export {HeadNode, headNodeValidate}
+const HeadNodePropertiesHelpPanel = () => {
+  const {t} = useTranslation()
+  const footerLinks = React.useMemo(
+    () => [
+      {
+        title: t('wizard.headNode.help.instanceSelectionLink.title'),
+        href: t('wizard.headNode.help.instanceSelectionLink.href'),
+      },
+      {
+        title: t('wizard.headNode.help.headNodePropertiesLink.title'),
+        href: t('wizard.headNode.help.headNodePropertiesLink.href'),
+      },
+      {
+        title: t('wizard.headNode.help.ssmLink.title'),
+        href: t('wizard.headNode.help.ssmLink.href'),
+      },
+      {
+        title: t('wizard.headNode.help.dcvLink.title'),
+        href: t('wizard.headNode.help.dcvLink.href'),
+      },
+      {
+        title: t('wizard.headNode.help.customActionsLink.title'),
+        href: t('wizard.headNode.help.customActionsLink.href'),
+      },
+    ],
+    [t],
+  )
+  return (
+    <TitleDescriptionHelpPanel
+      title={t('wizard.headNode.title')}
+      description={<Trans i18nKey="wizard.headNode.help.main" />}
+      footerLinks={footerLinks}
+    />
+  )
+}
+
+export {HeadNode, headNodeValidate, HeadNodePropertiesHelpPanel}

--- a/frontend/src/old-pages/Configure/SlurmSettings/SlurmSettings.tsx
+++ b/frontend/src/old-pages/Configure/SlurmSettings/SlurmSettings.tsx
@@ -11,7 +11,7 @@
 
 import * as React from 'react'
 import i18next from 'i18next'
-import {useTranslation} from 'react-i18next'
+import {Trans, useTranslation} from 'react-i18next'
 import {Container, Header, ColumnLayout} from '@cloudscape-design/components'
 import {setState, getState, clearState, useState} from '../../../store'
 import {SlurmAccountingForm} from './SlurmAccountingForm'
@@ -20,6 +20,8 @@ import {
   validateScaledownIdleTime,
 } from './ScaledownIdleTimeForm'
 import {QueueUpdateStrategyForm} from './QueueUpdateStrategyForm'
+import TitleDescriptionHelpPanel from '../../../components/help-panel/TitleDescriptionHelpPanel'
+import InfoLink from '../../../components/InfoLink'
 
 const slurmSettingsPath = [
   'app',
@@ -119,6 +121,7 @@ function SlurmSettings() {
         <Header
           variant="h2"
           description={t('wizard.headNode.slurmSettings.container.description')}
+          info={<InfoLink helpPanel={<SlurmSettingsHelpPanel />} />}
         >
           {t('wizard.headNode.slurmSettings.container.title')}{' '}
           <span
@@ -148,6 +151,34 @@ function SlurmSettings() {
         />
       </ColumnLayout>
     </Container>
+  )
+}
+
+const SlurmSettingsHelpPanel = () => {
+  const {t} = useTranslation()
+  const footerLinks = React.useMemo(
+    () => [
+      {
+        title: t('wizard.headNode.help.accountingLink.title'),
+        href: t('wizard.headNode.help.accountingLink.href'),
+      },
+      {
+        title: t('wizard.headNode.help.databaseLink.title'),
+        href: t('wizard.headNode.help.databaseLink.href'),
+      },
+      {
+        title: t('wizard.headNode.help.queueLink.title'),
+        href: t('wizard.headNode.help.queueLink.href'),
+      },
+    ],
+    [t],
+  )
+  return (
+    <TitleDescriptionHelpPanel
+      title={t('wizard.headNode.slurmSettings.container.title')}
+      description={<Trans i18nKey="wizard.headNode.help.slurmSettings" />}
+      footerLinks={footerLinks}
+    />
   )
 }
 

--- a/frontend/src/old-pages/Layout.tsx
+++ b/frontend/src/old-pages/Layout.tsx
@@ -114,9 +114,12 @@ export default function Layout({
   const messages = useState(['app', 'messages']) || []
   useLocationChangeLog()
 
-  const {element, open, setVisible} = useHelpPanel()
+  const {element, open, updateHelpPanel} = useHelpPanel()
   const updateHelpPanelVisibility: NonCancelableEventHandler<AppLayoutProps.ChangeDetail> =
-    useCallback(({detail}) => setVisible(detail.open), [setVisible])
+    useCallback(
+      ({detail}) => updateHelpPanel({open: detail.open}),
+      [updateHelpPanel],
+    )
 
   return (
     <>


### PR DESCRIPTION
## Description

Add Cloudscape Help Panels to the Head node section of the wizard.

## Changes

- add main Head node help panel
- add Slurm settings help panel
- fix a bug causing a wrong re-render of the help panel inside the wizard

## How Has This Been Tested?

Verified that the right help panels appear during the wizard

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
