### PR TITLE
Fix cluster instances tab copy and action buttons

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -116,11 +116,10 @@
       "state": "State",
       "actionsLabel": "Actions",
       "actions": {
-        "stop": "Stop compute fleet",
-        "start": "Start compute fleet",
+        "stop": "Stop",
+        "start": "Start",
         "logs": "Logs"
       },
-      "computeFleetInfo": "Compute fleet must be stopped.",
       "filtering": {
         "empty": {
           "title": "No instances",


### PR DESCRIPTION
## Description

* Fix copywriting for instance stop action button
* Make the buttons always visible but disabled if no instances is selected following Cloudscape guidelines

## How Has This Been Tested?

* Manually on local environment

## References

* https://cloudscape.design/components/button/

## Screenshots

<img width="1723" alt="Screenshot 2023-02-03 at 12 30 21" src="https://user-images.githubusercontent.com/25930133/216592873-755138a8-e422-4368-8350-fb6a0a8b2cd7.png">


## PR Quality Checklist

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used our `i18n` solution instead (see [here](https://github.com/aws-samples/pcluster-manager/pull/175/commits/fdc6b77987c87a26f51dbc8da5d371d95ef80601))
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
