### PR TITLE
Add AbsoluteTimestamp component to display dates following Cloudscape guidelines

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -42,6 +42,7 @@
         "jest-mock-extended": "^2.0.6",
         "lint-staged": "^13.0.3",
         "prettier": "^2.7.1",
+        "timezone-mock": "^1.3.6",
         "typescript": "^4.7.4"
       }
     },
@@ -9391,6 +9392,12 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
+    "node_modules/timezone-mock": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/timezone-mock/-/timezone-mock-1.3.6.tgz",
+      "integrity": "sha512-YcloWmZfLD9Li5m2VcobkCDNVaLMx8ohAb/97l/wYS3m+0TIEK5PFNMZZfRcusc6sFjIfxu8qcJT0CNnOdpqmg==",
+      "dev": true
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -16842,6 +16849,12 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true
+    },
+    "timezone-mock": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/timezone-mock/-/timezone-mock-1.3.6.tgz",
+      "integrity": "sha512-YcloWmZfLD9Li5m2VcobkCDNVaLMx8ohAb/97l/wYS3m+0TIEK5PFNMZZfRcusc6sFjIfxu8qcJT0CNnOdpqmg==",
       "dev": true
     },
     "tmpl": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,6 +61,7 @@
     "jest-mock-extended": "^2.0.6",
     "lint-staged": "^13.0.3",
     "prettier": "^2.7.1",
