### PR TITLE
Fix sign out not working when a cluster is selected

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -9,6 +9,16 @@
       "users": "Users",
       "viewLicense": "View License"
     },
+    "topBar": {
+      "signOut": "Sign out",
+      "logoAltText": "$t(global.projectName} logo",
+      "regionSelector": {
+        "defaultRegionText": "Region",
+        "ariaLabel": "Region"
+      },
+      "overflowMenuTitleText": "All",
+      "overflowMenuTriggerText": "More"
+    },
     "docs": {
       "title": "$t(global.projectName) documentation",
       "link": "https://pcluster.cloud/"

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -18,6 +18,7 @@ import TopNavigation from '@cloudscape-design/components/top-navigation'
 import {useQueryClient} from 'react-query'
 import {NavigateFunction, useNavigate} from 'react-router-dom'
 import {ButtonDropdownProps} from '@cloudscape-design/components'
+import {useTranslation} from 'react-i18next'
 
 export function regions(selected: string) {
   const supportedRegions = [
@@ -103,11 +104,13 @@ export const clearClusterOnRegionChange = (
 }
 
 export default function Topbar() {
+  const {t} = useTranslation()
   let username = useState(['identity', 'attributes', 'email'])
   const queryClient = useQueryClient()
   const navigate = useNavigate()
 
-  const defaultRegion = useState(['aws', 'region']) || 'DEFAULT'
+  const defaultRegionText = t('global.topBar.regionSelector.defaultRegionText')
+  const defaultRegion = useState(['aws', 'region']) || defaultRegionText
   const selectedRegion = useState(['app', 'selectedRegion']) || defaultRegion
   const displayedRegions = regions(selectedRegion)
 
@@ -123,22 +126,22 @@ export default function Topbar() {
     () => [
       {
         id: 'signout',
-        text: 'Sign out',
+        text: t('global.topBar.signOut'),
         href: '/logout',
       },
     ],
-    [],
+    [t],
   )
 
   return (
     <div id="top-bar">
       <TopNavigation
         identity={{
-          title: 'AWS ParallelCluster UI',
+          title: t('global.projectName'),
           href: '/',
           logo: {
             src: '/img/pcluster.svg',
-            alt: 'AWS ParallelCluster UI Logo',
+            alt: t('global.topBar.logoAltText'),
           },
         }}
         utilities={[
@@ -152,29 +155,25 @@ export default function Topbar() {
                 }
               : {
                   type: 'button',
-                  text: 'loading...',
+                  text: t('global.loading'),
                 },
           ],
           ...[
             selectedRegion && {
               type: 'menu-dropdown',
-              ariaLabel: 'Region',
+              ariaLabel: t('global.topBar.regionSelector.ariaLabel'),
               disableUtilityCollapse: true,
               text: (
-                <span style={{fontWeight: 'normal'}}>
-                  {selectedRegion || 'region'}
-                </span>
+                <span style={{fontWeight: 'normal'}}>{selectedRegion}</span>
               ),
               onItemClick: selectRegion,
               items: regionsToDropdownItems(displayedRegions, selectedRegion),
             },
           ],
         ]}
-        // @ts-expect-error TS(2741) FIXME: Property 'overflowMenuTitleText' is missing in typ... Remove this comment to see the full error message
         i18nStrings={{
-          searchIconAriaLabel: 'Search',
-          searchDismissIconAriaLabel: 'Close search',
-          overflowMenuTriggerText: 'More',
+          overflowMenuTitleText: t('global.topBar.overflowMenuTitleText'),
+          overflowMenuTriggerText: t('global.topBar.overflowMenuTriggerText'),
         }}
       />
     </div>

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -8,8 +8,7 @@
 // or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 // OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
-
-import * as React from 'react'
+import React, {useMemo} from 'react'
 
 import {useState, setState} from '../store'
 import {LoadInitialState} from '../model'
@@ -18,6 +17,7 @@ import {LoadInitialState} from '../model'
 import TopNavigation from '@cloudscape-design/components/top-navigation'
 import {useQueryClient} from 'react-query'
 import {NavigateFunction, useNavigate} from 'react-router-dom'
+import {ButtonDropdownProps} from '@cloudscape-design/components'
 
 export function regions(selected: string) {
   const supportedRegions = [
@@ -111,10 +111,6 @@ export default function Topbar() {
   const selectedRegion = useState(['app', 'selectedRegion']) || defaultRegion
   const displayedRegions = regions(selectedRegion)
 
-  const handleLogout = () => {
-    window.location.href = 'logout'
-  }
-
   const selectRegion = (region: any) => {
     let newRegion = region.detail.id
     setState(['app', 'selectedRegion'], newRegion)
@@ -123,7 +119,16 @@ export default function Topbar() {
     queryClient.invalidateQueries()
   }
 
-  const profileActions = [{type: 'button', id: 'signout', text: 'Sign out'}]
+  const profileActions: ButtonDropdownProps.Items = useMemo(
+    () => [
+      {
+        id: 'signout',
+        text: 'Sign out',
+        href: '/logout',
+      },
+    ],
+    [],
+  )
 
   return (
     <div id="top-bar">
@@ -143,7 +148,6 @@ export default function Topbar() {
                   type: 'menu-dropdown',
                   text: username || 'user',
                   iconName: 'user-profile',
-                  onItemClick: handleLogout,
                   items: profileActions,
                 }
               : {


### PR DESCRIPTION
## Description

This PR fixes an issue, making the logout button linking to non-existing pages, instead of properly logging out the user.

## Changes

- make the signout link to be relative to the domain instead of relative to the current path
- add i18n strings

## How Has This Been Tested?

- manually

## References

- [Cloudscape documentation](https://cloudscape.design/components/button-dropdown/?tabId=playground)

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
