### PR TITLE
Fixed OS select dropdown + switched to FormField for consistency with the rest of wizard

### DIFF
--- a/frontend/src/old-pages/Configure/Cluster.tsx
+++ b/frontend/src/old-pages/Configure/Cluster.tsx
@@ -159,28 +159,24 @@ function RegionSelect() {
 
   return (
     <>
-      <Header
-        // @ts-expect-error TS(2322) FIXME: Type '"h4"' is not assignable to type 'Variant | u... Remove this comment to see the full error message
-        variant="h4"
+      <FormField
+        label={t('wizard.cluster.region.label')}
         description={t('wizard.cluster.region.description')}
-        actions={
-          <Select
-            disabled={editing}
-            selectedOption={itemToOption(
-              // @ts-expect-error TS(2345) FIXME: Argument of type 'string[] | undefined' is not ass... Remove this comment to see the full error message
-              findFirst(supportedRegions, (r: string) => {
-                return r === region
-              }),
-            )}
-            onChange={handleChange}
-            // @ts-expect-error TS(2322) FIXME: Type '({ label: Element; value: string; } | undefi... Remove this comment to see the full error message
-            options={supportedRegions.map(itemToOption)}
-            selectedAriaLabel={t('wizard.cluster.region.selectedAriaLabel')}
-          />
-        }
       >
-        <Trans i18nKey="wizard.cluster.region.label" />
-      </Header>
+        <Select
+          disabled={editing}
+          selectedOption={itemToOption(
+            // @ts-expect-error TS(2345) FIXME: Argument of type 'string[] | undefined' is not ass... Remove this comment to see the full error message
+            findFirst(supportedRegions, (r: string) => {
+              return r === region
+            }),
+          )}
+          onChange={handleChange}
+          // @ts-expect-error TS(2322) FIXME: Type '({ label: Element; value: string; } | undefi... Remove this comment to see the full error message
+          options={supportedRegions.map(itemToOption)}
+          selectedAriaLabel={t('wizard.cluster.region.selectedAriaLabel')}
+        />
+      </FormField>
     </>
   )
 }
@@ -210,23 +206,19 @@ function OsSelect() {
 
   return (
     <>
-      <Header
-        // @ts-expect-error TS(2322) FIXME: Type '"h4"' is not assignable to type 'Variant | u... Remove this comment to see the full error message
-        variant="h4"
+      <FormField
+        label={t('wizard.cluster.os.label')}
         description={t('wizard.cluster.os.description')}
-        actions={
-          <Select
-            disabled={editing}
-            selectedOption={selectedOs}
-            onChange={handleChange}
-            // @ts-expect-error TS(2322) FIXME: Type '({ label: Element; value: string; } | undefi... Remove this comment to see the full error message
-            options={osesOptions}
-            selectedAriaLabel={t('wizard.cluster.os.selectedAriaLabel')}
-          />
-        }
       >
-        <Trans i18nKey="wizard.cluster.os.label" />
-      </Header>
+        <Select
+          disabled={editing}
+          selectedOption={selectedOs}
+          onChange={handleChange}
+          // @ts-expect-error TS(2322) FIXME: Type '({ label: Element; value: string; } | undefi... Remove this comment to see the full error message
+          options={osesOptions}
+          selectedAriaLabel={t('wizard.cluster.os.selectedAriaLabel')}
+        />
+      </FormField>
     </>
   )
 }
@@ -325,29 +317,24 @@ function VpcSelect() {
   }
 
   return (
-    <Header
-      // @ts-expect-error TS(2322) FIXME: Type '"h4"' is not assignable to type 'Variant | u... Remove this comment to see the full error message
-      variant="h4"
+    <FormField
+      errorText={error}
       description={t('wizard.cluster.vpc.description')}
-      actions={
-        <FormField errorText={error}>
-          <Select
-            disabled={editing}
-            // @ts-expect-error TS(2322) FIXME: Type '{ label: JSX.Element; value: any; }' is not ... Remove this comment to see the full error message
-            selectedOption={vpcToDisplayOption(
-              findFirst(vpcs, x => x.VpcId === vpc),
-            )}
-            onChange={({detail}) => {
-              setVpc(detail.selectedOption.value)
-            }}
-            options={vpcs.map(vpcToOption)}
-            selectedAriaLabel={t('wizard.cluster.vpc.selectedAriaLabel')}
-          />
-        </FormField>
-      }
+      label={t('wizard.cluster.vpc.label')}
     >
-      <Trans i18nKey="wizard.cluster.vpc.label" />
-    </Header>
+      <Select
+        disabled={editing}
+        // @ts-expect-error TS(2322) FIXME: Type '{ label: JSX.Element; value: any; }' is not ... Remove this comment to see the full error message
+        selectedOption={vpcToDisplayOption(
+          findFirst(vpcs, x => x.VpcId === vpc),
+        )}
+        onChange={({detail}) => {
+          setVpc(detail.selectedOption.value)
+        }}
+        options={vpcs.map(vpcToOption)}
+        selectedAriaLabel={t('wizard.cluster.vpc.selectedAriaLabel')}
+      />
+    </FormField>
   )
 }
 

--- a/frontend/src/old-pages/Configure/Cluster.tsx
+++ b/frontend/src/old-pages/Configure/Cluster.tsx
@@ -97,12 +97,14 @@ function itemToOption(
 ): SelectProps.Option | null {
   if (!item) return null
   let label, value
+
   if (typeof item == 'string') {
     label = item
     value = item
   } else {
     ;[value, label] = item
   }
+
   return {label, value}
 }
 

--- a/frontend/src/old-pages/Configure/__tests__/itemToOption.test.ts
+++ b/frontend/src/old-pages/Configure/__tests__/itemToOption.test.ts
@@ -1,0 +1,35 @@
+import {describe} from '@jest/globals'
+import {itemToOption} from '../Cluster'
+
+describe('Given a selection item', () => {
+  describe('when the item is a string', () => {
+    it('should return a valid SelectProps.Option', () => {
+      const item = 'option-value'
+      const expectedOption = {label: 'option-value', value: 'option-value'}
+
+      const option = itemToOption(item)
+
+      expect(option).toEqual(expectedOption)
+    })
+  })
+
+  describe('when the item is a tuple of 2 strings', () => {
+    it('should return a valid SelectProps.Option', () => {
+      const item = ['option-value', 'option-label'] as [string, string]
+      const expectedOption = {label: 'option-label', value: 'option-value'}
+
+      const option = itemToOption(item)
+
+      expect(option).toEqual(expectedOption)
+    })
+  })
+
+  describe('when the item is null', () => {
+    const item = null
+
+    it('should return null', () => {
+      const option = itemToOption(item)
+      expect(option).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Description
This PR  fixes a bug with the OS select dropdown which showed the dropdown option label and value as a concatenated string.
It also switches to a formfield wrapping the select for consistency with the rest of the wizard, also fixing a layout issue where the select would adapt to the width of the current selection, forcingly wrapping other option strings when the dropdown was open.

<!-- Summary of what this PR introduces and possibly why -->

## Changes
- improved and typed `itemToOption` funcion + added test for it
- switched to FormField wrapping a Select for OS, Vpc and Region selection in second step of the wizard
![Screen Shot 2023-02-03 at 11 26 27](https://user-images.githubusercontent.com/6314859/216576775-88d3df22-525d-40fa-8a4a-4dc36e502514.png)

## How Has This Been Tested?
- unit tests
- e2e tests
- manual testing
<!-- The tests you ran to verify your changes -->

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [x] I added tests to new or existing code
- [] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [x] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