+    "timezone-mock": "^1.3.6",
     "typescript": "^4.7.4"
   },
   "lint-staged": {

--- a/frontend/src/components/date/AbsoluteTimestamp.tsx
+++ b/frontend/src/components/date/AbsoluteTimestamp.tsx
@@ -1,0 +1,105 @@
+import React, {ReactElement} from 'react'
+
+const MINUTES_PER_HOUR = 60
+
+export enum TimeZone {
+  Local = 'local',
+  UTC = 'utc',
+}
+
+interface AbsoluteTimestampProps {
+  children: number
+  locales: string | string[]
+  timeZone: TimeZone
+}
+
+interface Options {
+  format: (hours: number, minutes: number) => string
+}
+
+const OPTIONS: Intl.DateTimeFormatOptions = {
+  day: '2-digit',
+  hour: '2-digit',
+  hour12: false,
+  minute: '2-digit',
+  month: 'long',
+  year: 'numeric',
+}
+
+function leftPad(n: number): number | string {
+  if (n < 10) {
+    return `0${n}`
+  }
+  return n
+}
+
+export function getTimeZoneOffsetString(
+  timeZoneOffset: number,
+  {format}: Options,
+): string {
+  if (timeZoneOffset === 0) {
+    return ''
+  }
+
+  const utcOffset: number = -1 * timeZoneOffset
+  const absUtcOffset: number = Math.abs(utcOffset)
+  const hours: number = Math.floor(absUtcOffset / MINUTES_PER_HOUR)
+  const minutes: number = absUtcOffset % MINUTES_PER_HOUR
+
+  const formatted: string = format(hours, minutes)
+  if (utcOffset < 0) {
+    return `-${formatted}`
+  }
+  return `+${formatted}`
+}
+
+export function mapTimeZoneOffsetToAbsoluteString(
+  timeZoneOffset: number,
+): string {
+  return getTimeZoneOffsetString(timeZoneOffset, {
+    format(hours: number, minutes: number): string {
+      return `${hours}:${leftPad(minutes)}`
+    },
+  })
+}
+
+export function mapTimeZoneOffsetToIsoString(timeZoneOffset: number): string {
+  return getTimeZoneOffsetString(timeZoneOffset, {
+    format(hours: number, minutes: number): string {
+      return `${leftPad(hours)}:${leftPad(minutes)}`
+    },
+  })
+}
+
+export default function AbsoluteTimestamp({
+  children: timestamp,
+  locales,
+  timeZone,
+}: AbsoluteTimestampProps): ReactElement {
+  const date: Date = React.useMemo((): Date => {
+    return new Date(timestamp)
+  }, [timestamp])
+
+  const options: Intl.DateTimeFormatOptions =
+    React.useMemo((): Intl.DateTimeFormatOptions => {
+      if (timeZone === TimeZone.Local) {
+        return OPTIONS
+      }
+      return {
+        ...OPTIONS,
+        timeZone: 'UTC',
+      }
+    }, [timeZone])
+
+  const isoString: string = date.toISOString()
+  const timeZoneOffset: number =
+    timeZone === TimeZone.Local ? date.getTimezoneOffset() : 0
+  const timeZoneOffsetStr: string =
+    mapTimeZoneOffsetToAbsoluteString(timeZoneOffset)
+
+  return (
+    <time dateTime={isoString} title={isoString}>
+      {`${date.toLocaleString(locales, options)} (UTC${timeZoneOffsetStr})`}
+    </time>
+  )
+}

--- a/frontend/src/components/date/DateView.tsx
+++ b/frontend/src/components/date/DateView.tsx
@@ -9,9 +9,23 @@
 // OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 import React from 'react'
+import AbsoluteTimestamp, {TimeZone} from './AbsoluteTimestamp'
 
-export default function DateView(props: any) {
-  var d = new Date()
-  d.setTime(Date.parse(props.date))
-  return <span>{d.toLocaleString()}</span>
+type DateViewProps = {
+  date: string
+  locales?: string | string[]
+  timeZone?: TimeZone
+}
+
+export default function DateView({
+  date,
+  locales = 'en-Us',
+  timeZone = TimeZone.Local,
+}: DateViewProps) {
+  const timestamp = Date.parse(date)
+  return (
+    <AbsoluteTimestamp locales={locales} timeZone={timeZone}>
+      {timestamp}
+    </AbsoluteTimestamp>
+  )
 }

--- a/frontend/src/components/date/__tests__/DateView.test.tsx
+++ b/frontend/src/components/date/__tests__/DateView.test.tsx
@@ -1,8 +1,10 @@
 import {render, RenderResult, waitFor} from '@testing-library/react'
 import {TimeZone} from '../AbsoluteTimestamp'
 import DateView from '../DateView'
+import tzmock from 'timezone-mock'
 
 describe('Given a DateView component', () => {
+  tzmock.register('UTC')
   let renderResult: RenderResult
 
   describe('when only a string date is provided', () => {

--- a/frontend/src/components/date/__tests__/DateView.test.tsx
+++ b/frontend/src/components/date/__tests__/DateView.test.tsx
@@ -1,0 +1,39 @@
+import {render, RenderResult, waitFor} from '@testing-library/react'
+import {TimeZone} from '../AbsoluteTimestamp'
+import DateView from '../DateView'
+
+describe('Given a DateView component', () => {
+  let renderResult: RenderResult
+
+  describe('when only a string date is provided', () => {
+    const dateString = '2022-09-16T14:03:35.000Z'
+    const expectedResult = 'September 16, 2022 at 14:03 (UTC)'
+
+    beforeEach(async () => {
+      renderResult = await waitFor(() => render(<DateView date={dateString} />))
+    })
+
+    it('should render the date in the expected absolute format with default locales and timezone', async () => {
+      expect(renderResult.getByText(expectedResult)).toBeTruthy()
+    })
+  })
+
+  describe('when a date string, a locale and a timezone is provided', () => {
+    const dateString = '2022-09-16T14:03:35.000Z'
+    const locale = 'it-IT'
+    const timeZone = TimeZone.UTC
+    const expectedResult = '16 settembre 2022 14:03 (UTC)'
+
+    beforeEach(async () => {
+      renderResult = await waitFor(() =>
+        render(
+          <DateView date={dateString} locales={locale} timeZone={timeZone} />,
+        ),
+      )
+    })
+
+    it('should render the date in the expeted absolute format with provided locales and timezone', async () => {
+      expect(renderResult.getByText(expectedResult)).toBeTruthy()
+    })
+  })
+})

--- a/frontend/src/old-pages/Clusters/Instances.tsx
+++ b/frontend/src/old-pages/Clusters/Instances.tsx
@@ -40,7 +40,7 @@ import {useCollection} from '@cloudscape-design/collection-hooks'
 // Components
 import {InstanceStatusIndicator} from '../../components/Status'
 import EmptyState from '../../components/EmptyState'
-import DateView from '../../components/DateView'
+import DateView from '../../components/date/DateView'
 
 function InstanceActions({
   fleetStatus,

--- a/frontend/src/old-pages/Clusters/Properties.tsx
+++ b/frontend/src/old-pages/Clusters/Properties.tsx
@@ -29,7 +29,7 @@ import {
 
 // Components
 import ConfigDialog from './ConfigDialog'
-import DateView from '../../components/DateView'
+import DateView from '../../components/date/DateView'
 import {
   ClusterStatusIndicator,
   ComputeFleetStatusIndicator,

--- a/frontend/src/old-pages/Clusters/StackEvents.tsx
+++ b/frontend/src/old-pages/Clusters/StackEvents.tsx
@@ -39,7 +39,7 @@ import {
 
 // Components
 import {StackEventStatusIndicator} from '../../components/Status'
-import DateView from '../../components/DateView'
+import DateView from '../../components/date/DateView'
 import Loading from '../../components/Loading'
 import EmptyState from '../../components/EmptyState'
 

--- a/frontend/src/old-pages/CustomImages/CustomImageDetails.tsx
+++ b/frontend/src/old-pages/CustomImages/CustomImageDetails.tsx
@@ -32,7 +32,7 @@ import {
 } from '@cloudscape-design/components'
 
 import Loading from '../../components/Loading'
-import DateView from '../../components/DateView'
+import DateView from '../../components/date/DateView'
 import CustomImageStackEvents from './CustomImageStackEvents'
 import {ValueWithLabel} from '../../components/ValueWithLabel'
 import EmptyState from '../../components/EmptyState'

--- a/frontend/src/old-pages/CustomImages/CustomImageStackEvents.tsx
+++ b/frontend/src/old-pages/CustomImages/CustomImageStackEvents.tsx
@@ -18,7 +18,7 @@ import {getState, useState} from '../../store'
 import {ExpandableSection} from '@cloudscape-design/components'
 
 // Components
-import DateView from '../../components/DateView'
+import DateView from '../../components/date/DateView'
 import Loading from '../../components/Loading'
 import {useTranslation} from 'react-i18next'
 

--- a/frontend/src/old-pages/Users/Users.tsx
+++ b/frontend/src/old-pages/Users/Users.tsx
@@ -29,7 +29,7 @@ import {
 
 // Components
 import EmptyState from '../../components/EmptyState'
-import DateView from '../../components/DateView'
+import DateView from '../../components/date/DateView'
 import {
   DeleteDialog,
   showDialog,


### PR DESCRIPTION
## Description
* Add `AbsoluteTimestamp` component to display dates following Cloudscape guidelines

## How Has This Been Tested?
* Manually on local environment

## References

* https://cloudscape.design/patterns/general/timestamps/

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
