### PR TITLE
Use Table component in custom images tags tab

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -829,7 +829,22 @@
       },
       "tags": {
         "key": "Key",
-        "value": "Value"
+        "value": "Value",
+        "filtering": {
+          "loadingText": "Loading tags...",
+          "countText": "Results: {{filteredItemsCount}}",
+          "filteringAriaLabel": "Enter search text",
+          "filteringPlaceholder": "Enter search text",
+          "empty": {
+            "title": "No tags",
+            "subtitle": "No tags to display."
+          },
+          "noMatch": {
+            "title": "No matches",
+            "subtitle": "No tags match the filters.",
+            "action": "Clear filter"
+          }
+        }
       },
       "properties": {
         "header": {

--- a/frontend/src/types/images.tsx
+++ b/frontend/src/types/images.tsx
@@ -65,7 +65,7 @@ export type ImageInfoSummary = {
   // Id of the image.
   imageId: ImageId
   // Ec2 image information.
-  ec2AmiInfo: Ec2AmiInfoSummary
+  ec2AmiInfo: Ec2AmiInfo
   // AWS region where the image is built.
   region: Region
   // ParallelCluster version used to build the image.
@@ -85,8 +85,3 @@ export type ImageConfigurationStructure = {
 
 // Image configuration as a YAML document
 export type ImageConfigurationData = string
-
-export type Ec2AmiInfoSummary = {
-  // EC2 AMI id
-  amiId: string
-}


### PR DESCRIPTION
## Description

Use `<Table>` component in custom images tags tab

## How Has This Been Tested?

* Manually on local environment

## References

* https://cloudscape.design/components/table/

## Screenshots

![Untitled](https://user-images.githubusercontent.com/25930133/215779410-679bb1fa-8519-4e43-8e5f-d2f503e076a2.png)


## PR Quality Checklist

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
