### PR TITLE
Remove File Upload as a way to create clusters

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -1003,7 +1003,7 @@
       "text": "Loading..."
     },
     "FileUploadButton": {
-      "label": "Chose file"
+      "label": "Choose file"
     }
   }
 }

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -299,10 +299,6 @@
           "label": "Existing cluster",
           "description": "Start by selecting an existing cluster for the configuration of your new cluster. The selected existing cluster version must match the $t(global.projectName) version.",
           "empty": "No cluster available"
-        },
-        "file": {
-          "label": "File upload",
-          "description": "Start by uploading your own partial or complete YAML configuration file."
         }
       }
     },

--- a/frontend/src/old-pages/Configure/Source.tsx
+++ b/frontend/src/old-pages/Configure/Source.tsx
@@ -113,11 +113,7 @@ function sourceValidate(suppressUpload = false) {
   // Returning false here tells the wizard not to advance
   // which allows us to explicitly control the page if the
   // user selects a file (or stay here if they do not)
-  if (
-    valid &&
-    (source === 'upload' || source === 'template') &&
-    !suppressUpload
-  ) {
+  if (valid && source === 'template' && !suppressUpload) {
     upload()
     return false
   }
@@ -221,11 +217,7 @@ function Source() {
   }, [])
 
   const handleUpload = (data: any) => {
-    if (source === 'upload') {
-      setState(['app', 'wizard', 'page'], 'create')
-      setState(['app', 'wizard', 'clusterConfigYaml'], data)
-      setState(loadingPath, false)
-    } else if (source === 'template') {
+    if (source === 'template') {
       loadTemplate(jsyaml.load(data))
     }
   }
@@ -301,13 +293,6 @@ function Source() {
                           </FormField>
                         </SpaceBetween>
                       </Box>
-                    ),
-                  },
-                  {
-                    value: 'upload',
-                    label: t('wizard.source.sourceOptions.file.label'),
-                    description: t(
-                      'wizard.source.sourceOptions.file.description',
                     ),
                   },
                 ]}

--- a/frontend/src/old-pages/Configure/__tests__/useWizardNavigation.test.tsx
+++ b/frontend/src/old-pages/Configure/__tests__/useWizardNavigation.test.tsx
@@ -127,36 +127,6 @@ describe('Given a hook to navigate through the wizard', () => {
     })
   })
 
-  describe('when on create page', () => {
-    const page = 'create'
-    describe('if the user has uploaded a file, when clicking back button', () => {
-      beforeEach(() => {
-        mockStore.getState.mockReturnValue({
-          app: {
-            wizard: {
-              page: page,
-              source: {
-                type: 'upload',
-              },
-            },
-          },
-        })
-      })
-      it('should navigate back to source page', () => {
-        const {result} = renderHook(() => useWizardNavigation(validate), {
-          wrapper: ({children}) => {
-            return <Provider store={mockStore}>{children}</Provider>
-          },
-        })
-        result.current('previous', 0)
-        expect(setState).toHaveBeenCalledWith(
-          ['app', 'wizard', 'page'],
-          'source',
-        )
-      })
-    })
-  })
-
   describe('when on a page', () => {
     const page = 'queues'
     beforeEach(() => {

--- a/frontend/src/old-pages/Configure/useWizardNavigation.ts
+++ b/frontend/src/old-pages/Configure/useWizardNavigation.ts
@@ -6,7 +6,6 @@ const pages = ['source', 'cluster', 'headNode', 'storage', 'queues', 'create']
 
 export const useWizardNavigation = (validate: (page: string) => boolean) => {
   const currentPage = useState(['app', 'wizard', 'page']) || 'source'
-  const source = useState(['app', 'wizard', 'source', 'type'])
 
   return (reason: string, requestedStepIndex: number) => {
     switch (reason) {
@@ -14,7 +13,7 @@ export const useWizardNavigation = (validate: (page: string) => boolean) => {
         handleNext(currentPage, validate)
         break
       case 'previous':
-        handlePrev(currentPage, source)
+        handlePrev(currentPage)
         break
       case 'step':
         handleStep(currentPage, pages[requestedStepIndex], validate)
@@ -39,15 +38,8 @@ const handleNext = (
   setPage(nextPage)
 }
 
-const handlePrev = (currentPage: string, source: string) => {
+const handlePrev = (currentPage: string) => {
   setState(['app', 'wizard', 'errors'], null)
-
-  // Special case where the user uploaded a file, hitting "back"
-  // goes back to the upload screen rather than through the wizard
-  if (currentPage === 'create' && source === 'upload') {
-    setPage('source')
-    return
-  }
 
   const prevPage = pages[pages.indexOf(currentPage) - 1]
   setPage(prevPage)


### PR DESCRIPTION
## Description

This PR removes the possibility of creating a cluster by uploading a file

## Changes

- remove file upload from the options of the radio group
- remove wizard navigation special case related to the file upload user flow

## How Has This Been Tested?

- unit tests
- e2e tests locally
- manually, see screenshot

<img width="863" alt="image" src="https://user-images.githubusercontent.com/11457067/216017439-8e6955dd-c8e6-4752-bf19-cb7670214900.png">

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
