### PR TITLE
Use inline copy buttons in custom images properties tab

### DIFF
--- a/frontend/src/old-pages/CustomImages/CustomImageDetails.tsx
+++ b/frontend/src/old-pages/CustomImages/CustomImageDetails.tsx
@@ -23,6 +23,7 @@ import {
   Container,
   Header,
   Pagination,
+  Link,
   Popover,
   SpaceBetween,
   StatusIndicator,
@@ -35,6 +36,7 @@ import DateView from '../../components/DateView'
 import CustomImageStackEvents from './CustomImageStackEvents'
 import {ValueWithLabel} from '../../components/ValueWithLabel'
 import EmptyState from '../../components/EmptyState'
+import {truncate} from 'lodash'
 
 const customImagesPath = ['app', 'customImages']
 
@@ -121,12 +123,17 @@ function CustomImageProperties() {
                 </StatusIndicator>
               }
             >
-              <Button iconName="copy" onClick={copyImageConfigUrl}>
-                {t(
-                  'customImages.imageDetails.properties.configurationUrl.copyText',
-                )}
-              </Button>
+              <Button
+                iconName="copy"
+                onClick={copyImageConfigUrl}
+                variant="inline-icon"
+              />
             </Popover>
+            <Link href={image.imageConfiguration.url}>
+              {truncate(image.imageConfiguration.url, {
+                length: 100,
+              })}
+            </Link>
           </ValueWithLabel>
           <ValueWithLabel
             label={t('customImages.imageDetails.properties.buildStatus')}
@@ -137,25 +144,29 @@ function CustomImageProperties() {
             label={t('customImages.imageDetails.properties.amiId.label')}
           >
             <SpaceBetween size="s" direction="horizontal">
-              <div>{image.ec2AmiInfo && image.ec2AmiInfo.amiId}</div>
               {image.ec2AmiInfo && (
-                <Popover
-                  size="medium"
-                  position="top"
-                  triggerType="custom"
-                  dismissButton={false}
-                  content={
-                    <StatusIndicator type="success">
-                      {t(
-                        'customImages.imageDetails.properties.amiId.tooltiptext',
-                      )}
-                    </StatusIndicator>
-                  }
-                >
-                  <Button iconName="copy" onClick={copyAmiId}>
-                    {t('customImages.imageDetails.properties.amiId.copyText')}
-                  </Button>
-                </Popover>
+                <span>
+                  <Popover
+                    size="medium"
+                    position="top"
+                    triggerType="custom"
+                    dismissButton={false}
+                    content={
+                      <StatusIndicator type="success">
+                        {t(
+                          'customImages.imageDetails.properties.amiId.tooltiptext',
+                        )}
+                      </StatusIndicator>
+                    }
+                  >
+                    <Button
+                      iconName="copy"
+                      onClick={copyAmiId}
+                      variant="inline-icon"
+                    />
+                  </Popover>
+                  {image.ec2AmiInfo.amiId}
+                </span>
               )}
               {!image.ec2AmiInfo && loadingText}
             </SpaceBetween>


### PR DESCRIPTION
## Description

Use copy `Buttons` in custom images properties tab

## How Has This Been Tested?

* Manually on local environment

## References

* https://cloudscape.design/components/copy-to-clipboard/

## Screenshots

<img width="1713" alt="Screenshot 2023-01-31 at 15 26 23" src="https://user-images.githubusercontent.com/25930133/215787209-3bdae8c2-7d66-405a-b1f1-1f5783e3e09f.png">


## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
