### PR TITLE
Add Queues help panels

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -632,6 +632,21 @@
     "queues": {
       "title": "Queues",
       "description": "Configure the cluster queues.",
+      "help": {
+        "main": "<p>Configure your cluster queues for job scheduling.</p><p>Add and remove queues and queue compute resources.</p><p>Choose <strong>Refresh</strong> to view recently changed or added AWS resources.</p>",
+        "schedulerLink": {
+          "title": "Queue scheduler properties",
+          "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/Scheduling-v3.html?icmpid=docs_parallelcluster_hp_queues_v1"
+        },
+        "customActionsLink": {
+          "title": "Custom actions",
+          "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/custom-bootstrap-actions-v3.html?icmpid=docs_parallelcluster_hp_headnode_v1"
+        },
+        "amiLink": {
+          "title": "AWS ParallelCluster AMI customization",
+          "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/custom-ami-v3.html?icmpid=docs_parallelcluster_hp_cluster_v1"
+        }
+      },
       "validation": {
         "instanceTypeUnique": "Instance types must be unique within a queue.",
         "instanceTypeMissing": "Select at least one instance type.",
@@ -649,7 +664,15 @@
       "slurmMemorySettings": {
         "container": {
           "title": "Slurm memory settings",
-          "help": "When using Slurm memory-based scheduling, use <i>--mem</i> to specify the amount of memory per node required by a job. For more information, see the <0>Slurm documentation for ConstrainRAMSpace</0>"
+          "help": "<p>Use Slurm memory-based scheduling to specify the amount of memory per node required by a job with Slurm's --mem parameter.</p><p>Choose <strong>Refresh</strong> to view recently changed or added AWS resources.</p>",
+          "memorySchedulingLink": {
+            "title": "How Slurm memory-based scheduling works with AWS ParallelCluster",
+            "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/slurm-mem-based-scheduling-v3.html?icmpid=docs_parallelcluster_hp_queues_slurm_memory_v1"
+          },
+          "schedulingPropertiesLink": {
+            "title": "Slurm memory-based scheduling setting",
+            "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/Scheduling-v3.html#yaml-Scheduling-SlurmSettings-EnableMemoryBasedScheduling"
+          }
         },
         "toggle": {
           "label": "Slurm memory based scheduling"

--- a/frontend/src/old-pages/Configure/Configure.tsx
+++ b/frontend/src/old-pages/Configure/Configure.tsx
@@ -29,7 +29,7 @@ import {
   headNodeValidate,
 } from './HeadNode'
 import {Storage, storageValidate} from './Storage'
-import {Queues, queuesValidate} from './Queues/Queues'
+import {Queues, QueuesHelpPanel, queuesValidate} from './Queues/Queues'
 import {
   Create,
   CreateReviewHelpPanel,
@@ -267,6 +267,7 @@ function Configure() {
             title: t('wizard.queues.title'),
             description: t('wizard.queues.description'),
             content: <Queues />,
+            info: <InfoLink helpPanel={<QueuesHelpPanel />} />,
           },
           {
             title: editing

--- a/frontend/src/old-pages/Configure/Queues/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.tsx
@@ -54,6 +54,8 @@ import {AllocationStrategy, ComputeResource} from './queues.types'
 import {SubnetMultiSelect} from './SubnetMultiSelect'
 import {NonCancelableEventHandler} from '@cloudscape-design/components/internal/events'
 import Head from 'next/head'
+import TitleDescriptionHelpPanel from '../../../components/help-panel/TitleDescriptionHelpPanel'
+import {useHelpPanel} from '../../../components/help-panel/HelpPanel'
 
 // Constants
 const queuesPath = ['app', 'wizard', 'config', 'Scheduling', 'SlurmQueues']
@@ -554,6 +556,8 @@ function Queues() {
     )
   }
 
+  useHelpPanel(<QueuesHelpPanel />)
+
   return (
     <ColumnLayout>
       {isMemoryBasedSchedulingActive && <SlurmMemorySettings />}
@@ -648,6 +652,34 @@ export function setSubnetsAndValidate(
     detail.selectedOptions.map((option: any) => option.value) || []
   setState(subnetPath, subnetIds)
   queueValidate(queueIndex)
+}
+
+export const QueuesHelpPanel = () => {
+  const {t} = useTranslation()
+  const footerLinks = React.useMemo(
+    () => [
+      {
+        title: t('wizard.queues.help.schedulerLink.title'),
+        href: t('wizard.queues.help.schedulerLink.href'),
+      },
+      {
+        title: t('wizard.queues.help.customActionsLink.title'),
+        href: t('wizard.queues.help.customActionsLink.href'),
+      },
+      {
+        title: t('wizard.queues.help.amiLink.title'),
+        href: t('wizard.queues.help.amiLink.href'),
+      },
+    ],
+    [t],
+  )
+  return (
+    <TitleDescriptionHelpPanel
+      title={t('wizard.queues.title')}
+      description={<Trans i18nKey="wizard.queues.help.main" />}
+      footerLinks={footerLinks}
+    />
+  )
 }
 
 export {Queues, queuesValidate}

--- a/frontend/src/old-pages/Configure/Queues/SlurmMemorySettings.tsx
+++ b/frontend/src/old-pages/Configure/Queues/SlurmMemorySettings.tsx
@@ -84,24 +84,7 @@ function SlurmMemorySettings() {
       header={
         <Header
           variant="h2"
-          info={
-            <InfoLink
-              helpPanel={
-                <TitleDescriptionHelpPanel
-                  title={t('wizard.queues.slurmMemorySettings.container.title')}
-                  description={
-                    <Trans i18nKey="wizard.queues.slurmMemorySettings.container.help">
-                      <a
-                        rel="noopener noreferrer"
-                        target="_blank"
-                        href="https://slurm.schedmd.com/cgroup.conf.html#OPT_ConstrainRAMSpace"
-                      ></a>
-                    </Trans>
-                  }
-                />
-              }
-            />
-          }
+          info={<InfoLink helpPanel={<SlurmMemorySettingsHelpPanel />} />}
         >
           {t('wizard.queues.slurmMemorySettings.container.title')}
         </Header>
@@ -133,6 +116,40 @@ function SlurmMemorySettings() {
         </Alert>
       </SpaceBetween>
     </Container>
+  )
+}
+
+const SlurmMemorySettingsHelpPanel = () => {
+  const {t} = useTranslation()
+  const footerLinks = React.useMemo(
+    () => [
+      {
+        title: t(
+          'wizard.queues.slurmMemorySettings.container.memorySchedulingLink.title',
+        ),
+        href: t(
+          'wizard.queues.slurmMemorySettings.container.memorySchedulingLink.href',
+        ),
+      },
+      {
+        title: t(
+          'wizard.queues.slurmMemorySettings.container.schedulingPropertiesLink.title',
+        ),
+        href: t(
+          'wizard.queues.slurmMemorySettings.container.schedulingPropertiesLink.href',
+        ),
+      },
+    ],
+    [t],
+  )
+  return (
+    <TitleDescriptionHelpPanel
+      title={t('wizard.queues.slurmMemorySettings.container.title')}
+      description={
+        <Trans i18nKey="wizard.queues.slurmMemorySettings.container.help" />
+      }
+      footerLinks={footerLinks}
+    />
   )
 }
 


### PR DESCRIPTION
## Description

Add Cloudscape Help Panels inside the Queues page of the wizard.

## How Has This Been Tested?

![Screenshot 2023-02-01 at 12 30 33](https://user-images.githubusercontent.com/3091286/216031063-b8b3c305-c632-4a76-9992-679957a12efc.png)

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
