### PR TITLE
Add HelpPanel to Create or Edit review page

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -246,7 +246,7 @@
       "remove": "Remove",
       "back": "Back",
       "next": "Next",
-      "update": "Edit",
+      "update": "Edit cluster",
       "create": "Create",
       "dryRun": "Dry run"
     },
@@ -667,14 +667,31 @@
       }
     },
     "create": {
-      "title": "{{action}}",
+      "title": "Create",
       "description": "Review or edit your configuration and create your cluster.",
       "configuration": {
-        "title": "Cluster configuration",
-        "description": "Review or edit your cluster configuration that's used to {{action}} your cluster.",
         "pending": "{{action}} request pending...",
         "forceUpdate": "Force update: Edit the cluster while the compute fleet is still running.",
         "disableRollback": "Disable rollback: Retain the cluster resources in case of a cluster create failure."
+      },
+      "helpPanel": {
+        "title": "Cluster configuration",
+        "description": "<p>Review, edit and test cluster configuration.</p><p>Choose <strong>Dry run</strong> to validate your configuration without creating your cluster.</p><p>Choose <strong>Create</strong> to validate your configuration and create your cluster in one step.</p>",
+        "link": {
+          "title": "Configuration properties",
+          "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/cluster-configuration-file-v3.html?icmpid=docs_parallelcluster_hp_config_create_v1"
+        }
+      }
+    },
+    "update": {
+      "title": "Edit",
+      "helpPanel": {
+        "title": "Cluster configuration",
+        "description": "<p>Review, edit and test cluster configuration.</p><p>Choose <strong>Dry run</strong> to validate your configuration without editing your cluster.</p><p>Choose <strong>Edit cluster</strong> to validate your configuration and edit your cluster in one step.</p>",
+        "link": {
+          "title": "Configuration properties",
+          "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/cluster-configuration-file-v3.html?icmpid=docs_parallelcluster_hp_config_create_v1"
+        }
       }
     },
     "components": {

--- a/frontend/src/old-pages/Configure/Configure.tsx
+++ b/frontend/src/old-pages/Configure/Configure.tsx
@@ -28,7 +28,9 @@ import {Storage, storageValidate} from './Storage'
 import {Queues, queuesValidate} from './Queues/Queues'
 import {
   Create,
+  CreateReviewHelpPanel,
   createValidate,
+  EditReviewHelpPanel,
   handleCreate as wizardHandleCreate,
   handleDryRun as wizardHandleDryRun,
 } from './Create'
@@ -197,6 +199,10 @@ function Configure() {
     )
   }
 
+  const CreateHelpPanelComponent = editing
+    ? EditReviewHelpPanel
+    : CreateReviewHelpPanel
+
   return (
     <Layout
       contentType="form"
@@ -258,13 +264,12 @@ function Configure() {
             content: <Queues />,
           },
           {
-            title: i18next.t('wizard.create.title', {
-              action: editing
-                ? t('wizard.actions.update')
-                : t('wizard.actions.create'),
-            }),
+            title: editing
+              ? t('wizard.update.title')
+              : t('wizard.create.title'),
             description: t('wizard.create.description'),
             content: <Create />,
+            info: <InfoLink helpPanel={<CreateHelpPanelComponent />} />,
           },
         ]}
       />

--- a/frontend/src/old-pages/Configure/Create.tsx
+++ b/frontend/src/old-pages/Configure/Create.tsx
@@ -34,6 +34,8 @@ import ConfigView from '../../components/ConfigView'
 // State
 import {setState, getState, useState} from '../../store'
 import {NavigateFunction} from 'react-router-dom'
+import TitleDescriptionHelpPanel from '../../components/help-panel/TitleDescriptionHelpPanel'
+import {useHelpPanel} from '../../components/help-panel/HelpPanel'
 
 // Constants
 const configPath = ['app', 'wizard', 'clusterConfigYaml']
@@ -146,6 +148,46 @@ function createValidate() {
   return true
 }
 
+const CreateReviewHelpPanel = () => {
+  const {t} = useTranslation()
+  const footerLinks = React.useMemo(
+    () => [
+      {
+        title: t('wizard.create.helpPanel.link.title'),
+        href: t('wizard.create.helpPanel.link.href'),
+      },
+    ],
+    [t],
+  )
+  return (
+    <TitleDescriptionHelpPanel
+      title={t('wizard.create.helpPanel.title')}
+      description={<Trans i18nKey="wizard.create.helpPanel.description" />}
+      footerLinks={footerLinks}
+    />
+  )
+}
+
+const EditReviewHelpPanel = () => {
+  const {t} = useTranslation()
+  const footerLinks = React.useMemo(
+    () => [
+      {
+        title: t('wizard.update.helpPanel.link.title'),
+        href: t('wizard.update.helpPanel.link.href'),
+      },
+    ],
+    [t],
+  )
+  return (
+    <TitleDescriptionHelpPanel
+      title={t('wizard.update.helpPanel.title')}
+      description={<Trans i18nKey="wizard.update.helpPanel.description" />}
+      footerLinks={footerLinks}
+    />
+  )
+}
+
 function Create() {
   const {t} = useTranslation()
   const clusterConfig = useState(configPath)
@@ -155,18 +197,15 @@ function Create() {
   const errors = useState(['app', 'wizard', 'errors', 'create'])
   const pending = useState(['app', 'wizard', 'pending'])
   const editing = getState(['app', 'wizard', 'editing'])
+
+  const HelpPanelComponent = editing
+    ? EditReviewHelpPanel
+    : CreateReviewHelpPanel
+
+  useHelpPanel(<HelpPanelComponent />)
+
   return (
-    <Container
-      header={
-        <Header
-          description={t('wizard.create.configuration.description', {
-            action: editing ? 'update' : 'create',
-          })}
-        >
-          <Trans i18nKey="wizard.create.configuration.title" />
-        </Header>
-      }
-    >
+    <Container>
       <ConfigView
         config={clusterConfig}
         pending={!clusterConfig}
@@ -205,4 +244,11 @@ function Create() {
   )
 }
 
-export {Create, createValidate, handleCreate, handleDryRun}
+export {
+  Create,
+  EditReviewHelpPanel,
+  CreateReviewHelpPanel,
+  createValidate,
+  handleCreate,
+  handleDryRun,
+}


### PR DESCRIPTION
## Description

This PR adds the help panel content for the Create or Edit review page

## Changes

![image](https://user-images.githubusercontent.com/11457067/215794552-6f798e52-4101-41b2-bba4-9e1aa385bce5.png)

## How Has This Been Tested?

- manually

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
