### PR TITLE
Fix e2e tests

### DIFF
--- a/e2e/specs/wizard.spec.ts
+++ b/e2e/specs/wizard.spec.ts
@@ -34,7 +34,7 @@ test.describe('Given an endpoint where AWS ParallelCluster UI is deployed', () =
     await expect(page.getByRole('heading', { name: 'Queues' }).first()).toBeVisible()
     await page.getByRole('button', { name: 'Next' }).click();
   
-    await expect(page.getByRole('heading', { name: 'Cluster configuration' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Create' })).toBeVisible()
     await page.getByRole('button', { name: 'Dry run' }).click();
   
     await expect(page.getByText('Request would have succeeded, but DryRun flag is set.')).toBeVisible()

--- a/e2e/specs/wizard.template.spec.ts
+++ b/e2e/specs/wizard.template.spec.ts
@@ -40,7 +40,7 @@ test.describe('environment: @demo', () => {
         await expect(page.getByRole('heading', { name: 'Queues' }).first()).toBeVisible()
         await page.getByRole('button', { name: 'Next' }).click();
 
-        await expect(page.getByRole('heading', { name: 'Cluster configuration' })).toBeVisible()
+        await expect(page.getByRole('heading', { name: 'Create' })).toBeVisible()
         await page.getByRole('button', { name: 'Dry run' }).click();
 
         await expect(page.getByText('Request would have succeeded, but DryRun flag is set.')).toBeVisible()


### PR DESCRIPTION
## Description

This PR fixes e2e tests, failing after #537 

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
