### PR TITLE
Added storage section help panel

### DIFF
--- a/e2e/specs/wizard.spec.ts
+++ b/e2e/specs/wizard.spec.ts
@@ -28,7 +28,7 @@ test.describe('Given an endpoint where AWS ParallelCluster UI is deployed', () =
     await expect(page.getByRole('heading', { name: 'Head node' })).toBeVisible()
     await page.getByRole('button', { name: 'Next' }).click();
   
-    await expect(page.getByRole('heading', { name: 'Storage' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Storage properties' })).toBeVisible()
     await page.getByRole('button', { name: 'Next' }).click();
   
     await expect(page.getByRole('heading', { name: 'Queues' }).first()).toBeVisible()

--- a/e2e/specs/wizard.template.spec.ts
+++ b/e2e/specs/wizard.template.spec.ts
@@ -34,7 +34,7 @@ test.describe('environment: @demo', () => {
         await expect(page.getByRole('heading', { name: 'Head node' })).toBeVisible()
         await page.getByRole('button', { name: 'Next' }).click();
 
-        await expect(page.getByRole('heading', { name: 'Storage' })).toBeVisible()
+        await expect(page.getByRole('heading', { name: 'Storage properties' })).toBeVisible()
         await page.getByRole('button', { name: 'Next' }).click();
 
         await expect(page.getByRole('heading', { name: 'Queues' }).first()).toBeVisible()

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -531,9 +531,8 @@
       }
     },
     "storage": {
-      "title": "Shared storage",
+      "title": "Storage properties",
       "description": "Configure shared storage for your cluster.",
-      "header": "Storage properties",
       "container": {
         "title": "Configure up to 20 shared storage resources.",
         "noStorageSelected": "No shared storage options selected.",

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -533,6 +533,7 @@
     "storage": {
       "title": "Shared storage",
       "description": "Configure shared storage for your cluster.",
+      "header": "Storage properties",
       "container": {
         "title": "Configure up to 20 shared storage resources.",
         "noStorageSelected": "No shared storage options selected.",
@@ -540,6 +541,38 @@
         "storageTypePlaceholder": "Select a file system type",
         "volumePlaceholder": "Select a volume",
         "addStorage": "Add storage"
+      },
+      "helpPanel": {
+        "title": "Shared storage properties",
+        "description": "<p>Add and configure shared storage for your cluster. Shared storage is shared between the head node and compute nodes.</p><p>Choose <strong>Add storage</strong> to configure shared storage for your cluster.</p><p>When you <strong>Edit</strong> shared storage configuration settings, AWS ParallelCluster doesn't check your inputs as you enter them. If your inputs can cause errors, AWS ParallelCluster returns validation error messages when you create the cluster or submit a dry run.</p><p>To see what settings can't be edited, search on the text \"Update policy: If this setting is changed, the update is not allowed\" in the <strong>Shared Storage section</strong> of the AWS ParallelCluster configuration documentation.</p><p>You can configure external or AWS ParallelCluster managed shared storage.</p>",
+        "section": {
+          "external": {
+            "title": "<strong>External storage</strong>",
+            "description": "<p>External storage refers to an existing volume or file system that you manage. AWS ParallelCluster doesn't create or delete external storage. You can configure AWS ParallelCluster to attach external storage to the cluster when the cluster is created or updated. Similarly, you can configure AWS ParallelCluster to detach external storage from the cluster when the cluster is deleted or edited. We recommend that you use external storage for long-term, permanent shared storage outside of the cluster lifecycle.</p>"
+          },
+          "managed": {
+            "title": "<strong>AWS ParallelCluster managed storage</strong>",
+            "description": "<p>Managed storage refers to a volume or file system that AWS ParallelCluster creates and can delete. By default, AWS ParallelCluster managed storage is configured to depend on the lifecycle of the cluster. By default, an AWS ParallelCluster managed file system or volume and its data are deleted if you do one of the following things:</p><0></0><p>For EBS storage you can edit the <strong>Deletion Policy</strong> and change it from the default <strong>Delete</strong> to <strong>Retain</strong>. Then, if you delete the cluster, the EBS volume persists and can be used as external storage for another cluster. <strong>Deletion policy</strong> is set to <strong>Delete</strong> for all other managed shared storage types.</p>",
+            "list": {
+              "delete": "<strong>Delete</strong> the cluster",
+              "remove": "<strong>Remove</strong> the managed shared storage",
+              "edit": "<strong>Edit</strong> the configuration YAML to change the managed shared name."
+            }
+          },
+          "recommendation": {
+            "description": "<p>We recommend that you regularly back up your data to avoid any data loss.</p><p>Learn more about shared storage properties, types, and quotas in <strong>Learn more</strong>.</p><p>Choose <strong>Refresh</strong> to view recently changed or added AWS resources.</p>"
+          }
+        },
+        "link": {
+          "sharedStorage": {
+            "title": "Shared storage",
+            "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/shared-storage-quotas-integration-v3.html?icmpid=docs_parallelcluster_hp_shared_storage_v1"
+          },
+          "sharedStorageSection": {
+            "title": "Shared storage section",
+            "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/SharedStorage-v3.html?icmpid=docs_parallelcluster_hp_shared_storage_v1"
+          }
+        }
       },
       "validation": {
         "volumeSize": "You must specify a valid volume size."

--- a/frontend/src/old-pages/Configure/Configure.tsx
+++ b/frontend/src/old-pages/Configure/Configure.tsx
@@ -28,7 +28,7 @@ import {
   HeadNodePropertiesHelpPanel,
   headNodeValidate,
 } from './HeadNode'
-import {Storage, storageValidate} from './Storage'
+import {Storage,StorageHelpPanel, storageValidate} from './Storage'
 import {Queues, QueuesHelpPanel, queuesValidate} from './Queues/Queues'
 import {
   Create,
@@ -262,6 +262,7 @@ function Configure() {
             title: t('wizard.storage.title'),
             description: t('wizard.storage.description'),
             content: <Storage />,
+            info: <InfoLink helpPanel={<StorageHelpPanel />} />,
           },
           {
             title: t('wizard.queues.title'),

--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -45,6 +45,8 @@ import {
 import {useFeatureFlag} from '../../feature-flags/useFeatureFlag'
 import InfoLink from '../../components/InfoLink'
 import TitleDescriptionHelpPanel from '../../components/help-panel/TitleDescriptionHelpPanel'
+import {useMemo} from 'react'
+import {useHelpPanel} from '../../components/help-panel/HelpPanel'
 
 // Constants
 const storagePath = ['app', 'wizard', 'config', 'SharedStorage']
@@ -991,6 +993,8 @@ function Storage() {
   const isFsxOpenZsfActive = useFeatureFlag('fsx_openzsf')
   const canEditFilesystems = useDynamicStorage()
 
+  useHelpPanel(<StorageHelpPanel />)
+
   const storageMaxes: Record<string, number> = {
     FsxLustre: 21,
     FsxOntap: 20,
@@ -1072,6 +1076,12 @@ function Storage() {
   return (
     <Container>
       <SpaceBetween direction="vertical" size="m">
+        <Header
+          variant="h2"
+          info={<InfoLink helpPanel={<StorageHelpPanel />} />}
+        >
+          <Trans i18nKey="wizard.storage.header" />
+        </Header>
         <TextContent>{t('wizard.storage.container.title')}</TextContent>
         <div style={{display: 'flex', flexDirection: 'column', gap: '20px'}}>
           {storages ? (
@@ -1128,6 +1138,51 @@ function Storage() {
         </div>
       </SpaceBetween>
     </Container>
+  )
+}
+
+const StorageHelpPanel = () => {
+  const {t} = useTranslation()
+  const footerLinks = useMemo(
+    () => [
+      {
+        title: t('wizard.storage.helpPanel.link.sharedStorage.title'),
+        href: t('wizard.storage.helpPanel.link.sharedStorage.href'),
+      },
+      {
+        title: t('wizard.storage.helpPanel.link.sharedStorageSection.title'),
+        href: t('wizard.storage.helpPanel.link.sharedStorageSection.href'),
+      },
+    ],
+    [t],
+  )
+  return (
+    <TitleDescriptionHelpPanel
+      title={<Trans i18nKey="wizard.storage.helpPanel.title" />}
+      description={
+        <>
+          <Trans i18nKey="wizard.storage.helpPanel.description" />
+          <Trans i18nKey="wizard.storage.helpPanel.section.external.title" />
+          <Trans i18nKey="wizard.storage.helpPanel.section.external.description" />
+          <Trans i18nKey="wizard.storage.helpPanel.section.managed.title" />
+          <Trans i18nKey="wizard.storage.helpPanel.section.managed.description">
+            <ul>
+              <li>
+                <Trans i18nKey="wizard.storage.helpPanel.section.managed.list.delete" />
+              </li>
+              <li>
+                <Trans i18nKey="wizard.storage.helpPanel.section.managed.list.remove" />
+              </li>
+              <li>
+                <Trans i18nKey="wizard.storage.helpPanel.section.managed.list.edit" />
+              </li>
+            </ul>
+          </Trans>
+          <Trans i18nKey="wizard.storage.helpPanel.section.recommendation.description" />
+        </>
+      }
+      footerLinks={footerLinks}
+    />
   )
 }
 

--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -1076,12 +1076,6 @@ function Storage() {
   return (
     <Container>
       <SpaceBetween direction="vertical" size="m">
-        <Header
-          variant="h2"
-          info={<InfoLink helpPanel={<StorageHelpPanel />} />}
-        >
-          <Trans i18nKey="wizard.storage.header" />
-        </Header>
         <TextContent>{t('wizard.storage.container.title')}</TextContent>
         <div style={{display: 'flex', flexDirection: 'column', gap: '20px'}}>
           {storages ? (
@@ -1241,4 +1235,5 @@ export {
   canCreateStorage,
   canAttachExistingStorage,
   useDynamicStorage,
+  StorageHelpPanel,
 }


### PR DESCRIPTION
## Description
This PR adds the info help panel for the storage session.

## How Has This Been Tested?
- manually
- unit tests
- e2e

## Screens
![Screen Shot 2023-02-01 at 15 45 04](https://user-images.githubusercontent.com/6314859/216102245-a1c00cfd-c9b0-4d51-a533-314699052cee.png)
![Screen Shot 2023-02-01 at 15 45 15](https://user-images.githubusercontent.com/6314859/216102308-8bf6d6ae-15db-40e1-80e9-2dd1d484194d.png)


## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
